### PR TITLE
release:2022-11-22

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -4,7 +4,25 @@ To publish ignition:
 
 1. git fetch, Checkout out `main`, then ensure your branch is up to date `git pull --ff-only`
 2. Run a full check, stopping on failure: `yarn fullcheck`
-3. Under `./packages/core`, update the package version based on semver if appropriate.
-4. Publish `core` if appropriate: `npm publish`
+3. Create a release branch `git checkout -b release/yyyy-mm-dd`
+4. Under `./packages/core`, update the package version based on semver if appropriate.
 5. Under `./packages/hardhat-plugin`, update the package version based on semver if appropriate.
-6. Publish `hardhat-plugin` if appropriate: `npm publish`
+6. Update dependency package versions in examples to match
+7. Update the `CHANGELOG.md` under `./packages/core`.
+8. Update the `CHANGELOG.md` under `./packages/hardhat-plugin`.
+9. Commit the version update `git commit`:
+
+```
+chore: bump version to vX.X.X
+
+Update the packages versions and changelogs for the `X.X.X -
+yyyy-mm-dd` release.
+```
+
+10. Push the release branch and open a pull request, the PR description should match the changelogs
+11. On a successful check, `rebase merge` the release branch into main
+12. Switch to main branch and pull the latest changes
+13. Git tag the version, `g tag -a v0.x.x -m "v0.x.x"` and push the tag `git push --follow-tags`
+14. Publish `core` if appropriate: `npm publish`
+15. Publish `hardhat-plugin` if appropriate: `npm publish`
+16. Create a release on github off of the pushed tag

--- a/examples/create2/package.json
+++ b/examples/create2/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "hardhat": "^2.10.0",
-    "@ignored/hardhat-ignition": "^0.0.3"
+    "@ignored/hardhat-ignition": "^0.0.4"
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.7.3"

--- a/examples/ens/package.json
+++ b/examples/ens/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.3",
+    "@ignored/hardhat-ignition": "^0.0.4",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.3",
+    "@ignored/hardhat-ignition": "^0.0.4",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/uniswap/package.json
+++ b/examples/uniswap/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.3",
+    "@ignored/hardhat-ignition": "^0.0.4",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## 0.0.4 - 2022-11-22
+
+### Added
+
+- Pass eth as `value` on deploy or call ([#60](https://github.com/NomicFoundation/ignition/pull/60))
+- Pass parameters for `value` ([#66](https://github.com/NomicFoundation/ignition/pull/66))
+
+## 0.0.3 - 2022-11-09
+
+### Added
+
+- Allow modules to depend on other calls ([#53](https://github.com/NomicFoundation/ignition/pull/53))
+- Allow depending on a module ([#54](https://github.com/NomicFoundation/ignition/pull/54))
+
+### Changed
+
+- Dependening on returned module contract equivalent to depending on the module ([#55](https://github.com/NomicFoundation/ignition/pull/55))
+
+## 0.0.2 - 2022-10-26
+
+### Added
+
+- Deploy a module to a ephemeral local hardhat node
+- Generate example execution graph for plans

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/ignition-core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## 0.0.4 - 2022-11-22
+
+### Added
+
+- Support setting module params from JSON file ([#64](https://github.com/NomicFoundation/ignition/pull/64))
+
+## 0.0.3 - 2022-11-09
+
+### Added
+
+- Allow modules to depend on other calls ([#53](https://github.com/NomicFoundation/ignition/pull/53))
+- Allow depending on a module ([#54](https://github.com/NomicFoundation/ignition/pull/54))
+
+### Changed
+
+- Dependening on returned module contract equivalent to depending on the module ([#55](https://github.com/NomicFoundation/ignition/pull/55))
+
+## 0.0.2 - 2022-10-26
+
+### Added
+
+- Add `deploy` task to hardhat via the plugin
+- Add `plan` task to hardhat via the plugin

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/hardhat-ignition",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",
@@ -32,7 +32,7 @@
     "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {
-    "@ignored/ignition-core": "^0.0.3",
+    "@ignored/ignition-core": "^0.0.4",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@types/chai": "^4.2.22",
@@ -67,7 +67,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@ignored/ignition-core": "^0.0.3",
+    "@ignored/ignition-core": "^0.0.4",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "hardhat": "^2.12.0"
   },


### PR DESCRIPTION
Update the packages versions and changelogs for the `0.0.4 - 2022-11-22` release:

## 0.0.4 - 2022-11-22

### Added

- Pass eth as `value` on deploy or call ([#60](https://github.com/NomicFoundation/ignition/pull/60))
- Pass parameters for `value` ([#66](https://github.com/NomicFoundation/ignition/pull/66))
- Support setting module params from JSON file ([#64](https://github.com/NomicFoundation/ignition/pull/64))