### PR TITLE
resolve AwaitFuture to emitted event args

### DIFF
--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -241,11 +241,13 @@ const event = m.awaitEvent(multisig, "AuthorizedBy", {
   args: ["0xUser1"],
   after: [call],
 });
+
+m.call(multisig, "execute", { args: [event.params.transactionId] });
 ```
 
 The `awaitEvent` during deployment will check whether an event matching the given filter args has been emitted. If it has, the deployment will continue, if not the deployment will pause and listen for the event for a [configurable](./running-a-deployment.md#configuration-options) period of time. If the event has not been detected within this listening period, the deployment stops in the `on-hold` condition. A further run of the deployment will recheck the `awaitEvent` condition.
 
-Upon execution, the `EventFuture` will be resolved to the values of the args emitted by the given event. You can then use those values in tests or other modules as expected.
+Upon execution, the `EventFuture` will be resolved to the values of the params emitted by the given event. You can then use those values in tests or other modules as expected.
 
 A full example of the `awaitEvent` function can be seen in our [Multisig example](../examples/multisig/README.md).
 

--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -237,13 +237,15 @@ const multisig = m.deploy("Multisig");
 
 const call = m.call(multisig, "authorize");
 
-m.awaitEvent(multisig, "AuthorizedBy", {
+const event = m.awaitEvent(multisig, "AuthorizedBy", {
   args: ["0xUser1"],
   after: [call],
 });
 ```
 
 The `awaitEvent` during deployment will check whether an event matching the given filter args has been emitted. If it has, the deployment will continue, if not the deployment will pause and listen for the event for a [configurable](./running-a-deployment.md#configuration-options) period of time. If the event has not been detected within this listening period, the deployment stops in the `on-hold` condition. A further run of the deployment will recheck the `awaitEvent` condition.
+
+Upon execution, the `AwaitFuture` will be resolved to the values of the args emitted by the given event. You can then use those values in tests or other modules as expected.
 
 A full example of the `awaitEvent` function can be seen in our [Multisig example](../examples/multisig/README.md).
 

--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -245,7 +245,7 @@ const event = m.awaitEvent(multisig, "AuthorizedBy", {
 
 The `awaitEvent` during deployment will check whether an event matching the given filter args has been emitted. If it has, the deployment will continue, if not the deployment will pause and listen for the event for a [configurable](./running-a-deployment.md#configuration-options) period of time. If the event has not been detected within this listening period, the deployment stops in the `on-hold` condition. A further run of the deployment will recheck the `awaitEvent` condition.
 
-Upon execution, the `AwaitFuture` will be resolved to the values of the args emitted by the given event. You can then use those values in tests or other modules as expected.
+Upon execution, the `EventFuture` will be resolved to the values of the args emitted by the given event. You can then use those values in tests or other modules as expected.
 
 A full example of the `awaitEvent` function can be seen in our [Multisig example](../examples/multisig/README.md).
 

--- a/examples/multisig/ignition/Multisig.js
+++ b/examples/multisig/ignition/Multisig.js
@@ -1,6 +1,8 @@
 const { ethers } = require("ethers");
 const { buildModule } = require("@ignored/hardhat-ignition");
 
+const MultisigArtifact = require("../artifacts/contracts/Multisig.sol/Multisig.json");
+
 const ACCOUNT_0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 const ACCOUNT_1 = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 
@@ -10,7 +12,7 @@ module.exports = buildModule("MultisigModule", (m) => {
   const value = ethers.utils.parseUnits("100");
 
   // todo: support arbitrary tx
-  const multisig = m.contract("Multisig", {
+  const multisig = m.contract("Multisig", MultisigArtifact, {
     args: [owners, required],
     value,
   });
@@ -26,7 +28,10 @@ module.exports = buildModule("MultisigModule", (m) => {
     after: [call],
   });
 
-  // m.call(multisig, "executeTransaction", { args: [0], after: [event] });
+  m.call(multisig, "executeTransaction", {
+    args: [event.params.transactionId],
+    after: [event],
+  });
 
   return { multisig, event };
 });

--- a/examples/multisig/ignition/Multisig.js
+++ b/examples/multisig/ignition/Multisig.js
@@ -21,12 +21,12 @@ module.exports = buildModule("MultisigModule", (m) => {
   });
 
   // todo: support sending via non-default account
-  m.awaitEvent(multisig, "Confirmation", {
+  const event = m.awaitEvent(multisig, "Confirmation", {
     args: [ACCOUNT_0, 0],
     after: [call],
   });
 
   // m.call(multisig, "executeTransaction", { args: [0], after: [event] });
 
-  return { multisig };
+  return { multisig, event };
 });

--- a/examples/multisig/package.json
+++ b/examples/multisig/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.1",
-    "@ignored/hardhat-ignition": "^0.0.3",
+    "@ignored/hardhat-ignition": "^0.0.4",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",
     "@openzeppelin/contracts": "^4.3.2",
     "chai": "^4.3.4",

--- a/examples/multisig/test/Multisig.js
+++ b/examples/multisig/test/Multisig.js
@@ -7,11 +7,13 @@ const ACCOUNT_0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
 describe.skip("Multisig", function () {
   let multisig;
+  let event;
 
   before(async () => {
     const moduleResult = await ignition.deploy(Multisig);
 
     multisig = moduleResult.multisig;
+    event = moduleResult.event;
   });
 
   it("should store a submitted transaction", async function () {
@@ -29,5 +31,10 @@ describe.skip("Multisig", function () {
     const [isConfirmed] = await multisig.functions.confirmations(0, ACCOUNT_0);
 
     expect(isConfirmed).to.equal(true);
+  });
+
+  it("should emit the sender and transaction id after confirming a stored transaction", async function () {
+    expect(event.sender).to.equal(ACCOUNT_0);
+    expect(ethers.BigNumber.from("0").eq(event.transactionId)).to.be.true;
   });
 });

--- a/examples/multisig/test/Multisig.js
+++ b/examples/multisig/test/Multisig.js
@@ -16,17 +16,6 @@ describe("Multisig", function () {
     event = moduleResult.event;
   });
 
-  it("should store a submitted transaction", async function () {
-    const submittedTx = await multisig.functions.transactions(0);
-
-    expect(submittedTx.destination).to.equal(ACCOUNT_0);
-    expect(submittedTx.value.toString()).to.equal(
-      ethers.utils.parseUnits("50").toString()
-    );
-    expect(submittedTx.data).to.equal("0x00");
-    expect(submittedTx.executed).to.equal(false);
-  });
-
   it("should confirm a stored transaction", async function () {
     const [isConfirmed] = await multisig.functions.confirmations(0, ACCOUNT_0);
 
@@ -36,5 +25,16 @@ describe("Multisig", function () {
   it("should emit the sender and transaction id after confirming a stored transaction", async function () {
     expect(event.sender).to.equal(ACCOUNT_0);
     expect(ethers.BigNumber.from("0").eq(event.transactionId)).to.be.true;
+  });
+
+  it("should execute a confirmed transaction", async function () {
+    const submittedTx = await multisig.functions.transactions(0);
+
+    expect(submittedTx.destination).to.equal(ACCOUNT_0);
+    expect(submittedTx.value.toString()).to.equal(
+      ethers.utils.parseUnits("50").toString()
+    );
+    expect(submittedTx.data).to.equal("0x00");
+    expect(submittedTx.executed).to.equal(true);
   });
 });

--- a/examples/multisig/test/Multisig.js
+++ b/examples/multisig/test/Multisig.js
@@ -5,7 +5,7 @@ const Multisig = require("../ignition/Multisig");
 
 const ACCOUNT_0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
-describe.skip("Multisig", function () {
+describe("Multisig", function () {
   let multisig;
   let event;
 

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -56,14 +56,12 @@ function parseEventParams(
   abi: Array<{ type: string; name: string; inputs: any[] }>,
   event: EventFuture
 ): EventParams {
-  const [contractName, eventName] = event.label.split("/");
+  const [_, eventName] = event.label.split("/");
 
   const abiEvent = abi.find((v) => v.type === "event" && v.name === eventName);
 
   if (!abiEvent) {
-    throw new Error(
-      `No event "${eventName}" found in ABI for contract "${contractName}"`
-    );
+    return {};
   }
 
   return abiEvent.inputs.reduce<EventParams>((acc, { name }) => {

--- a/packages/core/src/execution/dispatch/executeAwaitedEvent.ts
+++ b/packages/core/src/execution/dispatch/executeAwaitedEvent.ts
@@ -1,4 +1,4 @@
-import { Contract } from "ethers";
+import { Contract, ethers } from "ethers";
 
 import { ExecutionContext } from "types/deployment";
 import { AwaitedEvent } from "types/executionGraph";
@@ -17,13 +17,13 @@ export async function executeAwaitedEvent(
 
   const { address, abi } = resolve(contract);
 
-  let eventResult;
+  let topics: ethers.utils.Result;
   try {
     const contractInstance = new Contract(address, abi);
 
     const filter = contractInstance.filters[event](...resolvedArgs);
 
-    eventResult = await services.transactions.waitForEvent(
+    const eventResult = await services.transactions.waitForEvent(
       filter,
       options.awaitEventDuration
     );
@@ -37,6 +37,8 @@ export async function executeAwaitedEvent(
         ),
       };
     }
+
+    topics = contractInstance.interface.parseLog(eventResult).args;
   } catch (err) {
     return {
       _kind: "failure",
@@ -47,7 +49,7 @@ export async function executeAwaitedEvent(
   return {
     _kind: "success",
     result: {
-      hash: eventResult.transactionHash,
+      topics,
     },
   };
 }

--- a/packages/core/src/execution/dispatch/executeAwaitedEvent.ts
+++ b/packages/core/src/execution/dispatch/executeAwaitedEvent.ts
@@ -7,19 +7,19 @@ import { VertexVisitResult } from "types/graph";
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeAwaitedEvent(
-  { event, contract, args }: AwaitedEvent,
+  { event, address, abi, args }: AwaitedEvent,
   resultAccumulator: Map<number, VertexVisitResult | null>,
   { services, options }: ExecutionContext
 ): Promise<VertexVisitResult> {
   const resolve = resolveFrom(resultAccumulator);
 
-  const resolvedArgs = args.map(resolve).map(toAddress);
+  const resolvedArgs = [...args, address].map(resolve).map(toAddress);
 
-  const { address, abi } = resolve(contract);
+  const resolvedAddress = resolvedArgs.pop();
 
   let topics: ethers.utils.Result;
   try {
-    const contractInstance = new Contract(address, abi);
+    const contractInstance = new Contract(resolvedAddress, abi);
 
     const filter = contractInstance.filters[event](...resolvedArgs);
 

--- a/packages/core/src/execution/dispatch/utils.ts
+++ b/packages/core/src/execution/dispatch/utils.ts
@@ -1,6 +1,6 @@
 import { ArgValue } from "types/executionGraph";
 import { ResultsAccumulator } from "types/graph";
-import { isDependable, isProxy } from "utils/guards";
+import { isDependable, isEventParam, isProxy } from "utils/guards";
 
 export function toAddress(v: any) {
   if (typeof v === "object" && "address" in v) {
@@ -19,7 +19,7 @@ function resolveFromContext(context: ResultsAccumulator, arg: ArgValue): any {
     return resolveFromContext(context, arg.value);
   }
 
-  if (!isDependable(arg)) {
+  if (!isDependable(arg) && !isEventParam(arg)) {
     return arg;
   }
 
@@ -33,6 +33,10 @@ function resolveFromContext(context: ResultsAccumulator, arg: ArgValue): any {
     throw new Error(
       `Looking up context on a failed vertex - violation of constraint`
     );
+  }
+
+  if (isEventParam(arg)) {
+    return entry.result.topics[arg.label];
   }
 
   return entry.result;

--- a/packages/core/src/types/deploymentGraph.ts
+++ b/packages/core/src/types/deploymentGraph.ts
@@ -3,7 +3,7 @@ import type { BigNumber } from "ethers";
 import {
   ArtifactContract,
   ArtifactLibrary,
-  AwaitFuture,
+  EventFuture,
   ContractCall,
   DeployedContract,
   DeploymentGraphFuture,
@@ -17,6 +17,7 @@ import {
   Virtual,
   ParameterFuture,
   BytesFuture,
+  ArtifactFuture,
 } from "./future";
 import { AdjacencyList, VertexDescriptor } from "./graph";
 import { Artifact } from "./hardhat";
@@ -53,7 +54,7 @@ export type DeploymentGraphVertex =
   | ArtifactLibraryDeploymentVertex
   | CallDeploymentVertex
   | VirtualVertex
-  | AwaitVertex;
+  | EventVertex;
 
 export interface HardhatContractDeploymentVertex extends VertexDescriptor {
   type: "HardhatContract";
@@ -115,10 +116,11 @@ export interface VirtualVertex extends VertexDescriptor {
   after: DeploymentGraphFuture[];
 }
 
-export interface AwaitVertex extends VertexDescriptor {
-  type: "Await";
+export interface EventVertex extends VertexDescriptor {
+  type: "Event";
   scopeAdded: string;
-  contract: CallableFuture;
+  abi: any[];
+  address: string | ArtifactContract;
   event: string;
   args: InternalParamValue[];
   after: DeploymentGraphFuture[];
@@ -179,10 +181,10 @@ export interface IDeploymentBuilder {
   ) => ContractCall;
 
   awaitEvent: (
-    contractFuture: DeploymentGraphFuture,
+    contractFuture: ArtifactFuture,
     eventName: string,
     options: AwaitOptions
-  ) => AwaitFuture;
+  ) => EventFuture;
 
   getParam: (paramName: string) => RequiredParameter;
 

--- a/packages/core/src/types/deploymentGraph.ts
+++ b/packages/core/src/types/deploymentGraph.ts
@@ -18,6 +18,7 @@ import {
   ParameterFuture,
   BytesFuture,
   ArtifactFuture,
+  EventParamFuture,
 } from "./future";
 import { AdjacencyList, VertexDescriptor } from "./graph";
 import { Artifact } from "./hardhat";
@@ -44,7 +45,10 @@ export interface LibraryMap {
 
 export type ExternalParamValue = boolean | string | number | BigNumber;
 
-export type InternalParamValue = ExternalParamValue | DeploymentGraphFuture;
+export type InternalParamValue =
+  | ExternalParamValue
+  | DeploymentGraphFuture
+  | EventParamFuture;
 
 export type DeploymentGraphVertex =
   | HardhatContractDeploymentVertex

--- a/packages/core/src/types/executionGraph.ts
+++ b/packages/core/src/types/executionGraph.ts
@@ -1,7 +1,7 @@
 import type { BigNumber } from "ethers";
 
 import { LibraryMap } from "./deploymentGraph";
-import { DeploymentGraphFuture } from "./future";
+import { ArtifactContract, DeploymentGraphFuture } from "./future";
 import { AdjacencyList, VertexDescriptor } from "./graph";
 import { Artifact } from "./hardhat";
 
@@ -62,7 +62,8 @@ export interface ContractCall extends VertexDescriptor {
 
 export interface AwaitedEvent extends VertexDescriptor {
   type: "AwaitedEvent";
-  contract: any;
+  abi: any[];
+  address: string | ArtifactContract;
   event: string;
   args: ArgValue[];
 }

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -67,6 +67,7 @@ export interface EventParams {
 }
 
 export interface EventParamFuture {
+  vertexId: number;
   label: string;
   type: "eventParam";
   _future: true;
@@ -135,7 +136,8 @@ export type ParameterFuture = RequiredParameter | OptionalParameter;
 export type DeploymentGraphFuture =
   | DependableFuture
   | ParameterFuture
-  | BytesFuture;
+  | BytesFuture
+  | EventParamFuture;
 
 export interface FutureDict {
   [key: string]: DeploymentGraphFuture;

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -24,6 +24,7 @@ export interface DeployedContract {
   type: "contract";
   subtype: "deployed";
   abi: any[];
+  address: string;
   _future: true;
 }
 
@@ -52,10 +53,22 @@ export interface ContractCall {
   _future: true;
 }
 
-export interface AwaitFuture {
+export interface EventFuture {
   vertexId: number;
   label: string;
   type: "await";
+  subtype: "event";
+  _future: true;
+  params: EventParams;
+}
+
+export interface EventParams {
+  [eventParam: string]: EventParamFuture;
+}
+
+export interface EventParamFuture {
+  label: string;
+  type: "eventParam";
   _future: true;
 }
 
@@ -99,6 +112,8 @@ export interface ProxyFuture {
   _future: true;
 }
 
+export type ArtifactFuture = ArtifactContract | DeployedContract;
+
 export type ContractFuture =
   | HardhatContract
   | ArtifactContract
@@ -113,7 +128,7 @@ export type DependableFuture =
   | ContractCall
   | Virtual
   | ProxyFuture
-  | AwaitFuture;
+  | EventFuture;
 
 export type ParameterFuture = RequiredParameter | OptionalParameter;
 

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -1,13 +1,14 @@
 import type { ExternalParamValue, Subgraph } from "./deploymentGraph";
 import type {
   CallableFuture,
+  EventFuture,
   FutureDict,
   ProxyFuture,
   Virtual,
 } from "./future";
 
 export interface ModuleDict extends FutureDict {
-  [key: string]: CallableFuture | Virtual | ProxyFuture;
+  [key: string]: CallableFuture | Virtual | ProxyFuture | EventFuture;
 }
 
 export type Module<T extends ModuleDict> = Subgraph<T>;

--- a/packages/core/src/types/serialization.ts
+++ b/packages/core/src/types/serialization.ts
@@ -1,14 +1,17 @@
+import type { ethers } from "ethers";
+
 export type SerializedFutureResult =
   | { _kind: "string"; value: string }
   | { _kind: "number"; value: number }
   | { _kind: "contract"; value: Contract }
-  | { _kind: "tx"; value: Tx };
+  | { _kind: "tx"; value: Tx }
+  | { _kind: "event"; value: Event };
 
 export interface SerializedDeploymentResult {
   [key: string]: SerializedFutureResult;
 }
 
-export type FutureOutput = string | number | Contract | Tx;
+export type FutureOutput = string | number | Contract | Tx | Event;
 
 export interface Contract {
   name: string;
@@ -18,4 +21,8 @@ export interface Contract {
 
 export interface Tx {
   hash: string;
+}
+
+export interface Event {
+  topics: ethers.utils.Result;
 }

--- a/packages/core/src/utils/guards.ts
+++ b/packages/core/src/utils/guards.ts
@@ -8,7 +8,7 @@ import type {
   CallDeploymentVertex,
   HardhatLibraryDeploymentVertex,
   ArtifactLibraryDeploymentVertex,
-  AwaitVertex,
+  EventVertex,
   InternalParamValue,
 } from "types/deploymentGraph";
 import type {
@@ -58,8 +58,8 @@ export function isCall(
 
 export function isAwaitedEvent(
   node: DeploymentGraphVertex
-): node is AwaitVertex {
-  return node.type === "Await";
+): node is EventVertex {
+  return node.type === "Event";
 }
 
 export function isHardhatLibrary(

--- a/packages/core/src/utils/guards.ts
+++ b/packages/core/src/utils/guards.ts
@@ -20,6 +20,7 @@ import type {
   Virtual,
   ProxyFuture,
   BytesFuture,
+  EventParamFuture,
 } from "types/future";
 import { Artifact } from "types/hardhat";
 
@@ -101,6 +102,10 @@ export function isProxy(possible: any): possible is ProxyFuture {
 
 export function isVirtual(possible: any): possible is Virtual {
   return isFuture(possible) && possible.type === "virtual";
+}
+
+export function isEventParam(possible: any): possible is EventParamFuture {
+  return isFuture(possible) && possible.type === "eventParam";
 }
 
 export function isParameter(

--- a/packages/core/src/utils/proxy.ts
+++ b/packages/core/src/utils/proxy.ts
@@ -3,14 +3,14 @@ import {
   ContractCall,
   DependableFuture,
   Virtual,
-  AwaitFuture,
+  EventFuture,
 } from "types/future";
 
 import { isProxy } from "./guards";
 
 export function resolveProxyDependency(
   future: DependableFuture
-): CallableFuture | ContractCall | Virtual | AwaitFuture {
+): CallableFuture | ContractCall | Virtual | EventFuture {
   if (isProxy(future)) {
     return resolveProxyDependency(future.proxy);
   }
@@ -20,7 +20,7 @@ export function resolveProxyDependency(
 
 export function resolveProxyValue(
   future: DependableFuture
-): CallableFuture | ContractCall | Virtual | AwaitFuture {
+): CallableFuture | ContractCall | Virtual | EventFuture {
   if (isProxy(future)) {
     return resolveProxyValue(future.value);
   }

--- a/packages/core/src/utils/serialize.ts
+++ b/packages/core/src/utils/serialize.ts
@@ -9,6 +9,8 @@ export function serializeFutureOutput(x: FutureOutput): SerializedFutureResult {
     return { _kind: "contract" as const, value: x };
   } else if ("hash" in x) {
     return { _kind: "tx" as const, value: x };
+  } else if ("topics" in x) {
+    return { _kind: "event" as const, value: x };
   }
 
   const exhaustiveCheck: never = x;

--- a/packages/core/src/validation/dispatch/validateAwaitEvent.ts
+++ b/packages/core/src/validation/dispatch/validateAwaitEvent.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 
 import { Services } from "services/types";
-import { AwaitVertex } from "types/deploymentGraph";
+import { EventVertex } from "types/deploymentGraph";
 import { ResultsAccumulator, VertexVisitResult } from "types/graph";
 
 import {
@@ -10,12 +10,10 @@ import {
 } from "./helpers";
 
 export async function validateAwaitEvent(
-  vertex: AwaitVertex,
+  vertex: EventVertex,
   _resultAccumulator: ResultsAccumulator,
   context: { services: Services }
 ): Promise<VertexVisitResult> {
-  const contractName = vertex.contract.label;
-
   const invalidBytes = await validateBytesForArtifact(
     vertex.args,
     context.services
@@ -25,21 +23,31 @@ export async function validateAwaitEvent(
     return invalidBytes;
   }
 
-  const artifactAbi = await resolveArtifactForCallableFuture(
-    vertex.contract,
-    context
-  );
+  let artifactAbi: any[] | undefined;
+  if (typeof vertex.address !== "string") {
+    artifactAbi = await resolveArtifactForCallableFuture(
+      vertex.address,
+      context
+    );
 
-  if (artifactAbi === undefined) {
+    if (artifactAbi === undefined) {
+      return {
+        _kind: "failure",
+        failure: new Error(
+          `Artifact with name '${vertex.address.label}' doesn't exist`
+        ),
+      };
+    }
+  } else if (!ethers.utils.isAddress(vertex.address)) {
     return {
       _kind: "failure",
-      failure: new Error(`Artifact with name '${contractName}' doesn't exist`),
+      failure: new Error(`Invalid address ${vertex.address}`),
     };
   }
 
   const argsLength = vertex.args.length;
 
-  const iface = new ethers.utils.Interface(artifactAbi);
+  const iface = new ethers.utils.Interface(artifactAbi ?? vertex.abi);
 
   const events = Object.entries(iface.events)
     .filter(([fname]) => fname === vertex.event)
@@ -53,7 +61,7 @@ export async function validateAwaitEvent(
     return {
       _kind: "failure",
       failure: new Error(
-        `Contract '${contractName}' doesn't have an event ${vertex.event}`
+        `Given contract doesn't have an event ${vertex.event}`
       ),
     };
   }
@@ -67,14 +75,14 @@ export async function validateAwaitEvent(
       return {
         _kind: "failure",
         failure: new Error(
-          `Event ${vertex.event} in contract ${contractName} expects ${eventFragments[0].inputs.length} arguments but ${argsLength} were given`
+          `Event ${vertex.event} in contract expects ${eventFragments[0].inputs.length} arguments but ${argsLength} were given`
         ),
       };
     } else {
       return {
         _kind: "failure",
         failure: new Error(
-          `Event ${vertex.event} in contract ${contractName} is overloaded, but no overload expects ${argsLength} arguments`
+          `Event ${vertex.event} in contract is overloaded, but no overload expects ${argsLength} arguments`
         ),
       };
     }

--- a/packages/core/src/validation/dispatch/validateAwaitEvent.ts
+++ b/packages/core/src/validation/dispatch/validateAwaitEvent.ts
@@ -58,10 +58,12 @@ export async function validateAwaitEvent(
     .concat(events);
 
   if (eventFragments.length === 0) {
+    const contractName = vertex.label.split("/")[0];
+
     return {
       _kind: "failure",
       failure: new Error(
-        `Given contract doesn't have an event ${vertex.event}`
+        `Contract '${contractName}' doesn't have an event ${vertex.event}`
       ),
     };
   }
@@ -72,10 +74,12 @@ export async function validateAwaitEvent(
 
   if (matchingEventFragments.length === 0) {
     if (eventFragments.length === 1) {
+      const contractName = vertex.label.split("/")[0];
+
       return {
         _kind: "failure",
         failure: new Error(
-          `Event ${vertex.event} in contract expects ${eventFragments[0].inputs.length} arguments but ${argsLength} were given`
+          `Event ${vertex.event} in contract ${contractName} expects ${eventFragments[0].inputs.length} arguments but ${argsLength} were given`
         ),
       };
     } else {

--- a/packages/core/src/validation/dispatch/validationDispatch.ts
+++ b/packages/core/src/validation/dispatch/validationDispatch.ts
@@ -51,7 +51,7 @@ export function validationDispatch(
       );
     case "Virtual":
       return validateVirtual(deploymentVertex, resultAccumulator, context);
-    case "Await":
+    case "Event":
       return validateAwaitEvent(deploymentVertex, resultAccumulator, context);
     default:
       return assertUnknownDeploymentVertexType(deploymentVertex);

--- a/packages/core/test/deploymentBuilder/awaitedEvent.ts
+++ b/packages/core/test/deploymentBuilder/awaitedEvent.ts
@@ -25,7 +25,7 @@ describe("deployment builder - await event", () => {
         after: [another],
       });
 
-      m.awaitEvent(token, "Transfer", { args: [token], after: [call] });
+      m.awaitEvent({});
 
       return {};
     });

--- a/packages/core/test/deploymentBuilder/awaitedEvent.ts
+++ b/packages/core/test/deploymentBuilder/awaitedEvent.ts
@@ -4,28 +4,83 @@ import { assert } from "chai";
 import { buildModule } from "dsl/buildModule";
 import { generateDeploymentGraphFrom } from "process/generateDeploymentGraphFrom";
 import { IDeploymentBuilder, IDeploymentGraph } from "types/deploymentGraph";
-import { isAwaitedEvent, isCall, isHardhatContract } from "utils/guards";
+import { ArtifactContract } from "types/future";
+import { isAwaitedEvent, isCall, isArtifactContract } from "utils/guards";
 
 import {
   getDependenciesForVertex,
   getDeploymentVertexByLabel,
 } from "./helpers";
 
+const artifact = {
+  contractName: "Token",
+  abi: [
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "sender",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "uint256",
+          name: "value",
+          type: "uint256",
+        },
+      ],
+      name: "SomeEvent",
+      type: "event",
+    },
+    {
+      inputs: [],
+      name: "test",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          internalType: "uint256",
+          name: "num",
+          type: "uint256",
+        },
+      ],
+      name: "verify",
+      outputs: [],
+      stateMutability: "pure",
+      type: "function",
+    },
+  ],
+  bytecode:
+    "608060405234801561001057600080fd5b5061019c806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80638753367f1461003b578063f8a8fd6d14610057575b600080fd5b610055600480360381019061005091906100d7565b610061565b005b61005f610071565b005b607b811461006e57600080fd5b50565b3073ffffffffffffffffffffffffffffffffffffffff167fdde371250dcd21c331edbb965b9163f4898566e8c60e28868533281edf66ab03607b6040516100b89190610113565b60405180910390a2565b6000813590506100d18161014f565b92915050565b6000602082840312156100ed576100ec61014a565b5b60006100fb848285016100c2565b91505092915050565b61010d81610138565b82525050565b60006020820190506101286000830184610104565b92915050565b6000819050919050565b60006101438261012e565b9050919050565b600080fd5b6101588161012e565b811461016357600080fd5b5056fea2646970667358221220feb2fe32fb60d1ce42ae5b67f1d29871608dc1e7f38f6abad28706024c3aa14864736f6c63430008070033",
+  linkReferences: {},
+};
+
 describe("deployment builder - await event", () => {
   let deploymentGraph: IDeploymentGraph;
 
   before(() => {
     const eventModule = buildModule("event", (m: IDeploymentBuilder) => {
-      const token = m.contract("Token");
-      const exchange = m.contract("Exchange");
-      const another = m.contract("Another");
+      const testContract = m.contract("Test", artifact);
 
-      const call = m.call(exchange, "addToken", {
-        args: [token],
-        after: [another],
+      const call = m.call(testContract, "test", { args: [] });
+
+      const event = m.awaitEvent(
+        testContract as ArtifactContract,
+        "SomeEvent",
+        {
+          args: [testContract],
+          after: [call],
+        }
+      );
+
+      m.call(testContract, "verify", {
+        args: [event.params.value],
       });
-
-      m.awaitEvent({});
 
       return {};
     });
@@ -41,61 +96,59 @@ describe("deployment builder - await event", () => {
     assert.isDefined(deploymentGraph);
   });
 
-  it("should have five nodes", () => {
-    assert.equal(deploymentGraph.vertexes.size, 5);
+  it("should have four nodes", () => {
+    assert.equal(deploymentGraph.vertexes.size, 4);
   });
 
-  it("should have the contract node Token", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
-
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
-    assert.equal(depNode?.label, "Token");
-    assert(isHardhatContract(depNode));
-  });
-
-  it("should have the contract node Exchange", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
+  it("should have the contract node Test", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test");
 
     if (depNode === undefined) {
       return assert.isDefined(depNode);
     }
 
-    assert.equal(depNode?.label, "Exchange");
-    assert(isHardhatContract(depNode));
+    assert.equal(depNode?.label, "Test");
+    assert(isArtifactContract(depNode));
   });
 
-  it("should have the call node Exchange/addToken", () => {
-    const depNode = getDeploymentVertexByLabel(
-      deploymentGraph,
-      "Exchange/addToken"
-    );
+  it("should have the call node Test/test", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test/test");
 
     if (depNode === undefined) {
       return assert.isDefined(depNode);
     }
 
-    assert.equal(depNode?.label, "Exchange/addToken");
+    assert.equal(depNode?.label, "Test/test");
     assert(isCall(depNode));
   });
 
-  it("should have the await event node Token/Transfer", () => {
+  it("should have the await event node Test/SomeEvent", () => {
     const depNode = getDeploymentVertexByLabel(
       deploymentGraph,
-      "Token/Transfer"
+      "Test/SomeEvent"
     );
 
     if (depNode === undefined) {
       return assert.isDefined(depNode);
     }
 
-    assert.equal(depNode?.label, "Token/Transfer");
+    assert.equal(depNode?.label, "Test/SomeEvent");
     assert(isAwaitedEvent(depNode));
   });
 
-  it("should show no dependencies for the contract node Token", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+  it("should have the call node Test/verify", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test/verify");
+
+    if (depNode === undefined) {
+      return assert.isDefined(depNode);
+    }
+
+    assert.equal(depNode?.label, "Test/verify");
+    assert(isCall(depNode));
+  });
+
+  it("should show no dependencies for the contract node Test", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test");
 
     if (depNode === undefined) {
       return assert.isDefined(depNode);
@@ -106,8 +159,8 @@ describe("deployment builder - await event", () => {
     assert.deepStrictEqual(deps, []);
   });
 
-  it("should show no dependencies for the contract node Exchange", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
+  it("should show one dependency for the call node Test/test", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test/test");
 
     if (depNode === undefined) {
       return assert.isDefined(depNode);
@@ -115,13 +168,19 @@ describe("deployment builder - await event", () => {
 
     const deps = getDependenciesForVertex(deploymentGraph, depNode);
 
-    assert.deepStrictEqual(deps, []);
+    assert.deepStrictEqual(deps, [
+      {
+        id: 0,
+        label: "Test",
+        type: "",
+      },
+    ]);
   });
 
-  it("should show three dependencies for the call node Exchange/addToken", () => {
+  it("should show two dependencies for the event node Test/SomeEvent", () => {
     const depNode = getDeploymentVertexByLabel(
       deploymentGraph,
-      "Exchange/addToken"
+      "Test/SomeEvent"
     );
 
     if (depNode === undefined) {
@@ -133,19 +192,19 @@ describe("deployment builder - await event", () => {
     assert.deepStrictEqual(deps, [
       {
         id: 0,
-        label: "Token",
+        label: "Test",
         type: "",
       },
-      { id: 1, label: "Exchange", type: "" },
-      { id: 2, label: "Another", type: "" },
+      {
+        id: 1,
+        label: "Test/test",
+        type: "",
+      },
     ]);
   });
 
-  it("should show two dependencies for the call node Token/Transfer", () => {
-    const depNode = getDeploymentVertexByLabel(
-      deploymentGraph,
-      "Token/Transfer"
-    );
+  it("should show two dependencies for the call node Test/verify", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test/verify");
 
     if (depNode === undefined) {
       return assert.isDefined(depNode);
@@ -156,50 +215,33 @@ describe("deployment builder - await event", () => {
     assert.deepStrictEqual(deps, [
       {
         id: 0,
-        label: "Token",
+        label: "Test",
         type: "",
       },
       {
-        id: 3,
-        label: "Exchange/addToken",
+        id: 2,
+        label: "Test/SomeEvent",
         type: "",
       },
     ]);
   });
 
-  it("should record the argument list for the contract node Token as empty", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+  it("should record the argument list for the contract node Test as empty", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test");
 
     if (depNode === undefined) {
       return assert.isDefined(depNode);
     }
 
-    if (!isHardhatContract(depNode)) {
+    if (!isArtifactContract(depNode)) {
       return assert.fail("Not a hardhat contract dependency node");
     }
 
     assert.deepStrictEqual(depNode.args, []);
   });
 
-  it("should record the argument list for the contract node Exchange as empty", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
-
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
-
-    if (!isHardhatContract(depNode)) {
-      return assert.fail("Not a hardhat contract dependency node");
-    }
-
-    assert.deepStrictEqual(depNode.args, []);
-  });
-
-  it("should record the argument list for the call node Exchange at Exchange/addToken", () => {
-    const depNode = getDeploymentVertexByLabel(
-      deploymentGraph,
-      "Exchange/addToken"
-    );
+  it("should record the argument list for the call node Test/test as empty", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test/test");
 
     if (depNode === undefined) {
       return assert.isDefined(depNode);
@@ -209,22 +251,13 @@ describe("deployment builder - await event", () => {
       return assert.fail("Not a call dependency node");
     }
 
-    assert.deepStrictEqual(depNode.args, [
-      {
-        vertexId: 0,
-        label: "Token",
-        type: "contract",
-        subtype: "hardhat",
-        contractName: "Token",
-        _future: true,
-      },
-    ]);
+    assert.deepStrictEqual(depNode.args, []);
   });
 
-  it("should record the argument list for the event node Token at Token/Transfer", () => {
+  it("should record the argument list for the event node Test/SomeEvent", () => {
     const depNode = getDeploymentVertexByLabel(
       deploymentGraph,
-      "Token/Transfer"
+      "Test/SomeEvent"
     );
 
     if (depNode === undefined) {
@@ -238,10 +271,31 @@ describe("deployment builder - await event", () => {
     assert.deepStrictEqual(depNode.args, [
       {
         vertexId: 0,
-        label: "Token",
+        label: "Test",
         type: "contract",
-        subtype: "hardhat",
-        contractName: "Token",
+        subtype: "artifact",
+        artifact,
+        _future: true,
+      },
+    ]);
+  });
+
+  it("should record the argument list for the call node Test/verify", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Test/verify");
+
+    if (depNode === undefined) {
+      return assert.isDefined(depNode);
+    }
+
+    if (!isCall(depNode)) {
+      return assert.fail("Not a call dependency node");
+    }
+
+    assert.deepStrictEqual(depNode.args, [
+      {
+        vertexId: 2,
+        label: "value",
+        type: "eventParam",
         _future: true,
       },
     ]);

--- a/packages/core/test/execution.ts
+++ b/packages/core/test/execution.ts
@@ -298,12 +298,19 @@ describe("Execution", () => {
       args: [ACCOUNT_0],
     };
 
+    const iface = new ethers.utils.Interface(fakeArtifact.abi);
+
+    const fakeLog = iface.encodeEventLog(
+      ethers.utils.EventFragment.from(fakeArtifact.abi[0]),
+      ["0x0000000000000000000000000000000000000003"]
+    );
+
     const sendTxStub = sinon.stub();
     sendTxStub.onCall(0).resolves("0x1");
     sendTxStub.onCall(1).resolves("0x2");
 
     const waitForEventStub = sinon.stub();
-    waitForEventStub.onFirstCall().resolves({ transactionHash: "0x3" });
+    waitForEventStub.onFirstCall().resolves(fakeLog);
 
     const mockServices: Services = {
       ...getMockServices(),
@@ -339,7 +346,7 @@ describe("Execution", () => {
     assert.deepStrictEqual(response.result.get(2), {
       _kind: "success",
       result: {
-        hash: "0x3",
+        topics: ["0x0000000000000000000000000000000000000003"],
       },
     });
   });

--- a/packages/core/test/execution.ts
+++ b/packages/core/test/execution.ts
@@ -292,7 +292,15 @@ describe("Execution", () => {
     const awaitedEvent: ExecutionVertex = {
       type: "AwaitedEvent",
       id: 2,
-      contract: { vertexId: 0, type: "contract", label: "Test", _future: true },
+      abi: fakeArtifact.abi,
+      address: {
+        vertexId: 0,
+        type: "contract",
+        subtype: "artifact",
+        artifact: fakeArtifact,
+        label: "Test",
+        _future: true,
+      },
       label: "Test/SomeEvent",
       event: "SomeEvent",
       args: [ACCOUNT_0],

--- a/packages/core/test/validation.ts
+++ b/packages/core/test/validation.ts
@@ -6,6 +6,7 @@ import { buildModule } from "dsl/buildModule";
 import { buildSubgraph } from "dsl/buildSubgraph";
 import { generateDeploymentGraphFrom } from "process/generateDeploymentGraphFrom";
 import type { IDeploymentBuilder } from "types/deploymentGraph";
+import { ArtifactContract } from "types/future";
 import { Artifact } from "types/hardhat";
 import { validateDeploymentGraph } from "validation/validateDeploymentGraph";
 
@@ -644,11 +645,14 @@ describe("Validation", () => {
 
     it("should validate a correct awaited event", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.contract("Test");
+        const example = m.contract("Test", exampleEventArtifact);
 
         const call = m.call(example, "test", { args: [] });
 
-        m.awaitEvent(example, "SomeEvent", { after: [call], args: ["0x0"] });
+        m.awaitEvent(example as ArtifactContract, "SomeEvent", {
+          after: [call],
+          args: ["0x0"],
+        });
 
         return { example };
       });
@@ -674,11 +678,14 @@ describe("Validation", () => {
 
     it("should fail awaiting a nonexistant event", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.contract("Test");
+        const example = m.contract("Test", exampleEventArtifact);
 
         const call = m.call(example, "test", { args: [] });
 
-        m.awaitEvent(example, "Nonexistant", { args: [], after: [call] });
+        m.awaitEvent(example as ArtifactContract, "Nonexistant", {
+          args: [],
+          after: [call],
+        });
 
         return { example };
       });
@@ -717,11 +724,14 @@ describe("Validation", () => {
 
     it("should fail an awaited event with wrong number of arguments", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.contract("Test");
+        const example = m.contract("Test", exampleEventArtifact);
 
         const call = m.call(example, "test", { args: [] });
 
-        m.awaitEvent(example, "SomeEvent", { after: [call], args: [] });
+        m.awaitEvent(example as ArtifactContract, "SomeEvent", {
+          after: [call],
+          args: [],
+        });
 
         return { example };
       });

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -6,7 +6,7 @@ import {
   ModuleDict,
   ModuleParams,
 } from "@ignored/ignition-core";
-import { Contract } from "ethers";
+import { Contract, ethers } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { renderToCli } from "./ui/renderToCli";
@@ -14,7 +14,7 @@ import { renderToCli } from "./ui/renderToCli";
 type HardhatEthers = HardhatRuntimeEnvironment["ethers"];
 
 interface DeployResult {
-  [key: string]: string | number | Contract;
+  [key: string]: string | number | Contract | ethers.utils.Result;
 }
 
 export class IgnitionWrapper {
@@ -68,7 +68,9 @@ export class IgnitionWrapper {
       }
     }
 
-    const resolvedOutput: { [key: string]: string | number | Contract } = {};
+    const resolvedOutput: {
+      [key: string]: string | number | Contract | ethers.utils.Result;
+    } = {};
     for (const [key, serializedFutureResult] of Object.entries(
       deploymentResult.result
     )) {
@@ -79,6 +81,8 @@ export class IgnitionWrapper {
         resolvedOutput[key] = serializedFutureResult.value;
       } else if (serializedFutureResult._kind === "tx") {
         resolvedOutput[key] = serializedFutureResult.value.hash;
+      } else if (serializedFutureResult._kind === "event") {
+        resolvedOutput[key] = serializedFutureResult.value.topics;
       } else {
         const { abi, address } = serializedFutureResult.value;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,6 +1859,7 @@
     hardhat-watcher "^2.1.1"
 
 "@uniswap/v3-periphery@1.3.0", "v3-periphery-1_3_0@npm:@uniswap/v3-periphery@1.3.0":
+  name v3-periphery-1_3_0
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@uniswap/v3-periphery/-/v3-periphery-1.3.0.tgz#37f0a1ef6025221722e50e9f3f2009c2d5d6e4ec"
   integrity sha512-HjHdI5RkjBl8zz3bqHShrbULFoZSrjbbrRHoO2vbzn+WRzTa6xY4PWphZv2Tlcb38YEKfKHp6NPl5hVedac8uw==


### PR DESCRIPTION
- `m.awaitEvent` now includes a `params` field in its returned future that can be used to pass resolved emitted values into other module builder functions(i.e. as args)
- values from the emitted event are resolved and returned as the result of the event future