### PR TITLE
Fix/error on async to buildmodule

### DIFF
--- a/packages/core/src/process/generateDeploymentGraphFrom.ts
+++ b/packages/core/src/process/generateDeploymentGraphFrom.ts
@@ -5,6 +5,7 @@ import type {
 } from "types/deploymentGraph";
 import { FutureDict } from "types/future";
 import { Module, ModuleDict } from "types/module";
+import { IgnitionError } from "utils/errors";
 
 export function generateDeploymentGraphFrom<T extends ModuleDict>(
   ignitionModule: Module<T>,
@@ -14,5 +15,19 @@ export function generateDeploymentGraphFrom<T extends ModuleDict>(
 
   const moduleOutputs = ignitionModule.action(graphBuilder);
 
+  if (isPromise(moduleOutputs)) {
+    throw new IgnitionError(
+      `The callback passed to 'buildModule' for ${ignitionModule.name} returns a Promise; async callbacks are not allowed in 'buildModule'.`
+    );
+  }
+
   return { graph: graphBuilder.graph, moduleOutputs };
+}
+
+function isPromise(promise: any) {
+  return (
+    promise &&
+    typeof promise.then === "function" &&
+    promise[Symbol.toStringTag] === "Promise"
+  );
 }

--- a/packages/core/test/deploymentBuilder/buildModule.ts
+++ b/packages/core/test/deploymentBuilder/buildModule.ts
@@ -1,0 +1,19 @@
+/* eslint-disable import/no-unused-modules */
+import { assert } from "chai";
+
+import { buildModule } from "dsl/buildModule";
+import { generateDeploymentGraphFrom } from "process/generateDeploymentGraphFrom";
+
+describe("deployment builder - buildModule", () => {
+  it("should throw if build module is given an async callback", () => {
+    assert.throws(() => {
+      const badAsyncModule = buildModule("BadAsyncModule", (async () => {
+        return {};
+      }) as any);
+
+      return generateDeploymentGraphFrom(badAsyncModule, {
+        chainId: 31337,
+      });
+    }, /The callback passed to 'buildModule' for BadAsyncModule returns a Promise; async callbacks are not allowed in 'buildModule'./);
+  });
+});

--- a/packages/core/test/deploymentBuilder/buildModule.ts
+++ b/packages/core/test/deploymentBuilder/buildModule.ts
@@ -16,4 +16,16 @@ describe("deployment builder - buildModule", () => {
       });
     }, /The callback passed to 'buildModule' for BadAsyncModule returns a Promise; async callbacks are not allowed in 'buildModule'./);
   });
+
+  it("should throw if build module throws an exception", () => {
+    assert.throws(() => {
+      const badAsyncModule = buildModule("BadAsyncModule", () => {
+        throw new Error("User thrown error");
+      });
+
+      return generateDeploymentGraphFrom(badAsyncModule, {
+        chainId: 31337,
+      });
+    }, /User thrown error/);
+  });
 });

--- a/packages/hardhat-plugin/test/error-handling.ts
+++ b/packages/hardhat-plugin/test/error-handling.ts
@@ -17,4 +17,12 @@ describe("module error handling", () => {
       /The callback passed to 'buildModule' for MyModule returns a Promise; async callbacks are not allowed in 'buildModule'./
     );
   });
+
+  it("should error on module throwing an exception", async function () {
+    const promise = deployModule(this.hre, () => {
+      throw new Error("User thrown error");
+    });
+
+    return assert.isRejected(promise, /User thrown error/);
+  });
 });

--- a/packages/hardhat-plugin/test/error-handling.ts
+++ b/packages/hardhat-plugin/test/error-handling.ts
@@ -1,0 +1,20 @@
+/* eslint-disable import/no-unused-modules */
+import { assert } from "chai";
+
+import { deployModule } from "./helpers";
+import { useEnvironment } from "./useEnvironment";
+
+describe("module error handling", () => {
+  useEnvironment("minimal");
+
+  it("should error on passing async callback", async function () {
+    const promise = deployModule(this.hre, (async () => {
+      return {};
+    }) as any);
+
+    return assert.isRejected(
+      promise,
+      /The callback passed to 'buildModule' for MyModule returns a Promise; async callbacks are not allowed in 'buildModule'./
+    );
+  });
+});


### PR DESCRIPTION
Due to typescript transpilation we can't check that the function passed into `buildModule` is async, instead we check whether the returned result is a promise or not.

If we detect a promise being returned Ignition throws and relays on the general error handler for display in the UI.

Fixes #138.

## Preview

![image](https://user-images.githubusercontent.com/24030/218073311-ac0542ec-d7f3-4ef0-bc92-73e7190674d3.png)
