### PR TITLE
chore: bump version to v0.0.5

### DIFF
--- a/examples/create2/package.json
+++ b/examples/create2/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "hardhat": "^2.10.0",
-    "@ignored/hardhat-ignition": "^0.0.4"
+    "@ignored/hardhat-ignition": "^0.0.5"
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.7.3"

--- a/examples/ens/package.json
+++ b/examples/ens/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.4",
+    "@ignored/hardhat-ignition": "^0.0.5",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/multisig/package.json
+++ b/examples/multisig/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.1",
-    "@ignored/hardhat-ignition": "^0.0.4",
+    "@ignored/hardhat-ignition": "^0.0.5",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",
     "@openzeppelin/contracts": "^4.3.2",
     "chai": "^4.3.4",

--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.4",
+    "@ignored/hardhat-ignition": "^0.0.5",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/uniswap/package.json
+++ b/examples/uniswap/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.4",
+    "@ignored/hardhat-ignition": "^0.0.5",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.0.5 - 2022-12-20
+
+### Added
+
+- Expose config for pollingInterval ([#75](https://github.com/NomicFoundation/ignition/pull/75))
+- Support `getBytesForArtifact` in deployment api ([#76](https://github.com/NomicFoundation/ignition/pull/76))
+- Support use of emitted event args as futures for later deployment api calls ([#77](https://github.com/NomicFoundation/ignition/pull/77))
+- Support event params futures in `contractAt` ([#78](https://github.com/NomicFoundation/ignition/pull/78))
+
+### Fixed
+
+- Fix for planning on modules with deploys from artifacts ([#73](https://github.com/NomicFoundation/ignition/pull/73))
+
 ## 0.0.4 - 2022-11-22
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/ignition-core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.0.5 - 2022-12-20
+
+### Added
+
+- Add params section to deploy display in cli ([#74](https://github.com/NomicFoundation/ignition/pull/74))
+- Expose config for pollingInterval ([#75](https://github.com/NomicFoundation/ignition/pull/75))
+- Support `getBytesForArtifact` in deployment api ([#76](https://github.com/NomicFoundation/ignition/pull/76))
+- Support use of emitted event args as futures for later deployment api calls ([#77](https://github.com/NomicFoundation/ignition/pull/77))
+- Support event params futures in `contractAt` ([#78](https://github.com/NomicFoundation/ignition/pull/78))
+
+### Fixed
+
+- Fix for planning on modules with deploys from artifacts ([#73](https://github.com/NomicFoundation/ignition/pull/73))
+
 ## 0.0.4 - 2022-11-22
 
 ### Added

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/hardhat-ignition",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",
@@ -32,7 +32,7 @@
     "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {
-    "@ignored/ignition-core": "^0.0.4",
+    "@ignored/ignition-core": "^0.0.5",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@types/chai": "^4.2.22",
@@ -67,7 +67,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@ignored/ignition-core": "^0.0.4",
+    "@ignored/ignition-core": "^0.0.5",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "hardhat": "^2.12.0"
   },


### PR DESCRIPTION
Update the packages versions and changelogs for the `0.0.5 - 2022-12-20` release.

## 0.0.5 - 2022-12-20

### Added

- Add params section to deploy display in cli ([#74](https://github.com/NomicFoundation/ignition/pull/74))
- Expose config for pollingInterval ([#75](https://github.com/NomicFoundation/ignition/pull/75))
- Support `getBytesForArtifact` in deployment api ([#76](https://github.com/NomicFoundation/ignition/pull/76))
- Support use of emitted event args as futures for later deployment api calls ([#77](https://github.com/NomicFoundation/ignition/pull/77))
- Support event params futures in `contractAt` ([#78](https://github.com/NomicFoundation/ignition/pull/78))

### Fixed

- Fix for planning on modules with deploys from artifacts ([#73](https://github.com/NomicFoundation/ignition/pull/73))