### PR TITLE
chore: add github project automations

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issue to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/NomicFoundation/projects/7
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-label-to-new-issue.yml
+++ b/.github/workflows/add-label-to-new-issue.yml
@@ -1,0 +1,38 @@
+name: Add label to new issue
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  label-new-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const issue = await github.rest.issues.get({
+              owner: context.issue.owner,
+              repo: context.issue.repo,
+              issue_number: context.issue.number
+            });
+
+            const statusLabel = issue.data.labels.find(({ name }) =>
+              name.startsWith("status:")
+            );
+
+            if (statusLabel === undefined) {
+              await github.rest.issues.addLabels({
+                owner: context.issue.owner,
+                repo: context.issue.repo,
+                issue_number: context.issue.number,
+                labels: ["status:triaging"]
+              });
+            } else {
+              console.log(`Issue already has a status: ${statusLabel.name}`);
+            }


### PR DESCRIPTION
Automatically assign new issues and prs to the Ignition project. Add a triaging label as well.