### PR TITLE
Fix/missing error msg on no passed module params

### DIFF
--- a/packages/core/src/deployment/Deployment.ts
+++ b/packages/core/src/deployment/Deployment.ts
@@ -94,6 +94,16 @@ export class Deployment {
     );
   }
 
+  public failUnexpected(errors: Error[]) {
+    return this._runDeploymentCommand(
+      [`Failure from unexpected errors`, errors],
+      {
+        type: "UNEXPECTED_FAIL",
+        errors,
+      }
+    );
+  }
+
   public failReconciliation() {
     return this._runDeploymentCommand(`Reconciliation failed`, {
       type: "RECONCILIATION_FAILED",

--- a/packages/core/src/deployment/deployStateReducer.ts
+++ b/packages/core/src/deployment/deployStateReducer.ts
@@ -31,6 +31,9 @@ export function initializeDeployState(moduleName: string): DeployState {
       previousBatches: [],
       executionGraphHash: "",
     },
+    unexpected: {
+      errors: [],
+    },
   };
 }
 
@@ -76,6 +79,14 @@ export function deployStateReducer(
       };
     case "RECONCILIATION_FAILED":
       return { ...state, phase: "reconciliation-failed" };
+    case "UNEXPECTED_FAIL":
+      return {
+        ...state,
+        phase: "failed-unexpectedly",
+        unexpected: {
+          errors: action.errors,
+        },
+      };
     case "EXECUTION::START":
       if (state.transform.executionGraph === null) {
         return state;

--- a/packages/core/src/types/deployment.ts
+++ b/packages/core/src/types/deployment.ts
@@ -40,7 +40,8 @@ export type DeployPhase =
   | "failed"
   | "hold"
   | "validation-failed"
-  | "reconciliation-failed";
+  | "reconciliation-failed"
+  | "failed-unexpectedly";
 
 export type DeployStateExecutionCommand =
   | {
@@ -73,6 +74,10 @@ export type DeployStateCommand =
     }
   | {
       type: "RECONCILIATION_FAILED";
+    }
+  | {
+      type: "UNEXPECTED_FAIL";
+      errors: Error[];
     }
   | DeployStateExecutionCommand;
 
@@ -147,6 +152,9 @@ export interface DeployState {
     executionGraph: IGraph<ExecutionVertex> | null;
   };
   execution: ExecutionState;
+  unexpected: {
+    errors: Error[];
+  };
 }
 
 export interface ExecutionOptions {

--- a/packages/core/src/validation/validateDeploymentGraph.ts
+++ b/packages/core/src/validation/validateDeploymentGraph.ts
@@ -3,21 +3,39 @@ import { visit } from "graph/visit";
 import { Services } from "services/types";
 import { IDeploymentGraph } from "types/deploymentGraph";
 import { VertexVisitResult, VisitResult } from "types/graph";
+import { IgnitionError } from "utils/errors";
 
 import { validationDispatch } from "./dispatch/validationDispatch";
 
-export function validateDeploymentGraph(
+export async function validateDeploymentGraph(
   deploymentGraph: IDeploymentGraph,
   services: Services
 ): Promise<VisitResult> {
-  const orderedVertexIds = getSortedVertexIdsFrom(deploymentGraph);
+  try {
+    const orderedVertexIds = getSortedVertexIdsFrom(deploymentGraph);
 
-  return visit(
-    "Validation",
-    orderedVertexIds,
-    deploymentGraph,
-    { services },
-    new Map<number, VertexVisitResult | null>(),
-    validationDispatch
-  );
+    return await visit(
+      "Validation",
+      orderedVertexIds,
+      deploymentGraph,
+      { services },
+      new Map<number, VertexVisitResult | null>(),
+      validationDispatch
+    );
+  } catch (err) {
+    if (!(err instanceof Error)) {
+      return {
+        _kind: "failure",
+        failures: [
+          "Unsuccessful module validation",
+          [new IgnitionError("Unknown validation error")],
+        ],
+      };
+    }
+
+    return {
+      _kind: "failure",
+      failures: ["Unsuccessful module validation", [err]],
+    };
+  }
 }

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -22,6 +22,8 @@ export interface IgnitionConfig {
   eventDuration: number;
 }
 
+const DISPLAY_UI = !Boolean(process.env.DEBUG);
+
 /* ignition config defaults */
 const IGNITION_DIR = "ignition";
 const DEPLOYMENTS_DIR = "deployments";
@@ -144,12 +146,17 @@ task("deploy")
         await hre.ignition.deploy(userModule, {
           parameters,
           journalPath,
-          ui: true,
+          ui: DISPLAY_UI,
         });
-      } catch {
-        // display of error or on hold is done
-        // based on state, thrown error can be ignored
-        process.exit(1);
+      } catch (err) {
+        if (DISPLAY_UI) {
+          // display of error or on hold is done
+          // based on state, thrown error display
+          // can be ignored
+          process.exit(1);
+        } else {
+          throw err;
+        }
       }
     }
   );

--- a/packages/hardhat-plugin/src/ui/components/UnexpectedErrorPanel.tsx
+++ b/packages/hardhat-plugin/src/ui/components/UnexpectedErrorPanel.tsx
@@ -1,0 +1,27 @@
+import { DeployState } from "@ignored/ignition-core";
+import { Box, Text } from "ink";
+
+export const UnexpectedErrorPanel = ({
+  deployState,
+}: {
+  deployState: DeployState;
+}) => {
+  return (
+    <Box flexDirection="column">
+      <Text>
+        Ignition <Text color="red">failed</Text> with an error for{" "}
+        {deployState.details.moduleName}
+      </Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        {deployState.unexpected.errors.map((err, i) => (
+          <ErrorBox key={`err-${i}`} error={err} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export const ErrorBox = ({ error }: { error: Error }) => {
+  return <Text>{error.message}</Text>;
+};

--- a/packages/hardhat-plugin/src/ui/components/index.tsx
+++ b/packages/hardhat-plugin/src/ui/components/index.tsx
@@ -1,7 +1,12 @@
-import type { DeployState, ModuleParams } from "@ignored/ignition-core";
+import {
+  DeployState,
+  IgnitionError,
+  ModuleParams,
+} from "@ignored/ignition-core";
 
 import { ReconciliationFailedPanel } from "./ReconciliationFailedPanel";
 import { StartingPanel } from "./StartingPanel";
+import { UnexpectedErrorPanel } from "./UnexpectedErrorPanel";
 import { ValidationFailedPanel } from "./ValidationFailedPanel";
 import { ExecutionPanel } from "./execution/ExecutionPanel";
 
@@ -23,11 +28,28 @@ export const IgnitionUi = ({
     return <ValidationFailedPanel deployState={deployState} />;
   }
 
+  if (deployState.phase === "failed-unexpectedly") {
+    return <UnexpectedErrorPanel deployState={deployState} />;
+  }
+
   if (deployState.phase === "reconciliation-failed") {
     return <ReconciliationFailedPanel deployState={deployState} />;
   }
 
-  return (
-    <ExecutionPanel deployState={deployState} moduleParams={moduleParams} />
-  );
+  if (
+    deployState.phase === "execution" ||
+    deployState.phase === "complete" ||
+    deployState.phase === "failed" ||
+    deployState.phase === "hold"
+  ) {
+    return (
+      <ExecutionPanel deployState={deployState} moduleParams={moduleParams} />
+    );
+  }
+
+  return assertNeverPhase(deployState.phase);
 };
+
+function assertNeverPhase(deployStatePhase: never): null {
+  throw new IgnitionError(`Unknown deploy state phase ${deployStatePhase}`);
+}


### PR DESCRIPTION
General errors during transform were not being reported back, instead leaking out to the top level but not being shown.

A top level handler has been added to the deploy process in ignition core that moves the phase to `failed-unexpectedly`. The cli has been modified to display errors in this state.

A caveat to the general handling of unexpected errors is that any exception happening in the validation phase is treated as a validation error rather than an unexpected error.

The top level ui display component has been refactored to show a type error if it is not covering all phases.

An additional change is that the ink ui is now turned off if you have `DEBUG` set, so:

```shell
DEBUG=ignition:* npx hardhat deploy ExampleModule
```

Fixes #141.

## Preview

![Feb-09-2023 15-47-00](https://user-images.githubusercontent.com/24030/217863621-1ac4511a-dc95-4d5f-b2da-a0afb07aa54c.gif)
