### PR TITLE
added ability to send a normal ETH transaction

### DIFF
--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -15,6 +15,7 @@
   - [Create2](./creating-modules-for-deployment.md#create2)
 - [Calling contract methods](./creating-modules-for-deployment.md#calling-contract-methods)
   - [Transfering _Eth_ as part of a call](./creating-modules-for-deployment.md#transfering-eth-as-part-of-a-call)
+  - [Transfering _Eth_ outside of a call](./creating-modules-for-deployment.md#transfering-eth-outside-of-a-call)
   - [Using the results of a call with a deferred value (TBD)](./creating-modules-for-deployment.md#using-the-results-of-a-call-with-a-deferred-value-tbd)
   - [Waiting for on-chain events](./creating-modules-for-deployment.md#waiting-for-on-chain-events)
 - [Including modules within modules](./creating-modules-for-deployment.md#including-modules-within-modules)
@@ -201,6 +202,16 @@ Similar to `ethers`, a call can transfer `Eth` by passing a `value` under the op
 ```tsx
 m.call(exchange, "deposit", {
   args: [],
+  value: ethers.utils.parseUnits("1"),
+});
+```
+
+### Transferring _Eth_ outside of a call
+
+It's also possible to transfer `Eth` to a given address via a regular Ethereum transaction:
+
+```tsx
+m.sendETH(exchange, {
   value: ethers.utils.parseUnits("1"),
 });
 ```

--- a/examples/multisig/contracts/Multisig.sol
+++ b/examples/multisig/contracts/Multisig.sol
@@ -84,7 +84,7 @@ contract Multisig {
             emit Deposit(msg.sender, msg.value);
     }
 
-    constructor(address[] memory _owners, uint _required) payable
+    constructor(address[] memory _owners, uint _required)
         validRequirement(_owners.length, _required)
     {
         for (uint i=0; i<_owners.length; i++) {

--- a/examples/multisig/ignition/Multisig.js
+++ b/examples/multisig/ignition/Multisig.js
@@ -11,15 +11,15 @@ module.exports = buildModule("MultisigModule", (m) => {
   const required = 1;
   const value = ethers.utils.parseUnits("100");
 
-  // todo: support arbitrary tx
   const multisig = m.contract("Multisig", MultisigArtifact, {
     args: [owners, required],
-    value,
   });
+
+  const funding = m.sendETH(multisig, { value, after: [multisig] });
 
   const call = m.call(multisig, "submitTransaction", {
     args: [ACCOUNT_0, ethers.utils.parseUnits("50"), "0x00"],
-    after: [multisig],
+    after: [funding],
   });
 
   // todo: support sending via non-default account

--- a/packages/core/src/execution/dispatch/executeSendETH.ts
+++ b/packages/core/src/execution/dispatch/executeSendETH.ts
@@ -1,0 +1,38 @@
+import type { PopulatedTransaction } from "ethers";
+
+import { ExecutionContext } from "types/deployment";
+import { SentETH } from "types/executionGraph";
+import { VertexVisitResult } from "types/graph";
+
+import { resolveFrom, toAddress } from "./utils";
+
+export async function executeSendETH(
+  { address, value }: SentETH,
+  resultAccumulator: Map<number, VertexVisitResult | null>,
+  { services, options }: ExecutionContext
+): Promise<VertexVisitResult> {
+  const resolve = resolveFrom(resultAccumulator);
+
+  const to = toAddress(resolve(address));
+
+  let txHash: string;
+  try {
+    const tx: PopulatedTransaction = { to, value };
+
+    txHash = await services.contracts.sendTx(tx, options);
+  } catch (err) {
+    return {
+      _kind: "failure",
+      failure: err as any,
+    };
+  }
+
+  await services.transactions.wait(txHash);
+
+  return {
+    _kind: "success",
+    result: {
+      hash: txHash,
+    },
+  };
+}

--- a/packages/core/src/execution/dispatch/executionDispatch.ts
+++ b/packages/core/src/execution/dispatch/executionDispatch.ts
@@ -7,6 +7,7 @@ import { executeContractCall } from "./executeContractCall";
 import { executeContractDeploy } from "./executeContractDeploy";
 import { executeDeployedContract } from "./executeDeployedContract";
 import { executeLibraryDeploy } from "./executeLibraryDeploy";
+import { executeSendETH } from "./executeSendETH";
 
 export function executionDispatch(
   executionVertex: ExecutionVertex,
@@ -28,14 +29,14 @@ export function executionDispatch(
       return executeLibraryDeploy(executionVertex, resultAccumulator, context);
     case "AwaitedEvent":
       return executeAwaitedEvent(executionVertex, resultAccumulator, context);
+    case "SentETH":
+      return executeSendETH(executionVertex, resultAccumulator, context);
     default:
-      return assertUnknownExecutionVertexType(executionVertex);
+      assertUnknownExecutionVertexType(executionVertex);
   }
 }
 
-function assertUnknownExecutionVertexType(
-  executionVertex: never
-): Promise<VertexVisitResult> {
+function assertUnknownExecutionVertexType(executionVertex: never): never {
   const vertex = executionVertex as any;
 
   const forReport = "type" in vertex ? vertex.type : vertex;

--- a/packages/core/src/process/transform/convertDeploymentVertexToExecutionVertex.ts
+++ b/packages/core/src/process/transform/convertDeploymentVertexToExecutionVertex.ts
@@ -12,6 +12,7 @@ import {
   DeploymentGraphVertex,
   ExternalParamValue,
   EventVertex,
+  SendVertex,
 } from "types/deploymentGraph";
 import {
   AwaitedEvent,
@@ -20,6 +21,7 @@ import {
   DeployedContract,
   ExecutionVertex,
   LibraryDeploy,
+  SentETH,
 } from "types/executionGraph";
 import {
   BytesFuture,
@@ -64,6 +66,8 @@ export function convertDeploymentVertexToExecutionVertex(
         return convertArtifactLibraryToLibraryDeploy(deploymentVertex, context);
       case "Event":
         return convertAwaitToAwaitedEvent(deploymentVertex, context);
+      case "SendETH":
+        return convertSendToSentETH(deploymentVertex, context);
       case "Virtual":
         throw new Error(
           `Virtual vertex should be removed ${deploymentVertex.id} (${deploymentVertex.label})`
@@ -185,6 +189,22 @@ async function convertAwaitToAwaitedEvent(
     address: vertex.address,
     event: vertex.event,
     args: await convertArgs(vertex.args, transformContext),
+  };
+}
+
+async function convertSendToSentETH(
+  vertex: SendVertex,
+  transformContext: TransformContext
+): Promise<SentETH> {
+  return {
+    type: "SentETH",
+    id: vertex.id,
+    label: vertex.label,
+    address: vertex.address,
+    value: (await resolveParameter(
+      vertex.value,
+      transformContext
+    )) as BigNumber,
   };
 }
 

--- a/packages/core/src/types/deploymentGraph.ts
+++ b/packages/core/src/types/deploymentGraph.ts
@@ -19,6 +19,8 @@ import {
   BytesFuture,
   ArtifactFuture,
   EventParamFuture,
+  SendFuture,
+  AddressResolvable,
 } from "./future";
 import { AdjacencyList, VertexDescriptor } from "./graph";
 import { Artifact } from "./hardhat";
@@ -58,7 +60,8 @@ export type DeploymentGraphVertex =
   | ArtifactLibraryDeploymentVertex
   | CallDeploymentVertex
   | VirtualVertex
-  | EventVertex;
+  | EventVertex
+  | SendVertex;
 
 export interface HardhatContractDeploymentVertex extends VertexDescriptor {
   type: "HardhatContract";
@@ -130,6 +133,14 @@ export interface EventVertex extends VertexDescriptor {
   after: DeploymentGraphFuture[];
 }
 
+export interface SendVertex extends VertexDescriptor {
+  type: "SendETH";
+  scopeAdded: string;
+  address: AddressResolvable;
+  value: BigNumber | ParameterFuture;
+  after: DeploymentGraphFuture[];
+}
+
 export interface ContractOptions {
   args?: InternalParamValue[];
   libraries?: {
@@ -147,6 +158,11 @@ export interface CallOptions {
 
 export interface AwaitOptions {
   args: InternalParamValue[];
+  after?: DeploymentGraphFuture[];
+}
+
+export interface SendOptions {
+  value: BigNumber | ParameterFuture;
   after?: DeploymentGraphFuture[];
 }
 
@@ -189,6 +205,8 @@ export interface IDeploymentBuilder {
     eventName: string,
     options: AwaitOptions
   ) => EventFuture;
+
+  sendETH: (sendTo: AddressResolvable, options: SendOptions) => SendFuture;
 
   getParam: (paramName: string) => RequiredParameter;
 

--- a/packages/core/src/types/executionGraph.ts
+++ b/packages/core/src/types/executionGraph.ts
@@ -2,6 +2,7 @@ import type { BigNumber } from "ethers";
 
 import { LibraryMap } from "./deploymentGraph";
 import {
+  AddressResolvable,
   ArtifactContract,
   DeploymentGraphFuture,
   EventParamFuture,
@@ -27,14 +28,16 @@ export type ExecutionVertexType =
   | "DeployedContract"
   | "LibraryDeploy"
   | "ContractCall"
-  | "AwaitedEvent";
+  | "AwaitedEvent"
+  | "SentETH";
 
 export type ExecutionVertex =
   | ContractDeploy
   | DeployedContract
   | LibraryDeploy
   | ContractCall
-  | AwaitedEvent;
+  | AwaitedEvent
+  | SentETH;
 
 export interface ContractDeploy extends VertexDescriptor {
   type: "ContractDeploy";
@@ -70,4 +73,10 @@ export interface AwaitedEvent extends VertexDescriptor {
   address: string | ArtifactContract | EventParamFuture;
   event: string;
   args: ArgValue[];
+}
+
+export interface SentETH extends VertexDescriptor {
+  type: "SentETH";
+  address: AddressResolvable;
+  value: BigNumber;
 }

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -62,6 +62,14 @@ export interface EventFuture {
   params: EventParams;
 }
 
+export interface SendFuture {
+  vertexId: number;
+  label: string;
+  type: "send";
+  subtype: "eth";
+  _future: true;
+}
+
 export interface EventParams {
   [eventParam: string]: EventParamFuture;
 }
@@ -70,6 +78,7 @@ export interface EventParamFuture {
   vertexId: number;
   label: string;
   type: "eventParam";
+  subtype: string;
   _future: true;
 }
 
@@ -115,8 +124,6 @@ export interface ProxyFuture {
 
 export type ArtifactFuture = ArtifactContract | DeployedContract;
 
-export type AddressResolvable = EventParamFuture | ArtifactFuture;
-
 export type ContractFuture =
   | HardhatContract
   | ArtifactContract
@@ -132,6 +139,12 @@ export type DependableFuture =
   | Virtual
   | ProxyFuture
   | EventFuture;
+
+export type AddressResolvable =
+  | string
+  | ParameterFuture
+  | EventParamFuture
+  | ContractFuture;
 
 export type ParameterFuture = RequiredParameter | OptionalParameter;
 

--- a/packages/core/src/utils/guards.ts
+++ b/packages/core/src/utils/guards.ts
@@ -21,6 +21,7 @@ import type {
   ProxyFuture,
   BytesFuture,
   EventParamFuture,
+  ContractFuture,
 } from "types/future";
 import { Artifact } from "types/hardhat";
 
@@ -130,4 +131,24 @@ export function isCallable(
   }
 
   return future.type === "contract" || future.type === "library";
+}
+
+export function isContract(
+  future: DeploymentGraphFuture
+): future is ContractFuture {
+  if (isProxy(future)) {
+    return isContract(future.value);
+  }
+
+  return future.type === "contract";
+}
+
+export function assertUnknownDeploymentVertexType(
+  deploymentVertex: never
+): never {
+  const vertex = deploymentVertex as any;
+
+  const forReport = "type" in vertex ? vertex.type : vertex;
+
+  throw new Error(`Unknown deployment vertex type: ${forReport}`);
 }

--- a/packages/core/src/validation/dispatch/validateSendETH.ts
+++ b/packages/core/src/validation/dispatch/validateSendETH.ts
@@ -12,7 +12,7 @@ export async function validateSendETH(
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
       _kind: "failure",
-      failure: new IgnitionError(`For call 'value' must be a BigNumber`),
+      failure: new IgnitionError(`For send 'value' must be a BigNumber`),
     };
   }
 

--- a/packages/core/src/validation/dispatch/validateSendETH.ts
+++ b/packages/core/src/validation/dispatch/validateSendETH.ts
@@ -1,0 +1,33 @@
+import { ethers, BigNumber } from "ethers";
+
+import { SendVertex } from "types/deploymentGraph";
+import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import { IgnitionError } from "utils/errors";
+import { isParameter } from "utils/guards";
+
+export async function validateSendETH(
+  vertex: SendVertex,
+  _resultAccumulator: ResultsAccumulator
+): Promise<VertexVisitResult> {
+  if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
+    return {
+      _kind: "failure",
+      failure: new IgnitionError(`For call 'value' must be a BigNumber`),
+    };
+  }
+
+  if (
+    typeof vertex.address === "string" &&
+    !ethers.utils.isAddress(vertex.address)
+  ) {
+    return {
+      _kind: "failure",
+      failure: new Error(`"${vertex.address}" is not a valid address`),
+    };
+  }
+
+  return {
+    _kind: "success",
+    result: undefined,
+  };
+}

--- a/packages/core/src/validation/dispatch/validationDispatch.ts
+++ b/packages/core/src/validation/dispatch/validationDispatch.ts
@@ -1,6 +1,7 @@
 import { Services } from "services/types";
 import { DeploymentGraphVertex } from "types/deploymentGraph";
 import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import { assertUnknownDeploymentVertexType } from "utils/guards";
 
 import { validateArtifactContract } from "./validateArtifactContract";
 import { validateArtifactLibrary } from "./validateArtifactLibrary";
@@ -9,6 +10,7 @@ import { validateCall } from "./validateCall";
 import { validateDeployedContract } from "./validateDeployedContract";
 import { validateHardhatContract } from "./validateHardhatContract";
 import { validateHardhatLibrary } from "./validateHardhatLibrary";
+import { validateSendETH } from "./validateSendETH";
 import { validateVirtual } from "./validateVirtual";
 
 export function validationDispatch(
@@ -53,17 +55,9 @@ export function validationDispatch(
       return validateVirtual(deploymentVertex, resultAccumulator, context);
     case "Event":
       return validateAwaitEvent(deploymentVertex, resultAccumulator, context);
+    case "SendETH":
+      return validateSendETH(deploymentVertex, resultAccumulator);
     default:
-      return assertUnknownDeploymentVertexType(deploymentVertex);
+      assertUnknownDeploymentVertexType(deploymentVertex);
   }
-}
-
-function assertUnknownDeploymentVertexType(
-  deploymentVertex: never
-): Promise<VertexVisitResult> {
-  const vertex = deploymentVertex as any;
-
-  const forReport = "type" in vertex ? vertex.type : vertex;
-
-  throw new Error(`Unknown deployment vertex type: ${forReport}`);
 }

--- a/packages/core/test/deploymentBuilder/awaitedEvent.ts
+++ b/packages/core/test/deploymentBuilder/awaitedEvent.ts
@@ -296,6 +296,7 @@ describe("deployment builder - await event", () => {
         vertexId: 2,
         label: "value",
         type: "eventParam",
+        subtype: "uint256",
         _future: true,
       },
     ]);

--- a/packages/core/test/deploymentBuilder/sendETH.ts
+++ b/packages/core/test/deploymentBuilder/sendETH.ts
@@ -1,0 +1,107 @@
+/* eslint-disable import/no-unused-modules */
+import { assert } from "chai";
+import { ethers } from "ethers";
+
+import { buildModule } from "dsl/buildModule";
+import { generateDeploymentGraphFrom } from "process/generateDeploymentGraphFrom";
+import { IDeploymentBuilder, IDeploymentGraph } from "types/deploymentGraph";
+import { isHardhatContract } from "utils/guards";
+
+import {
+  getDependenciesForVertex,
+  getDeploymentVertexByLabel,
+} from "./helpers";
+
+describe("deployment builder - send ETH", () => {
+  let deploymentGraph: IDeploymentGraph;
+
+  before(() => {
+    const sendModule = buildModule("send", (m: IDeploymentBuilder) => {
+      const token = m.contract("Token");
+      const value = ethers.utils.parseUnits("10");
+
+      m.sendETH(token, { value, after: [token] });
+
+      return {};
+    });
+
+    const { graph } = generateDeploymentGraphFrom(sendModule, {
+      chainId: 31337,
+    });
+
+    deploymentGraph = graph;
+  });
+
+  it("should create a graph", () => {
+    assert.isDefined(deploymentGraph);
+  });
+
+  it("should have two nodes", () => {
+    assert.equal(deploymentGraph.vertexes.size, 2);
+  });
+
+  it("should have the contract node Token", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+
+    if (depNode === undefined) {
+      return assert.isDefined(depNode);
+    }
+    assert.equal(depNode?.label, "Token");
+    assert(isHardhatContract(depNode));
+  });
+
+  it("should have the send node send/1", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "send/1");
+
+    if (depNode === undefined) {
+      return assert.isDefined(depNode);
+    }
+
+    assert.equal(depNode?.label, "send/1");
+    assert(depNode.type === "SendETH");
+  });
+
+  it("should show no dependencies for the contract node Token", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+
+    if (depNode === undefined) {
+      return assert.isDefined(depNode);
+    }
+
+    const deps = getDependenciesForVertex(deploymentGraph, depNode);
+
+    assert.deepStrictEqual(deps, []);
+  });
+
+  it("should show 1 dependency for the send node send/1", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "send/1");
+
+    if (depNode === undefined) {
+      return assert.isDefined(depNode);
+    }
+
+    const deps = getDependenciesForVertex(deploymentGraph, depNode);
+
+    assert.deepStrictEqual(deps, [
+      {
+        id: 0,
+        label: "Token",
+        type: "",
+      },
+    ]);
+  });
+
+  it("should record the argument list for the contract node Token as empty", () => {
+    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+
+    if (depNode === undefined) {
+      return assert.isDefined(depNode);
+    }
+
+    if (!isHardhatContract(depNode)) {
+      return assert.fail("Not a hardhat contract dependency node");
+    }
+
+    assert.deepStrictEqual(depNode.args, []);
+  });
+});

--- a/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
@@ -126,6 +126,8 @@ const resolveFailureTypeFrom = (vertex: ExecutionVertex): string => {
       return "Failed library deploy";
     case "AwaitedEvent":
       return "Failed awaited event";
+    case "SentETH":
+      return "Failed to send ETH";
     default:
       return assertNeverUiVertexType(vertex);
   }

--- a/packages/hardhat-plugin/src/ui/types.ts
+++ b/packages/hardhat-plugin/src/ui/types.ts
@@ -174,6 +174,8 @@ export class DeploymentState {
         return "Failed library deploy";
       case "AwaitedEvent":
         return "Failed awaited event";
+      case "SentETH":
+        return "Failed to send ETH";
       default:
         return assertNeverUiVertexType(vertex.type);
     }


### PR DESCRIPTION
Support sending `ETH` to a contract without having to make a call/deploy:

```tsx
m.sendETH(exchange, {
  value: ethers.utils.parseUnits("1"),
});
```