### PR TITLE
docs: fix lock example in quickstart

### DIFF
--- a/docs/getting-started-guide.md
+++ b/docs/getting-started-guide.md
@@ -63,14 +63,14 @@ Add a deployment module under the `./ignition` folder for the example `Lock.sol`
 // ./ignition/LockModule.js
 const { buildModule } = require("@ignored/hardhat-ignition");
 
-const currentTimestampInSeconds = Math.round(Date.now() / 1000);
-const ONE_YEAR_IN_SECS = 365 * 24 * 60 * 60;
-const ONE_YEAR_IN_FUTURE = currentTimestampInSeconds + ONE_YEAR_IN_SECS;
+const currentTimestampInSeconds = Math.round(new Date(2023, 01, 01) / 1000);
+const TEN_YEAR_IN_SECS = 10 * 365 * 24 * 60 * 60;
+const TEN_YEARS_IN_FUTURE = currentTimestampInSeconds + TEN_YEAR_IN_SECS;
 
 const ONE_GWEI = hre.ethers.utils.parseUnits("1", "gwei");
 
 module.exports = buildModule("LockModule", (m) => {
-  const unlockTime = m.getOptionalParam("unlockTime", ONE_YEAR_IN_FUTURE);
+  const unlockTime = m.getOptionalParam("unlockTime", TEN_YEARS_IN_FUTURE);
   const lockedAmount = m.getOptionalParam("lockedAmount", ONE_GWEI);
 
   const lock = m.contract("Lock", { args: [unlockTime], value: lockedAmount });
@@ -97,13 +97,13 @@ A file containing module parameters can be passed as a flag at the command line:
 ```
 
 ```bash
-npx hardhat deploy --parameters ignition/LockModule.config.json LockModule.js
+npx hardhat deploy --parameters ignition/LockModule.config.json LockModule
 ```
 
 Parameters can also be passed at the command line via a json string:
 
 ```bash
-npx hardhat deploy --parameters "{\"unlockTime\":4102491600,\"lockedAmount\":2000000000}" LockModule.js
+npx hardhat deploy --parameters "{\"unlockTime\":4102491600,\"lockedAmount\":2000000000}" LockModule
 # Ensure you have properly escaped the json string
 ```
 
@@ -112,7 +112,7 @@ To deploy against a specific network pass it on the command line, for instance t
 ```bash
 npx hardhat node
 # in another terminal
-npx hardhat deploy --network localhost LockModule.js
+npx hardhat deploy --network localhost LockModule
 ```
 
 ### Using the Module within Hardhat Tests

--- a/examples/sample/ignition/LockModule.js
+++ b/examples/sample/ignition/LockModule.js
@@ -12,7 +12,6 @@ module.exports = buildModule("LockModule", (m) => {
   const lockedAmount = m.getOptionalParam("lockedAmount", ONE_GWEI);
 
   const lock = m.contract("Lock", { args: [unlockTime], value: lockedAmount });
-  const lock2 = m.contract("Lock", { args: [unlockTime], value: lockedAmount });
 
-  return { lock, lock2 };
+  return { lock };
 });

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -45,10 +45,7 @@ export class IgnitionWrapper {
     const ignition = new Ignition({
       services,
       uiRenderer: showUi
-        ? renderToCli(
-            initializeRenderState(),
-            this._providers.config.parameters
-          )
+        ? renderToCli(initializeRenderState(), deployParams?.parameters)
         : undefined,
       journal: deployParams?.journal
         ? deployParams?.journal


### PR DESCRIPTION
The LockModule as taken from the HH quickstart changes the input time based on the time it is run. This was taken over but causes an issue on rerunning a deployment as the one of the module parameters has changed.

The sample project was previously changed to use a specific time in the example, this commit applies the same change to the quick start guide.

Fixes https://github.com/NomicFoundation/ignition/issues/133.

Includes a bonus bug fix to re-enable display of module params in the cli ui.