### PR TITLE
fix(journal): categorise commands by chainId

### DIFF
--- a/docs/running-a-deployment.md
+++ b/docs/running-a-deployment.md
@@ -109,6 +109,6 @@ A run of a deployment can succeed, fail or be on hold. A failed deployment or on
 
 `npx hardhat deploy MyModule.js --network localhost`
 
-Each run logs its events to a journal file (recorded in a sibling file to the module under `MyModule.journal.ndjson`). The journal file is used to reconstruct the state of the deployment during previous runs. Any failed contract deploys or contract calls will be retried, the deployment picking up from where the last fail occurred. Any `awaitEvent` invocations that had not returned and hence were on `Hold` on the last run, will be retried as well.
+Each run logs its events to a journal file (recorded in a sibling file to the module under `MyModule.journal.ndjson`). The journal file is used to reconstruct the state of the deployment during previous runs. Runs are scoped to the `chainId` of the network, so that runs against different networks do not interact. Any failed contract deploys or contract calls will be retried, the deployment picking up from where the last fail occurred. Any `awaitEvent` invocations that had not returned and hence were on `Hold` on the last run, will be retried as well.
 
 For non-development network deployments, this means some form of deployment freezing will be recommended that records relevant information such as contract abi, deployed address and network. These files will be recommended to be committed into project repositories as well.

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -38,15 +38,18 @@ export class IgnitionWrapper {
   ): Promise<DeployResult> {
     const showUi = deployParams?.ui ?? false;
 
+    const services = createServices(this._providers);
+    const chainId = await services.network.getChainId();
+
     const ignition = new Ignition({
-      services: createServices(this._providers),
+      services,
       uiRenderer: showUi
         ? renderToCli(this._providers.config.parameters)
         : undefined,
       journal: deployParams?.journal
         ? deployParams?.journal
         : deployParams?.journalPath !== undefined
-        ? new CommandJournal(deployParams?.journalPath)
+        ? new CommandJournal(chainId, deployParams?.journalPath)
         : undefined,
     });
 


### PR DESCRIPTION
Record the `chainId` along with the execution command, so that reruns are scoped by chain.

Fixes #99.