### PR TITLE
fix: guard against reruns with changes

### DIFF
--- a/examples/sample/ignition/LockModule.js
+++ b/examples/sample/ignition/LockModule.js
@@ -1,14 +1,14 @@
 // ./ignition/LockModule.js
 const { buildModule } = require("@ignored/hardhat-ignition");
 
-const currentTimestampInSeconds = Math.round(Date.now() / 1000);
-const ONE_YEAR_IN_SECS = 365 * 24 * 60 * 60;
-const ONE_YEAR_IN_FUTURE = currentTimestampInSeconds + ONE_YEAR_IN_SECS;
+const currentTimestampInSeconds = Math.round(new Date(2023, 01, 01) / 1000);
+const TEN_YEAR_IN_SECS = 10 * 365 * 24 * 60 * 60;
+const TEN_YEARS_IN_FUTURE = currentTimestampInSeconds + TEN_YEAR_IN_SECS;
 
 const ONE_GWEI = hre.ethers.utils.parseUnits("1", "gwei");
 
 module.exports = buildModule("LockModule", (m) => {
-  const unlockTime = m.getOptionalParam("unlockTime", ONE_YEAR_IN_FUTURE);
+  const unlockTime = m.getOptionalParam("unlockTime", TEN_YEARS_IN_FUTURE);
   const lockedAmount = m.getOptionalParam("lockedAmount", ONE_GWEI);
 
   const lock = m.contract("Lock", { args: [unlockTime], value: lockedAmount });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,6 +76,7 @@
     "ethers": "^5.4.7",
     "fs-extra": "^10.0.0",
     "js-graph-algorithms": "1.0.18",
-    "object-hash": "^3.0.0"
+    "object-hash": "^3.0.0",
+    "serialize-error": "8.1.0"
   }
 }

--- a/packages/core/src/deployment/Deployment.ts
+++ b/packages/core/src/deployment/Deployment.ts
@@ -94,9 +94,16 @@ export class Deployment {
     );
   }
 
-  public startExecutionPhase() {
+  public failReconciliation() {
+    return this._runDeploymentCommand(`Reconciliation failed`, {
+      type: "RECONCILIATION_FAILED",
+    });
+  }
+
+  public startExecutionPhase(executionGraphHash: string) {
     return this._runDeploymentCommand("Starting Execution", {
       type: "EXECUTION::START",
+      executionGraphHash,
     });
   }
 

--- a/packages/core/src/deployment/deployStateReducer.ts
+++ b/packages/core/src/deployment/deployStateReducer.ts
@@ -29,6 +29,7 @@ export function initializeDeployState(moduleName: string): DeployState {
       vertexes: {},
       batch: null,
       previousBatches: [],
+      executionGraphHash: "",
     },
   };
 }
@@ -73,6 +74,8 @@ export function deployStateReducer(
         ...state,
         transform: { executionGraph: action.executionGraph },
       };
+    case "RECONCILIATION_FAILED":
+      return { ...state, phase: "reconciliation-failed" };
     case "EXECUTION::START":
       if (state.transform.executionGraph === null) {
         return state;
@@ -81,6 +84,7 @@ export function deployStateReducer(
       const executionStateForRun = deployExecutionStateReducer(
         initialiseExecutionStateFrom(
           state.transform.executionGraph,
+          action.executionGraphHash,
           state.execution
         ),
         action
@@ -115,6 +119,7 @@ export function deployStateReducer(
 
 function initialiseExecutionStateFrom(
   executionGraph: ExecutionGraph,
+  executionGraphHash: string,
   previousExecutionState: ExecutionState
 ): ExecutionState {
   const vertexes = Array.from(executionGraph.vertexes.keys()).reduce<{
@@ -133,6 +138,7 @@ function initialiseExecutionStateFrom(
     vertexes,
     batch: null,
     previousBatches: [],
+    executionGraphHash,
   };
 
   return executionState;

--- a/packages/core/src/execution/execute.ts
+++ b/packages/core/src/execution/execute.ts
@@ -13,7 +13,7 @@ import { IgnitionError } from "utils/errors";
 
 import { ExecutionGraph } from "./ExecutionGraph";
 import { executionDispatch } from "./dispatch/executionDispatch";
-import { allDependenciesCompleted } from "./utils";
+import { allDependenciesCompleted, hashExecutionGraph } from "./utils";
 
 export async function execute(
   deployment: Deployment,
@@ -37,7 +37,9 @@ export async function executeInBatches(
   executionVertexDispatcher: ExecutionVertexDispatcher,
   options: ExecutionOptions
 ): Promise<VisitResult> {
-  await deployment.startExecutionPhase();
+  const executionGraphHash = hashExecutionGraph(executionGraph);
+
+  await deployment.startExecutionPhase(executionGraphHash);
 
   while (deployment.hasUnstarted()) {
     const batch = calculateNextBatch(

--- a/packages/core/src/execution/utils.ts
+++ b/packages/core/src/execution/utils.ts
@@ -1,5 +1,8 @@
+import hash from "object-hash";
+
 import { ExecutionGraph } from "execution/ExecutionGraph";
 import { getDependenciesFor } from "graph/adjacencyList";
+import { serializeReplacer } from "utils/serialize";
 
 export function allDependenciesCompleted(
   vertexId: number,
@@ -12,4 +15,8 @@ export function allDependenciesCompleted(
   );
 
   return depenencies.every((vid) => completed.has(vid));
+}
+
+export function hashExecutionGraph(executionGrpah: ExecutionGraph) {
+  return hash(JSON.parse(JSON.stringify(executionGrpah, serializeReplacer)));
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,8 @@ export { buildModule } from "dsl/buildModule";
 export { buildSubgraph } from "dsl/buildSubgraph";
 export { viewExecutionResults } from "deployment/utils";
 export { createServices } from "services/createServices";
+export { serializeReplacer } from "utils/serialize";
+export { IgnitionError } from "utils/errors";
 
 export type {
   SerializedDeploymentResult,

--- a/packages/core/src/types/deployment.ts
+++ b/packages/core/src/types/deployment.ts
@@ -39,11 +39,13 @@ export type DeployPhase =
   | "complete"
   | "failed"
   | "hold"
-  | "validation-failed";
+  | "validation-failed"
+  | "reconciliation-failed";
 
 export type DeployStateExecutionCommand =
   | {
       type: "EXECUTION::START";
+      executionGraphHash: string;
     }
   | {
       type: "EXECUTION::SET_BATCH";
@@ -68,6 +70,9 @@ export type DeployStateCommand =
   | {
       type: "TRANSFORM_COMPLETE";
       executionGraph: IGraph<ExecutionVertex>;
+    }
+  | {
+      type: "RECONCILIATION_FAILED";
     }
   | DeployStateExecutionCommand;
 
@@ -125,6 +130,7 @@ export interface ExecutionState {
   vertexes: { [key: number]: VertexExecutionState };
   batch: Set<number> | null;
   previousBatches: Array<Set<number>>;
+  executionGraphHash: string;
 }
 
 export interface DeployNetworkConfig {

--- a/packages/core/src/utils/serialize.ts
+++ b/packages/core/src/utils/serialize.ts
@@ -1,3 +1,5 @@
+import { serializeError } from "serialize-error";
+
 import { FutureOutput, SerializedFutureResult } from "types/serialization";
 
 export function serializeFutureOutput(x: FutureOutput): SerializedFutureResult {
@@ -29,4 +31,37 @@ export function deserializeFutureOutput(x: any) {
   }
 
   return x.value;
+}
+
+/**
+ * When stringifying core state, use this as the replacer.
+ */
+export function serializeReplacer(_key: string, value: unknown) {
+  if (value instanceof Set) {
+    return Array.from(value).sort();
+  }
+
+  if (value instanceof Map) {
+    return Object.fromEntries(value);
+  }
+
+  if (typeof value === "bigint") {
+    return `${value.toString(10)}n`;
+  }
+
+  if (value instanceof Error) {
+    return serializeError(new Error(value.message));
+  }
+
+  if (value instanceof Object && !(value instanceof Array)) {
+    const obj: any = value;
+    return Object.keys(obj)
+      .sort()
+      .reduce((sorted: any, key) => {
+        sorted[key] = obj[key];
+        return sorted;
+      }, {});
+  }
+
+  return value;
 }

--- a/packages/core/test/execution/rerun.ts
+++ b/packages/core/test/execution/rerun.ts
@@ -313,7 +313,7 @@ describe("Reruning execution", () => {
       // Assert
       assert.equal(result._kind, "failure");
 
-      // two calls sent
+      // one calls sent
       assert.equal(
         sentTransactionCount,
         1,
@@ -353,6 +353,46 @@ describe("Reruning execution", () => {
         redeployResult.result.token.value.address,
         "0x1F98431c8aD98523631AE4a59f267346ea31F984"
       );
+    });
+
+    it("should error if the module has been changed", async () => {
+      // Arrange
+      const someModule = buildModule("MyModule", (m) => {
+        const token = m.contract("Token");
+
+        m.call(token, "configure", { args: [100] });
+
+        return { token };
+      });
+
+      const modifiedModule = buildModule("MyModule", (m) => {
+        const token = m.contract("Token");
+
+        m.call(token, "configure", { args: [999] });
+
+        return { token };
+      });
+
+      await ignition.deploy(someModule, {} as any);
+
+      // Act
+      const [modifiedResult] = await ignition.deploy(modifiedModule, {} as any);
+
+      // Assert
+      // the second transaction is not sent
+      assert.equal(sentTransactionCount, 1, "postconditition after rerun");
+
+      assert.deepStrictEqual(modifiedResult, {
+        _kind: "failure",
+        failures: [
+          "module change failure",
+          [
+            new Error(
+              "The module has been modified since the last run. Delete the journal file to start again."
+            ),
+          ],
+        ],
+      });
     });
   });
 });

--- a/packages/core/test/state-reducer/execution.ts
+++ b/packages/core/test/state-reducer/execution.ts
@@ -54,6 +54,7 @@ describe("deployment state reducer", () => {
     beforeEach(() => {
       state = deployStateReducer(state, {
         type: "EXECUTION::START",
+        executionGraphHash: "XXX",
       });
     });
 
@@ -88,6 +89,7 @@ describe("deployment state reducer", () => {
       state = applyActions(state, [
         {
           type: "EXECUTION::START",
+          executionGraphHash: "XXX",
         },
         {
           type: "EXECUTION::SET_BATCH",
@@ -107,6 +109,7 @@ describe("deployment state reducer", () => {
       state = applyActions(state, [
         {
           type: "EXECUTION::START",
+          executionGraphHash: "XXX",
         },
         {
           type: "EXECUTION::SET_BATCH",
@@ -141,6 +144,7 @@ describe("deployment state reducer", () => {
       state = applyActions(state, [
         {
           type: "EXECUTION::START",
+          executionGraphHash: "XXX",
         },
         {
           type: "EXECUTION::SET_BATCH",
@@ -174,6 +178,7 @@ describe("deployment state reducer", () => {
       state = applyActions(state, [
         {
           type: "EXECUTION::START",
+          executionGraphHash: "XXX",
         },
 
         {
@@ -246,6 +251,7 @@ describe("deployment state reducer", () => {
       state = applyActions(state, [
         {
           type: "EXECUTION::START",
+          executionGraphHash: "XXX",
         },
 
         {
@@ -294,6 +300,7 @@ describe("deployment state reducer", () => {
       state = applyActions(state, [
         {
           type: "EXECUTION::START",
+          executionGraphHash: "XXX",
         },
 
         {

--- a/packages/hardhat-plugin/src/CommandJournal.ts
+++ b/packages/hardhat-plugin/src/CommandJournal.ts
@@ -1,11 +1,12 @@
 import {
   DeployStateExecutionCommand,
   ICommandJournal,
+  serializeReplacer,
 } from "@ignored/ignition-core";
 import { BigNumber } from "ethers";
 import fs from "fs";
 import ndjson from "ndjson";
-import { serializeError, deserializeError } from "serialize-error";
+import { deserializeError } from "serialize-error";
 
 export class CommandJournal implements ICommandJournal {
   constructor(private _chainId: number, private _path: string) {}
@@ -15,7 +16,7 @@ export class CommandJournal implements ICommandJournal {
       this._path,
       `${JSON.stringify(
         { chainId: this._chainId, ...command },
-        this._serializeReplacer.bind(this)
+        serializeReplacer.bind(this)
       )}\n`
     );
   }
@@ -51,26 +52,6 @@ export class CommandJournal implements ICommandJournal {
 
       yield deserializedChunk as DeployStateExecutionCommand;
     }
-  }
-
-  private _serializeReplacer(_key: string, value: unknown) {
-    if (value instanceof Set) {
-      return Array.from(value);
-    }
-
-    if (value instanceof Map) {
-      return Object.fromEntries(value);
-    }
-
-    if (typeof value === "bigint") {
-      return `${value.toString(10)}n`;
-    }
-
-    if (value instanceof Error) {
-      return serializeError(new Error(value.message));
-    }
-
-    return value;
   }
 
   private _deserializeReplace(_key: string, value: unknown) {

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -7,12 +7,13 @@ import {
   ModuleParams,
   createServices,
   ICommandJournal,
+  IgnitionError,
 } from "@ignored/ignition-core";
 import { Contract, ethers } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { CommandJournal } from "./CommandJournal";
-import { renderToCli } from "./ui/renderToCli";
+import { initializeRenderState, renderToCli } from "./ui/renderToCli";
 
 type HardhatEthers = HardhatRuntimeEnvironment["ethers"];
 
@@ -44,7 +45,10 @@ export class IgnitionWrapper {
     const ignition = new Ignition({
       services,
       uiRenderer: showUi
-        ? renderToCli(this._providers.config.parameters)
+        ? renderToCli(
+            initializeRenderState(),
+            this._providers.config.parameters
+          )
         : undefined,
       journal: deployParams?.journal
         ? deployParams?.journal
@@ -70,7 +74,7 @@ export class IgnitionWrapper {
         heldMessage += `  - ${vertex.label}\n`;
       }
 
-      throw new Error(
+      throw new IgnitionError(
         `Execution held for module '${ignitionModule.name}':\n\n${heldMessage}`
       );
     }
@@ -83,7 +87,7 @@ export class IgnitionWrapper {
         failuresMessage += `  - ${failure.message}\n`;
       }
 
-      throw new Error(
+      throw new IgnitionError(
         `Execution failed for module '${moduleId}':\n\n${failuresMessage}`
       );
     }

--- a/packages/hardhat-plugin/src/ui/components/ReconciliationFailedPanel.tsx
+++ b/packages/hardhat-plugin/src/ui/components/ReconciliationFailedPanel.tsx
@@ -1,0 +1,24 @@
+import { DeployState } from "@ignored/ignition-core";
+import { Box, Text } from "ink";
+
+export const ReconciliationFailedPanel = ({
+  deployState,
+}: {
+  deployState: DeployState;
+}) => {
+  return (
+    <Box flexDirection="column">
+      <Text color={"red"}>
+        Ignition cannot rerun the module{" "}
+        <Text bold>{deployState.details.moduleName}</Text>, it has been altered.
+        since the last run
+      </Text>
+
+      <Box marginTop={1}>
+        <Text>
+          Remove the journal file to restart the deployment from a clean state.
+        </Text>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/hardhat-plugin/src/ui/components/index.tsx
+++ b/packages/hardhat-plugin/src/ui/components/index.tsx
@@ -1,5 +1,6 @@
 import type { DeployState, ModuleParams } from "@ignored/ignition-core";
 
+import { ReconciliationFailedPanel } from "./ReconciliationFailedPanel";
 import { StartingPanel } from "./StartingPanel";
 import { ValidationFailedPanel } from "./ValidationFailedPanel";
 import { ExecutionPanel } from "./execution/ExecutionPanel";
@@ -20,6 +21,10 @@ export const IgnitionUi = ({
 
   if (deployState.phase === "validation-failed") {
     return <ValidationFailedPanel deployState={deployState} />;
+  }
+
+  if (deployState.phase === "reconciliation-failed") {
+    return <ReconciliationFailedPanel deployState={deployState} />;
   }
 
   return (

--- a/packages/hardhat-plugin/src/ui/renderToCli.tsx
+++ b/packages/hardhat-plugin/src/ui/renderToCli.tsx
@@ -7,8 +7,58 @@ import { render } from "ink";
 
 import { IgnitionUi } from "./components";
 
-export function renderToCli(moduleParams?: ModuleParams): UpdateUiAction {
-  return (state: DeployState) => {
-    render(<IgnitionUi deployState={state} moduleParams={moduleParams} />);
+interface RenderState {
+  rerender: null | ((node: React.ReactNode) => void);
+  unmount: null | (() => void);
+  waitUntilExit: null | (() => Promise<void>);
+  clear: null | (() => void);
+}
+
+export function initializeRenderState(): RenderState {
+  return {
+    rerender: null,
+    unmount: null,
+    waitUntilExit: null,
+    clear: null,
   };
+}
+
+export function renderToCli(
+  renderState: RenderState,
+  moduleParams?: ModuleParams
+): UpdateUiAction {
+  return (state: DeployState) => {
+    if (renderState.rerender === null) {
+      const { rerender, unmount, waitUntilExit, clear } = render(
+        <IgnitionUi deployState={state} moduleParams={moduleParams} />,
+        { patchConsole: false }
+      );
+
+      renderState.rerender = rerender;
+      renderState.unmount = unmount;
+      renderState.waitUntilExit = waitUntilExit;
+      renderState.clear = clear;
+
+      return;
+    }
+
+    renderState.rerender(
+      <IgnitionUi deployState={state} moduleParams={moduleParams} />
+    );
+  };
+}
+
+export function unmountCli(state: RenderState): Promise<void> {
+  if (
+    state.unmount === null ||
+    state.waitUntilExit === null ||
+    state.clear === null
+  ) {
+    throw new Error("Cannot unmount with no unmount function");
+  }
+
+  state.clear();
+  state.unmount();
+
+  return state.waitUntilExit();
 }

--- a/packages/hardhat-plugin/test/CommandJournal.ts
+++ b/packages/hardhat-plugin/test/CommandJournal.ts
@@ -19,7 +19,7 @@ describe("File based command journal", () => {
     const journal = new CommandJournal(31337, tempCommandFilePath);
 
     const commands: DeployStateExecutionCommand[] = [
-      { type: "EXECUTION::START" },
+      { type: "EXECUTION::START", executionGraphHash: "XXX" },
       { type: "EXECUTION::SET_BATCH", batch: [0, 1, 2, 3] },
       {
         type: "EXECUTION::SET_VERTEX_RESULT",
@@ -93,7 +93,7 @@ describe("File based command journal", () => {
     );
 
     const commands: DeployStateExecutionCommand[] = [
-      { type: "EXECUTION::START" },
+      { type: "EXECUTION::START", executionGraphHash: "XXX" },
     ];
 
     for (const command of commands) {


### PR DESCRIPTION
We intend to add a reconciliation phase to allow for small changes in modules between runs. For the moment we will ban all changes and report an error if any are found.