### PR TITLE
Support event params in contractAt

### DIFF
--- a/examples/create2/ignition/Create2FactoryModule.js
+++ b/examples/create2/ignition/Create2FactoryModule.js
@@ -1,7 +1,42 @@
 const { buildModule } = require("@ignored/hardhat-ignition");
 
-module.exports = buildModule("Create2Factory", (m) => {
-  const create2 = m.contract("Create2Factory");
+const Create2Artifact = require("../artifacts/contracts/Create2Factory.sol/Create2Factory.json");
+const BarArtifact = require("../artifacts/contracts/Bar.sol/Bar.json");
+const FooArtifact = require("../artifacts/contracts/Foo.sol/Foo.json");
 
-  return { create2 };
+module.exports = buildModule("Create2Factory", (m) => {
+  const create2 = m.contract("Create2Factory", Create2Artifact, { args: [] });
+
+  const fooCall = m.call(create2, "deploy", {
+    args: [0, toBytes32(1), m.getBytesForArtifact("Foo")],
+  });
+
+  const fooEvent = m.awaitEvent(create2, "Deployed", {
+    args: [toBytes32(1)],
+    after: [fooCall],
+  });
+
+  const barCall = m.call(create2, "deploy", {
+    args: [0, toBytes32(2), m.getBytesForArtifact("Bar")],
+    after: [fooEvent],
+  });
+
+  const barEvent = m.awaitEvent(create2, "Deployed", {
+    args: [toBytes32(2)],
+    after: [barCall],
+  });
+
+  const foo = m.contractAt("Foo", fooEvent.params.deployed, FooArtifact.abi, {
+    after: [fooEvent],
+  });
+
+  const bar = m.contractAt("Bar", barEvent.params.deployed, BarArtifact.abi, {
+    after: [barEvent],
+  });
+
+  return { create2, foo, bar, fooEvent, barEvent };
 });
+
+function toBytes32(n) {
+  return hre.ethers.utils.hexZeroPad(hre.ethers.utils.hexlify(n), 32);
+}

--- a/examples/create2/test/create2.test.js
+++ b/examples/create2/test/create2.test.js
@@ -16,11 +16,16 @@ describe("Create2", function () {
           args: [0, toBytes32(1), m.getBytesForArtifact("Foo")],
         });
 
-        m.call(create2, "deploy", {
+        const call = m.call(create2, "deploy", {
           args: [0, toBytes32(2), m.getBytesForArtifact("Bar")],
         });
 
-        return { create2 };
+        const event = m.awaitEvent(create2, "Deployed", {
+          args: [toBytes32(2)],
+          after: [call],
+        });
+
+        return { create2, bar: m.contractAt(event.params.deployed) };
       }
     );
 

--- a/examples/create2/test/create2.test.js
+++ b/examples/create2/test/create2.test.js
@@ -1,45 +1,20 @@
 const { assert } = require("chai");
-const { buildModule } = require("@ignored/hardhat-ignition");
 
 const Create2FactoryModule = require("../ignition/Create2FactoryModule");
 
 describe("Create2", function () {
-  let factory;
+  let deployResults;
 
   before(async () => {
-    const DeployViaCreate2Module = buildModule(
-      "DeployViaCreate2Module",
-      (m) => {
-        const { create2 } = m.useModule(Create2FactoryModule);
-
-        m.call(create2, "deploy", {
-          args: [0, toBytes32(1), m.getBytesForArtifact("Foo")],
-        });
-
-        const call = m.call(create2, "deploy", {
-          args: [0, toBytes32(2), m.getBytesForArtifact("Bar")],
-        });
-
-        const event = m.awaitEvent(create2, "Deployed", {
-          args: [toBytes32(2)],
-          after: [call],
-        });
-
-        return { create2, bar: m.contractAt(event.params.deployed) };
-      }
-    );
-
-    const { create2 } = await ignition.deploy(DeployViaCreate2Module);
-
-    factory = create2;
+    deployResults = await ignition.deploy(Create2FactoryModule);
   });
 
   it("should return an instantiated factory", async function () {
-    assert.isDefined(factory);
+    assert.isDefined(deployResults.create2);
   });
 
   it("should have deployed the foo contract", async () => {
-    const address = await resolveAddressBasedOnSalt(factory, 1);
+    const address = deployResults.fooEvent.deployed;
     const FooFactory = await hre.ethers.getContractFactory("Foo");
     const foo = FooFactory.attach(address);
 
@@ -47,22 +22,10 @@ describe("Create2", function () {
   });
 
   it("should have deployed the bar contract", async () => {
-    const address = await resolveAddressBasedOnSalt(factory, 2);
-    const FooFactory = await hre.ethers.getContractFactory("Bar");
-    const foo = FooFactory.attach(address);
+    const address = deployResults.barEvent.deployed;
+    const BarFactory = await hre.ethers.getContractFactory("Bar");
+    const bar = BarFactory.attach(address);
 
-    assert.equal(await foo.name(), "Bar");
+    assert.equal(await bar.name(), "Bar");
   });
 });
-
-function toBytes32(n) {
-  return hre.ethers.utils.hexZeroPad(hre.ethers.utils.hexlify(n), 32);
-}
-
-async function resolveAddressBasedOnSalt(factory, salt) {
-  const deployedEvents = await factory.queryFilter(
-    factory.filters.Deployed(toBytes32(salt))
-  );
-
-  return deployedEvents[0].args.deployed;
-}

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -35,6 +35,7 @@ import type {
   BytesFuture,
   EventParams,
   ArtifactFuture,
+  EventParamFuture,
 } from "types/future";
 import type { Artifact } from "types/hardhat";
 import type { ModuleCache, ModuleDict } from "types/module";
@@ -204,7 +205,7 @@ export class DeploymentBuilder implements IDeploymentBuilder {
 
   public contractAt(
     contractName: string,
-    address: string,
+    address: string | EventParamFuture,
     abi: any[],
     options?: { after?: DeploymentGraphFuture[] }
   ): DeployedContract {
@@ -313,7 +314,7 @@ export class DeploymentBuilder implements IDeploymentBuilder {
     }
 
     let abi: any[];
-    let address: string | ArtifactContract;
+    let address: string | ArtifactContract | EventParamFuture;
     if (artifactFuture.subtype === "artifact") {
       abi = artifactFuture.artifact.abi;
       address = artifactFuture;

--- a/packages/core/src/types/deploymentGraph.ts
+++ b/packages/core/src/types/deploymentGraph.ts
@@ -83,7 +83,7 @@ export interface ArtifactContractDeploymentVertex extends VertexDescriptor {
 export interface DeployedContractDeploymentVertex extends VertexDescriptor {
   type: "DeployedContract";
   scopeAdded: string;
-  address: string;
+  address: string | EventParamFuture;
   abi: any[];
   after: DeploymentGraphFuture[];
 }
@@ -124,7 +124,7 @@ export interface EventVertex extends VertexDescriptor {
   type: "Event";
   scopeAdded: string;
   abi: any[];
-  address: string | ArtifactContract;
+  address: string | ArtifactContract | EventParamFuture;
   event: string;
   args: InternalParamValue[];
   after: DeploymentGraphFuture[];
@@ -167,7 +167,7 @@ export interface IDeploymentBuilder {
 
   contractAt: (
     contractName: string,
-    address: string,
+    address: string | EventParamFuture,
     abi: any[],
     options?: { after?: DeploymentGraphFuture[] }
   ) => DeployedContract;

--- a/packages/core/src/types/executionGraph.ts
+++ b/packages/core/src/types/executionGraph.ts
@@ -1,7 +1,11 @@
 import type { BigNumber } from "ethers";
 
 import { LibraryMap } from "./deploymentGraph";
-import { ArtifactContract, DeploymentGraphFuture } from "./future";
+import {
+  ArtifactContract,
+  DeploymentGraphFuture,
+  EventParamFuture,
+} from "./future";
 import { AdjacencyList, VertexDescriptor } from "./graph";
 import { Artifact } from "./hardhat";
 
@@ -42,7 +46,7 @@ export interface ContractDeploy extends VertexDescriptor {
 
 export interface DeployedContract extends VertexDescriptor {
   type: "DeployedContract";
-  address: string;
+  address: string | EventParamFuture;
   abi: any[];
 }
 
@@ -63,7 +67,7 @@ export interface ContractCall extends VertexDescriptor {
 export interface AwaitedEvent extends VertexDescriptor {
   type: "AwaitedEvent";
   abi: any[];
-  address: string | ArtifactContract;
+  address: string | ArtifactContract | EventParamFuture;
   event: string;
   args: ArgValue[];
 }

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -24,7 +24,7 @@ export interface DeployedContract {
   type: "contract";
   subtype: "deployed";
   abi: any[];
-  address: string;
+  address: string | EventParamFuture;
   _future: true;
 }
 
@@ -114,6 +114,8 @@ export interface ProxyFuture {
 }
 
 export type ArtifactFuture = ArtifactContract | DeployedContract;
+
+export type AddressResolvable = EventParamFuture | ArtifactFuture;
 
 export type ContractFuture =
   | HardhatContract

--- a/packages/core/src/validation/dispatch/validateAwaitEvent.ts
+++ b/packages/core/src/validation/dispatch/validateAwaitEvent.ts
@@ -24,7 +24,16 @@ export async function validateAwaitEvent(
   }
 
   let artifactAbi: any[] | undefined;
-  if (typeof vertex.address !== "string") {
+  if (typeof vertex.address === "string") {
+    if (!ethers.utils.isAddress(vertex.address)) {
+      return {
+        _kind: "failure",
+        failure: new Error(`Invalid address ${vertex.address}`),
+      };
+    }
+
+    artifactAbi = vertex.abi;
+  } else if (vertex.address.type === "contract") {
     artifactAbi = await resolveArtifactForCallableFuture(
       vertex.address,
       context
@@ -38,11 +47,6 @@ export async function validateAwaitEvent(
         ),
       };
     }
-  } else if (!ethers.utils.isAddress(vertex.address)) {
-    return {
-      _kind: "failure",
-      failure: new Error(`Invalid address ${vertex.address}`),
-    };
   }
 
   const argsLength = vertex.args.length;

--- a/packages/core/src/validation/dispatch/validateAwaitEvent.ts
+++ b/packages/core/src/validation/dispatch/validateAwaitEvent.ts
@@ -73,7 +73,7 @@ export async function validateAwaitEvent(
   }
 
   const matchingEventFragments = eventFragments.filter(
-    (f) => f.inputs.length === argsLength
+    (f) => f.inputs.length >= argsLength
   );
 
   if (matchingEventFragments.length === 0) {

--- a/packages/core/src/validation/dispatch/validateDeployedContract.ts
+++ b/packages/core/src/validation/dispatch/validateDeployedContract.ts
@@ -9,7 +9,7 @@ export async function validateDeployedContract(
   _resultAccumulator: ResultsAccumulator,
   _context: { services: Services }
 ): Promise<VertexVisitResult> {
-  if (!isAddress(vertex.address)) {
+  if (typeof vertex.address === "string" && !isAddress(vertex.address)) {
     return {
       _kind: "failure",
       failure: new Error(

--- a/packages/core/test/validation.ts
+++ b/packages/core/test/validation.ts
@@ -722,7 +722,7 @@ describe("Validation", () => {
       );
     });
 
-    it("should fail an awaited event with wrong number of arguments", async () => {
+    it("should fail an awaited event with too many arguments", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
         const example = m.contract("Test", exampleEventArtifact);
 
@@ -730,7 +730,7 @@ describe("Validation", () => {
 
         m.awaitEvent(example as ArtifactContract, "SomeEvent", {
           after: [call],
-          args: [],
+          args: [1, 2, 3, 4],
         });
 
         return { example };
@@ -764,7 +764,7 @@ describe("Validation", () => {
       assert.equal(text, "Validation failed");
       assert.equal(
         error.message,
-        "Event SomeEvent in contract Test expects 1 arguments but 0 were given"
+        "Event SomeEvent in contract Test expects 1 arguments but 4 were given"
       );
     });
   });


### PR DESCRIPTION
- event param futures can now be passed as addresses to `m.contractAt`
- updated create2 example to use `m.contractAt`


** merge #77 first **