### PR TITLE
Typescript support

### DIFF
--- a/examples/create2/ignition/Create2FactoryModule.js
+++ b/examples/create2/ignition/Create2FactoryModule.js
@@ -34,7 +34,7 @@ module.exports = buildModule("Create2Factory", (m) => {
     after: [barEvent],
   });
 
-  return { create2, foo, bar, fooEvent, barEvent };
+  return { create2, foo, bar };
 });
 
 function toBytes32(n) {

--- a/examples/create2/test/create2.test.js
+++ b/examples/create2/test/create2.test.js
@@ -12,20 +12,4 @@ describe("Create2", function () {
   it("should return an instantiated factory", async function () {
     assert.isDefined(deployResults.create2);
   });
-
-  it("should have deployed the foo contract", async () => {
-    const address = deployResults.fooEvent.deployed;
-    const FooFactory = await hre.ethers.getContractFactory("Foo");
-    const foo = FooFactory.attach(address);
-
-    assert.equal(await foo.name(), "Foo");
-  });
-
-  it("should have deployed the bar contract", async () => {
-    const address = deployResults.barEvent.deployed;
-    const BarFactory = await hre.ethers.getContractFactory("Bar");
-    const bar = BarFactory.attach(address);
-
-    assert.equal(await bar.name(), "Bar");
-  });
 });

--- a/examples/multisig/ignition/MultisigModule.js
+++ b/examples/multisig/ignition/MultisigModule.js
@@ -33,5 +33,5 @@ module.exports = buildModule("MultisigModule", (m) => {
     after: [event],
   });
 
-  return { multisig, event };
+  return { multisig };
 });

--- a/examples/multisig/test/Multisig.js
+++ b/examples/multisig/test/Multisig.js
@@ -8,7 +8,6 @@ const ACCOUNT_0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 describe("Multisig", function () {
   describe("a deploy broken up by an external call", () => {
     let multisig;
-    let event;
 
     this.beforeAll(async () => {
       const journal = new MemoryCommandJournal();
@@ -33,7 +32,6 @@ describe("Multisig", function () {
       });
 
       multisig = moduleResult.multisig;
-      event = moduleResult.event;
     });
 
     it("should confirm a stored transaction", async function () {
@@ -43,11 +41,6 @@ describe("Multisig", function () {
       );
 
       expect(isConfirmed).to.equal(true);
-    });
-
-    it("should emit the sender and transaction id after confirming a stored transaction", async function () {
-      expect(event.sender).to.equal(ACCOUNT_0);
-      expect(ethers.BigNumber.from("0").eq(event.transactionId)).to.be.true;
     });
 
     it("should execute a confirmed transaction", async function () {

--- a/examples/sample/ignition/LockModule.js
+++ b/examples/sample/ignition/LockModule.js
@@ -5,7 +5,7 @@ const currentTimestampInSeconds = Math.round(new Date(2023, 01, 01) / 1000);
 const TEN_YEAR_IN_SECS = 10 * 365 * 24 * 60 * 60;
 const TEN_YEARS_IN_FUTURE = currentTimestampInSeconds + TEN_YEAR_IN_SECS;
 
-const ONE_GWEI = hre.ethers.utils.parseUnits("1", "gwei");
+const ONE_GWEI = hre.ethers.utils.parseUnits("1", "gwei").toString();
 
 module.exports = buildModule("LockModule", (m) => {
   const unlockTime = m.getOptionalParam("unlockTime", TEN_YEARS_IN_FUTURE);

--- a/examples/ts-sample/.eslintrc.js
+++ b/examples/ts-sample/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  extends: ["plugin:prettier/recommended"],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.json",
+    tsConfigRootDir: "./",
+  },
+  plugins: ["eslint-plugin-import", "@typescript-eslint"],
+  env: {
+    es6: true,
+    node: true,
+  },
+  rules: {
+    "no-console": "error",
+  },
+  ignorePatterns: ["post-build.js", "artifacts/*", "cache/*"],
+};

--- a/examples/ts-sample/.gitignore
+++ b/examples/ts-sample/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.env
+coverage
+coverage.json
+typechain
+typechain-types
+
+#Hardhat files
+cache
+artifacts
+

--- a/examples/ts-sample/.prettierignore
+++ b/examples/ts-sample/.prettierignore
@@ -1,0 +1,5 @@
+/node_modules
+/artifacts
+/cache
+/coverage
+/.nyc_output

--- a/examples/ts-sample/README.md
+++ b/examples/ts-sample/README.md
@@ -7,7 +7,7 @@ This hardhat project is a variant of Hardhat's javascript sample project.
 To run the ignition deploy against the ephemeral hardhat network:
 
 ```shell
-npx hardhat deploy LockModule.js
+npx hardhat deploy LockModule
 ```
 
 ## Test

--- a/examples/ts-sample/README.md
+++ b/examples/ts-sample/README.md
@@ -1,0 +1,19 @@
+# Hardhat Sample for Ignition
+
+This hardhat project is a variant of Hardhat's javascript sample project.
+
+## Deploying
+
+To run the ignition deploy against the ephemeral hardhat network:
+
+```shell
+npx hardhat deploy LockModule.js
+```
+
+## Test
+
+To run the hardhat tests using ignition:
+
+```shell
+npm run test:examples
+```

--- a/examples/ts-sample/README.md
+++ b/examples/ts-sample/README.md
@@ -1,6 +1,6 @@
 # Hardhat Sample for Ignition
 
-This hardhat project is a variant of Hardhat's javascript sample project.
+This hardhat project is a variant of Hardhat's typescript sample project.
 
 ## Deploying
 

--- a/examples/ts-sample/contracts/Lock.sol
+++ b/examples/ts-sample/contracts/Lock.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+// Uncomment this line to use console.log
+// import "hardhat/console.sol";
+
+contract Lock {
+    uint public unlockTime;
+    address payable public owner;
+
+    event Withdrawal(uint amount, uint when);
+
+    constructor(uint _unlockTime) payable {
+        require(
+            block.timestamp < _unlockTime,
+            "Unlock time should be in the future"
+        );
+
+        unlockTime = _unlockTime;
+        owner = payable(msg.sender);
+    }
+
+    function withdraw() public {
+        // Uncomment this line, and the import of "hardhat/console.sol", to print a log in your terminal
+        // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
+
+        require(block.timestamp >= unlockTime, "You can't withdraw yet");
+        require(msg.sender == owner, "You aren't the owner");
+
+        emit Withdrawal(address(this).balance, block.timestamp);
+
+        owner.transfer(address(this).balance);
+    }
+}

--- a/examples/ts-sample/contracts/Lock.sol
+++ b/examples/ts-sample/contracts/Lock.sol
@@ -20,6 +20,10 @@ contract Lock {
         owner = payable(msg.sender);
     }
 
+    function test() public {
+        emit Withdrawal(address(this).balance, block.timestamp);
+    }
+
     function withdraw() public {
         // Uncomment this line, and the import of "hardhat/console.sol", to print a log in your terminal
         // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);

--- a/examples/ts-sample/hardhat.config.ts
+++ b/examples/ts-sample/hardhat.config.ts
@@ -1,0 +1,10 @@
+import type { HardhatUserConfig } from "hardhat/config";
+
+import "@nomicfoundation/hardhat-toolbox";
+import "@ignored/hardhat-ignition";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.17",
+};
+
+export default config;

--- a/examples/ts-sample/ignition/LockModule.ts
+++ b/examples/ts-sample/ignition/LockModule.ts
@@ -20,11 +20,7 @@ const LockModule = buildModule("LockModule", (m) => {
     value: lockedAmount,
   });
 
-  const c = m.call(lock, "test", { args: [] });
-
-  const event = m.event(lock, "Withdrawal", { args: [], after: [c] });
-
-  return { lock, event };
+  return { lock };
 });
 
 export default LockModule;

--- a/examples/ts-sample/ignition/LockModule.ts
+++ b/examples/ts-sample/ignition/LockModule.ts
@@ -1,0 +1,28 @@
+import hre from "hardhat";
+import { buildModule } from "@ignored/hardhat-ignition";
+
+const currentTimestampInSeconds = Math.round(
+  new Date(2023, 1, 1).valueOf() / 1000
+);
+const TEN_YEAR_IN_SECS = 10 * 365 * 24 * 60 * 60;
+const TEN_YEARS_IN_FUTURE = currentTimestampInSeconds + TEN_YEAR_IN_SECS;
+
+const ONE_GWEI = hre.ethers.utils.parseUnits("1", "gwei").toString();
+
+const LockModule = buildModule("LockModule", (m) => {
+  const artifact = require("../artifacts/contracts/Lock.sol/Lock.json");
+
+  const unlockTime = m.getOptionalParam("unlockTime", TEN_YEARS_IN_FUTURE);
+  const lockedAmount = m.getOptionalParam("lockedAmount", ONE_GWEI);
+
+  const lock = m.contract("Lock", artifact, {
+    args: [unlockTime],
+    value: lockedAmount,
+  });
+
+  const event = m.event(lock, "Withdrawal", { args: [] });
+
+  return { lock, event };
+});
+
+export default LockModule;

--- a/examples/ts-sample/ignition/LockModule.ts
+++ b/examples/ts-sample/ignition/LockModule.ts
@@ -10,12 +10,10 @@ const TEN_YEARS_IN_FUTURE = currentTimestampInSeconds + TEN_YEAR_IN_SECS;
 const ONE_GWEI = hre.ethers.utils.parseUnits("1", "gwei").toString();
 
 const LockModule = buildModule("LockModule", (m) => {
-  const artifact = require("../artifacts/contracts/Lock.sol/Lock.json");
-
   const unlockTime = m.getOptionalParam("unlockTime", TEN_YEARS_IN_FUTURE);
   const lockedAmount = m.getOptionalParam("lockedAmount", ONE_GWEI);
 
-  const lock = m.contract("Lock", artifact, {
+  const lock = m.contract("Lock", {
     args: [unlockTime],
     value: lockedAmount,
   });

--- a/examples/ts-sample/ignition/LockModule.ts
+++ b/examples/ts-sample/ignition/LockModule.ts
@@ -20,7 +20,9 @@ const LockModule = buildModule("LockModule", (m) => {
     value: lockedAmount,
   });
 
-  const event = m.event(lock, "Withdrawal", { args: [] });
+  const c = m.call(lock, "test", { args: [] });
+
+  const event = m.event(lock, "Withdrawal", { args: [], after: [c] });
 
   return { lock, event };
 });

--- a/examples/ts-sample/package.json
+++ b/examples/ts-sample/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.7",
+    "@ignored/hardhat-ignition": "^0.0.8",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/ts-sample/package.json
+++ b/examples/ts-sample/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nomicfoundation/ignition-ts-sample-example",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "test:examples": "hardhat test",
+    "lint": "npm run prettier -- --check && npm run eslint",
+    "lint:fix": "npm run prettier -- --write && npm run eslint -- --fix",
+    "eslint": "eslint \"ignition/**/*.{js,jsx,ts,tsx}\" \"test/**/*.{js,jsx,ts,tsx}\"",
+    "prettier": "prettier \"*.{js,ts,md,json}\" \"ignition/*.{js,ts,md,json}\" \"test/*.{js,ts,md,json}\""
+  },
+  "devDependencies": {
+    "@ethersproject/abi": "5.7.0",
+    "@ethersproject/providers": "5.7.2",
+    "@ignored/hardhat-ignition": "^0.0.7",
+    "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
+    "@nomicfoundation/hardhat-network-helpers": "1.0.6",
+    "@nomicfoundation/hardhat-toolbox": "2.0.0",
+    "@nomiclabs/hardhat-ethers": "2.2.1",
+    "@nomiclabs/hardhat-etherscan": "3.1.2",
+    "@typechain/ethers-v5": "10.1.1",
+    "@typechain/hardhat": "6.1.4",
+    "@typescript-eslint/eslint-plugin": "^5.52.0",
+    "@typescript-eslint/parser": "^5.52.0",
+    "chai": "4.3.7",
+    "eslint-import-resolver-typescript": "^3.5.3",
+    "eslint-plugin-import": "^2.27.5",
+    "ethers": "5.7.2",
+    "hardhat": "^2.12.0",
+    "hardhat-gas-reporter": "1.0.9",
+    "solidity-coverage": "0.8.2",
+    "typechain": "8.1.1",
+    "typescript": "^4.7.4"
+  }
+}

--- a/examples/ts-sample/test/Lock.ts
+++ b/examples/ts-sample/test/Lock.ts
@@ -1,0 +1,130 @@
+import { ethers, ignition } from "hardhat";
+import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { expect } from "chai";
+
+import LockModule from "../ignition/LockModule";
+
+describe("Lock", function () {
+  // We define a fixture to reuse the same setup in every test.
+  // We use loadFixture to run this setup once, snapshot that state,
+  // and reset Hardhat Network to that snapshot in every test.
+  async function deployOneYearLockFixture() {
+    const ONE_YEAR_IN_SECS = 365 * 24 * 60 * 60;
+    const ONE_GWEI = 1_000_000_000;
+
+    const lockedAmount = ONE_GWEI;
+    const unlockTime = (await time.latest()) + ONE_YEAR_IN_SECS;
+
+    // Contracts are deployed using the first signer/account by default
+    const [owner, otherAccount] = await ethers.getSigners();
+
+    const { lock } = await ignition.deploy(LockModule, {
+      parameters: {
+        unlockTime,
+        lockedAmount,
+      },
+    });
+
+    return { lock, unlockTime, lockedAmount, owner, otherAccount };
+  }
+
+  describe("Deployment", function () {
+    it("Should set the right unlockTime", async function () {
+      const { lock, unlockTime } = await loadFixture(deployOneYearLockFixture);
+
+      expect(await lock.unlockTime()).to.equal(unlockTime);
+    });
+
+    it("Should set the right owner", async function () {
+      const { lock, owner } = await loadFixture(deployOneYearLockFixture);
+
+      expect(await lock.owner()).to.equal(owner.address);
+    });
+
+    it("Should receive and store the funds to lock", async function () {
+      const { lock, lockedAmount } = await loadFixture(
+        deployOneYearLockFixture
+      );
+
+      expect(await ethers.provider.getBalance(lock.address)).to.equal(
+        lockedAmount
+      );
+    });
+
+    it("Should fail if the unlockTime is not in the future", async function () {
+      // We don't use the fixture here because we want a different deployment
+      const latestTime = await time.latest();
+      const Lock = await ethers.getContractFactory("Lock");
+      await expect(Lock.deploy(latestTime, { value: 1 })).to.be.revertedWith(
+        "Unlock time should be in the future"
+      );
+    });
+  });
+
+  describe("Withdrawals", function () {
+    describe("Validations", function () {
+      it("Should revert with the right error if called too soon", async function () {
+        const { lock } = await loadFixture(deployOneYearLockFixture);
+
+        await expect(lock.withdraw()).to.be.revertedWith(
+          "You can't withdraw yet"
+        );
+      });
+
+      it("Should revert with the right error if called from another account", async function () {
+        const { lock, unlockTime, otherAccount } = await loadFixture(
+          deployOneYearLockFixture
+        );
+
+        // We can increase the time in Hardhat Network
+        await time.increaseTo(unlockTime);
+
+        // We use lock.connect() to send a transaction from another account
+        await expect(lock.connect(otherAccount).withdraw()).to.be.revertedWith(
+          "You aren't the owner"
+        );
+      });
+
+      it("Shouldn't fail if the unlockTime has arrived and the owner calls it", async function () {
+        const { lock, unlockTime } = await loadFixture(
+          deployOneYearLockFixture
+        );
+
+        // Transactions are sent using the first signer by default
+        await time.increaseTo(unlockTime);
+
+        await expect(lock.withdraw()).not.to.be.reverted;
+      });
+    });
+
+    describe("Events", function () {
+      it("Should emit an event on withdrawals", async function () {
+        const { lock, unlockTime, lockedAmount } = await loadFixture(
+          deployOneYearLockFixture
+        );
+
+        await time.increaseTo(unlockTime);
+
+        await expect(lock.withdraw())
+          .to.emit(lock, "Withdrawal")
+          .withArgs(lockedAmount, anyValue); // We accept any value as `when` arg
+      });
+    });
+
+    describe("Transfers", function () {
+      it.skip("Should transfer the funds to the owner", async function () {
+        const { lock, unlockTime, lockedAmount, owner } = await loadFixture(
+          deployOneYearLockFixture
+        );
+
+        await time.increaseTo(unlockTime);
+
+        await expect(lock.withdraw()).to.changeEtherBalances(
+          [owner, lock],
+          [lockedAmount, -lockedAmount]
+        );
+      });
+    });
+  });
+});

--- a/examples/ts-sample/tsconfig.json
+++ b/examples/ts-sample/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,6 +145,255 @@
         "hardhat": "^2.0.0"
       }
     },
+    "examples/ts-sample": {
+      "name": "@nomicfoundation/ignition-ts-sample-example",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ignored/hardhat-ignition": "^0.0.7",
+        "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
+        "@nomicfoundation/hardhat-network-helpers": "1.0.6",
+        "@nomicfoundation/hardhat-toolbox": "2.0.0",
+        "@nomiclabs/hardhat-ethers": "2.2.1",
+        "@nomiclabs/hardhat-etherscan": "3.1.2",
+        "@typechain/ethers-v5": "10.1.1",
+        "@typechain/hardhat": "6.1.4",
+        "@typescript-eslint/eslint-plugin": "^5.52.0",
+        "@typescript-eslint/parser": "^5.52.0",
+        "chai": "4.3.7",
+        "eslint-import-resolver-typescript": "^3.5.3",
+        "eslint-plugin-import": "^2.27.5",
+        "ethers": "5.7.2",
+        "hardhat": "^2.12.0",
+        "hardhat-gas-reporter": "1.0.9",
+        "solidity-coverage": "0.8.2",
+        "typechain": "8.1.1",
+        "typescript": "^4.7.4"
+      }
+    },
+    "examples/ts-sample/node_modules/@nomiclabs/hardhat-ethers": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.1.tgz",
+      "integrity": "sha512-RHWYwnxryWR8hzRmU4Jm/q4gzvXpetUOJ4OPlwH2YARcDB+j79+yAYCwO0lN1SUOb4++oOTJEe6AWLEc42LIvg==",
+      "dev": true,
+      "peerDependencies": {
+        "ethers": "^5.0.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "examples/ts-sample/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.52.0.tgz",
+      "integrity": "sha512-lHazYdvYVsBokwCdKOppvYJKaJ4S41CgKBcPvyd0xjZNbvQdhn/pnJlGtQksQ/NhInzdaeaSarlBjDXHuclEbg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/type-utils": "5.52.0",
+        "@typescript-eslint/utils": "5.52.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "examples/ts-sample/node_modules/@typescript-eslint/parser": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz",
+      "integrity": "sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/typescript-estree": "5.52.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "examples/ts-sample/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz",
+      "integrity": "sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "examples/ts-sample/node_modules/@typescript-eslint/types": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
+      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "examples/ts-sample/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
+      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "examples/ts-sample/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
+      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.52.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "examples/ts-sample/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "examples/ts-sample/node_modules/eslint-plugin-import": {
+      "version": "2.27.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "array.prototype.flatmap": "^1.3.1",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-module-utils": "^2.7.4",
+        "has": "^1.0.3",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.values": "^1.1.6",
+        "resolve": "^1.22.1",
+        "semver": "^6.3.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "examples/ts-sample/node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "examples/ts-sample/node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "examples/ts-sample/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "examples/ts-sample/node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "examples/uniswap": {
       "name": "@nomicfoundation/ignition-uniswap-example",
       "version": "0.0.1",
@@ -2310,6 +2559,10 @@
       "resolved": "examples/sample",
       "link": true
     },
+    "node_modules/@nomicfoundation/ignition-ts-sample-example": {
+      "resolved": "examples/ts-sample",
+      "link": true
+    },
     "node_modules/@nomicfoundation/ignition-uniswap-example": {
       "resolved": "examples/uniswap",
       "link": true
@@ -3925,6 +4178,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "node_modules/@types/sinon": {
       "version": "10.0.13",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
@@ -4065,6 +4324,99 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.52.0.tgz",
+      "integrity": "sha512-tEKuUHfDOv852QGlpPtB3lHOoig5pyFQN/cUiZtpw99D93nEBjexRLre5sQZlkMoHry/lZr8qDAt2oAHLKA6Jw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.52.0",
+        "@typescript-eslint/utils": "5.52.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
+      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
+      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
+      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.52.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
       "version": "4.31.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.2.tgz",
@@ -4103,6 +4455,115 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.52.0.tgz",
+      "integrity": "sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/typescript-estree": "5.52.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz",
+      "integrity": "sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
+      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
+      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
+      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.52.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -4660,6 +5121,24 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
       "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -9817,6 +10296,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
     "node_modules/growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -12472,6 +12957,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "node_modules/ndjson": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.7",
+        "@ignored/hardhat-ignition": "^0.0.8",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -170,31 +170,6 @@
         "solidity-coverage": "0.8.2",
         "typechain": "8.1.1",
         "typescript": "^4.7.4"
-      }
-    },
-    "examples/ts-sample/node_modules/@ignored/hardhat-ignition": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@ignored/hardhat-ignition/-/hardhat-ignition-0.0.7.tgz",
-      "integrity": "sha512-NTY+ca/jooDmZYwKRETpzHYwSCCp5vWwfApP80TVU/OVw86nIdB8H0o+Q208cKHR6esQf0sPR4TiMNwHyVGGNQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.2",
-        "ethers": "^5.4.7",
-        "fs-extra": "^10.0.0",
-        "ink": "3.2.0",
-        "ink-spinner": "4.0.3",
-        "ndjson": "2.0.0",
-        "prompts": "^2.4.2",
-        "react": "18.2.0",
-        "serialize-error": "8.1.0"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "@ignored/ignition-core": "^0.0.7",
-        "@nomiclabs/hardhat-ethers": "^2.0.2",
-        "hardhat": "^2.12.0"
       }
     },
     "examples/ts-sample/node_modules/@ignored/ignition-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,6 +172,53 @@
         "typescript": "^4.7.4"
       }
     },
+    "examples/ts-sample/node_modules/@ignored/hardhat-ignition": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@ignored/hardhat-ignition/-/hardhat-ignition-0.0.7.tgz",
+      "integrity": "sha512-NTY+ca/jooDmZYwKRETpzHYwSCCp5vWwfApP80TVU/OVw86nIdB8H0o+Q208cKHR6esQf0sPR4TiMNwHyVGGNQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.2",
+        "ethers": "^5.4.7",
+        "fs-extra": "^10.0.0",
+        "ink": "3.2.0",
+        "ink-spinner": "4.0.3",
+        "ndjson": "2.0.0",
+        "prompts": "^2.4.2",
+        "react": "18.2.0",
+        "serialize-error": "8.1.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "@ignored/ignition-core": "^0.0.7",
+        "@nomiclabs/hardhat-ethers": "^2.0.2",
+        "hardhat": "^2.12.0"
+      }
+    },
+    "examples/ts-sample/node_modules/@ignored/ignition-core": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@ignored/ignition-core/-/ignition-core-0.0.7.tgz",
+      "integrity": "sha512-I6o9hnrPfSh/6b3PW2Y+SDYA4y7GaCwV/Ovrt6tRFw5QDsmkSuLocaP11a1znz/ks9xoai6RVkK55J9rAN4LfA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/address": "5.6.1",
+        "debug": "^4.3.2",
+        "ethers": "^5.4.7",
+        "fs-extra": "^10.0.0",
+        "js-graph-algorithms": "1.0.18",
+        "object-hash": "^3.0.0",
+        "serialize-error": "8.1.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.12.0"
+      }
+    },
     "examples/ts-sample/node_modules/@nomiclabs/hardhat-ethers": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.1.tgz",
@@ -392,6 +439,18 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "examples/ts-sample/node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "examples/uniswap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,28 +172,6 @@
         "typescript": "^4.7.4"
       }
     },
-    "examples/ts-sample/node_modules/@ignored/ignition-core": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@ignored/ignition-core/-/ignition-core-0.0.7.tgz",
-      "integrity": "sha512-I6o9hnrPfSh/6b3PW2Y+SDYA4y7GaCwV/Ovrt6tRFw5QDsmkSuLocaP11a1znz/ks9xoai6RVkK55J9rAN4LfA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/address": "5.6.1",
-        "debug": "^4.3.2",
-        "ethers": "^5.4.7",
-        "fs-extra": "^10.0.0",
-        "js-graph-algorithms": "1.0.18",
-        "object-hash": "^3.0.0",
-        "serialize-error": "8.1.0"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.12.0"
-      }
-    },
     "examples/ts-sample/node_modules/@nomiclabs/hardhat-ethers": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.1.tgz",
@@ -414,18 +392,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "examples/ts-sample/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "examples/uniswap": {

--- a/packages/core/src/Ignition.ts
+++ b/packages/core/src/Ignition.ts
@@ -239,7 +239,8 @@ export class Ignition {
         executionResultValue === undefined ||
         executionResultValue === null ||
         executionResultValue._kind === "failure" ||
-        executionResultValue._kind === "hold"
+        executionResultValue._kind === "hold" ||
+        future.type !== "contract"
       ) {
         continue;
       }

--- a/packages/core/src/Ignition.ts
+++ b/packages/core/src/Ignition.ts
@@ -9,12 +9,18 @@ import { NoopCommandJournal } from "journal/NoopCommandJournal";
 import { generateDeploymentGraphFrom } from "process/generateDeploymentGraphFrom";
 import { transformDeploymentGraphToExecutionGraph } from "process/transformDeploymentGraphToExecutionGraph";
 import { Services } from "services/types";
-import { DeploymentResult, UpdateUiAction } from "types/deployment";
-import { ResultsAccumulator, VisitResult } from "types/graph";
-import { ICommandJournal } from "types/journal";
-import { Module, ModuleDict } from "types/module";
-import { IgnitionPlan } from "types/plan";
-import { ContractInfo, SerializedDeploymentResult } from "types/serialization";
+import type { DeploymentResult, UpdateUiAction } from "types/deployment";
+import type {
+  ExecutionResultsAccumulator,
+  ExecutionVisitResult,
+} from "types/executionGraph";
+import type { ICommandJournal } from "types/journal";
+import type { Module, ModuleDict } from "types/module";
+import type { IgnitionPlan } from "types/plan";
+import type {
+  ContractInfo,
+  SerializedDeploymentResult,
+} from "types/serialization";
 import { IgnitionError } from "utils/errors";
 import { resolveProxyValue } from "utils/proxy";
 import { validateDeploymentGraph } from "validation/validateDeploymentGraph";
@@ -198,7 +204,7 @@ export class Ignition {
   }
 
   private _buildOutputFrom<T extends ModuleDict>(
-    executionResult: VisitResult,
+    executionResult: ExecutionVisitResult,
     moduleOutputs: T
   ): DeploymentResult<T> {
     if (executionResult._kind === "failure") {
@@ -219,7 +225,7 @@ export class Ignition {
 
   private _serialize<T extends ModuleDict>(
     moduleOutputs: T,
-    result: ResultsAccumulator
+    result: ExecutionResultsAccumulator
   ): SerializedDeploymentResult<T> {
     const entries = Object.entries(moduleOutputs);
 

--- a/packages/core/src/deployment/Deployment.ts
+++ b/packages/core/src/deployment/Deployment.ts
@@ -1,19 +1,16 @@
 import setupDebug from "debug";
 
 import { ExecutionGraph } from "execution/ExecutionGraph";
-import { Services } from "services/types";
-import {
+import type { Services } from "services/types";
+import type {
   DeployState,
   UpdateUiAction,
   DeployStateCommand,
   DeployStateExecutionCommand,
 } from "types/deployment";
-import {
-  VertexDescriptor,
-  VertexVisitResult,
-  VertexVisitResultFailure,
-} from "types/graph";
-import { ICommandJournal } from "types/journal";
+import type { ExecutionVertexVisitResult } from "types/executionGraph";
+import type { VertexDescriptor, VertexVisitResultFailure } from "types/graph";
+import type { ICommandJournal } from "types/journal";
 import { IgnitionError } from "utils/errors";
 
 import {
@@ -126,7 +123,10 @@ export class Deployment {
     });
   }
 
-  public async updateVertexResult(vertexId: number, result: VertexVisitResult) {
+  public async updateVertexResult(
+    vertexId: number,
+    result: ExecutionVertexVisitResult
+  ) {
     return this._runDeploymentCommand(
       [`Update current with batch result for ${vertexId}`, [result]],
       {

--- a/packages/core/src/deployment/deployExecutionStateReducer.ts
+++ b/packages/core/src/deployment/deployExecutionStateReducer.ts
@@ -7,7 +7,7 @@ import type {
   VertexExecutionStatusCompleted,
   VertexExecutionStatusHold,
 } from "types/deployment";
-import { VertexVisitResult } from "types/graph";
+import { VertexResultEnum, VertexVisitResult } from "types/graph";
 import { IgnitionError } from "utils/errors";
 
 import { assertNeverMessageType } from "./utils";
@@ -81,17 +81,17 @@ function updateExecutionStateWithNewBatch(
 
 function convertTo(vertexVisitResult: VertexVisitResult): VertexExecutionState {
   switch (vertexVisitResult._kind) {
-    case "success":
+    case VertexResultEnum.SUCCESS:
       return {
         status: "COMPLETED" as VertexExecutionStatusCompleted,
         result: vertexVisitResult,
       };
-    case "failure":
+    case VertexResultEnum.FAILURE:
       return {
         status: "FAILED" as VertexExecutionStatusFailed,
         result: vertexVisitResult,
       };
-    case "hold":
+    case VertexResultEnum.HOLD:
       return {
         status: "HOLD" as VertexExecutionStatusHold,
         result: null,

--- a/packages/core/src/deployment/deployExecutionStateReducer.ts
+++ b/packages/core/src/deployment/deployExecutionStateReducer.ts
@@ -7,7 +7,8 @@ import type {
   VertexExecutionStatusCompleted,
   VertexExecutionStatusHold,
 } from "types/deployment";
-import { VertexResultEnum, VertexVisitResult } from "types/graph";
+import type { ExecutionVertexVisitResult } from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 import { IgnitionError } from "utils/errors";
 
 import { assertNeverMessageType } from "./utils";
@@ -79,7 +80,9 @@ function updateExecutionStateWithNewBatch(
   };
 }
 
-function convertTo(vertexVisitResult: VertexVisitResult): VertexExecutionState {
+function convertTo(
+  vertexVisitResult: ExecutionVertexVisitResult
+): VertexExecutionState {
   switch (vertexVisitResult._kind) {
     case VertexResultEnum.SUCCESS:
       return {

--- a/packages/core/src/deployment/utils.ts
+++ b/packages/core/src/deployment/utils.ts
@@ -3,7 +3,10 @@ import type {
   DeployStateCommand,
   DeployStateExecutionCommand,
 } from "types/deployment";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import type {
+  ExecutionResultsAccumulator,
+  ExecutionVertexVisitResult,
+} from "types/executionGraph";
 import { IgnitionError } from "utils/errors";
 
 export function isDeployStateExecutionCommand(
@@ -22,13 +25,11 @@ export function assertNeverMessageType(action: never) {
 
 export function viewExecutionResults(
   deployState: DeployState
-): ResultsAccumulator {
-  const entries: Array<[number, VertexVisitResult | null]> = Object.entries(
-    deployState.execution.vertexes
-  ).map(([vertexId, vertexState]) => [
-    parseInt(vertexId, 10),
-    vertexState.result,
-  ]);
+): ExecutionResultsAccumulator {
+  const entries: Array<[number, ExecutionVertexVisitResult | null]> =
+    Object.entries(deployState.execution.vertexes).map(
+      ([vertexId, vertexState]) => [parseInt(vertexId, 10), vertexState.result]
+    );
 
-  return new Map<number, VertexVisitResult | null>(entries);
+  return new Map<number, ExecutionVertexVisitResult | null>(entries);
 }

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -95,11 +95,19 @@ export class DeploymentBuilder implements IDeploymentBuilder {
   constructor(options: DeploymentBuilderOptions) {
     this.chainId = options.chainId;
   }
-
   public library(
     libraryName: string,
-    artifactOrOptions?: ContractOptions | Artifact | undefined,
-    givenOptions?: ContractOptions | undefined
+    options?: ContractOptions
+  ): HardhatLibrary;
+  public library(
+    libraryName: string,
+    artifact: Artifact,
+    options?: ContractOptions
+  ): ArtifactLibrary;
+  public library(
+    libraryName: string,
+    artifactOrOptions?: ContractOptions | Artifact,
+    givenOptions?: ContractOptions
   ): HardhatLibrary | ArtifactLibrary {
     if (isArtifact(artifactOrOptions)) {
       const artifact = artifactOrOptions;

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -8,7 +8,6 @@ import {
   InternalParamValue,
   IDeploymentGraph,
   IDeploymentBuilder,
-  Subgraph,
   DeploymentBuilderOptions,
   DeploymentGraphVertex,
   UseSubgraphOptions,
@@ -42,9 +41,10 @@ import type {
   AddressResolvable,
 } from "types/future";
 import type { Artifact } from "types/hardhat";
-import type { ModuleCache, ModuleDict } from "types/module";
+import type { ModuleCache, ModuleDict, Subgraph } from "types/module";
 import { IgnitionError } from "utils/errors";
 import {
+  assertModuleReturnTypes,
   assertUnknownDeploymentVertexType,
   isArtifact,
   isCallable,
@@ -477,16 +477,7 @@ export class DeploymentBuilder implements IDeploymentBuilder {
 
     const { result, after } = this._useSubscope(module, options);
 
-    // type casting here so that typescript lets us validate against js users bypassing typeguards
-    for (const future of Object.values(result)) {
-      if (isCallable(future)) {
-        continue;
-      }
-
-      throw new IgnitionError(
-        `Cannot return Future of type "${future.type}" from a module`
-      );
-    }
+    assertModuleReturnTypes(result);
 
     const moduleResult = { ...this._enhance(result, after), ...after };
 

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -153,6 +153,15 @@ export class DeploymentBuilder implements IDeploymentBuilder {
 
   public contract(
     contractName: string,
+    options?: ContractOptions
+  ): HardhatContract;
+  public contract(
+    contractName: string,
+    artifact: Artifact,
+    options?: ContractOptions
+  ): ArtifactContract;
+  public contract(
+    contractName: string,
     artifactOrOptions?: Artifact | ContractOptions,
     givenOptions?: ContractOptions
   ): HardhatContract | ArtifactContract {

--- a/packages/core/src/dsl/buildSubgraph.ts
+++ b/packages/core/src/dsl/buildSubgraph.ts
@@ -1,5 +1,6 @@
-import type { IDeploymentBuilder, Subgraph } from "types/deploymentGraph";
+import type { IDeploymentBuilder } from "types/deploymentGraph";
 import type { FutureDict } from "types/future";
+import { Subgraph } from "types/module";
 
 export function buildSubgraph<T extends FutureDict>(
   subgraphName: string,

--- a/packages/core/src/execution/dispatch/executeAwaitedEvent.ts
+++ b/packages/core/src/execution/dispatch/executeAwaitedEvent.ts
@@ -1,16 +1,19 @@
 import { Contract, ethers } from "ethers";
 
-import { ExecutionContext } from "types/deployment";
-import { AwaitedEvent } from "types/executionGraph";
-import { VertexVisitResult, VertexResultEnum } from "types/graph";
+import type { ExecutionContext } from "types/deployment";
+import type {
+  AwaitedEvent,
+  ExecutionVertexVisitResult,
+} from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeAwaitedEvent(
   { event, address, abi, args }: AwaitedEvent,
-  resultAccumulator: Map<number, VertexVisitResult | null>,
+  resultAccumulator: Map<number, ExecutionVertexVisitResult | null>,
   { services, options }: ExecutionContext
-): Promise<VertexVisitResult> {
+): Promise<ExecutionVertexVisitResult> {
   const resolve = resolveFrom(resultAccumulator);
 
   const resolvedArgs = [...args, address].map(resolve).map(toAddress);

--- a/packages/core/src/execution/dispatch/executeAwaitedEvent.ts
+++ b/packages/core/src/execution/dispatch/executeAwaitedEvent.ts
@@ -2,7 +2,7 @@ import { Contract, ethers } from "ethers";
 
 import { ExecutionContext } from "types/deployment";
 import { AwaitedEvent } from "types/executionGraph";
-import { VertexVisitResult } from "types/graph";
+import { VertexVisitResult, VertexResultEnum } from "types/graph";
 
 import { resolveFrom, toAddress } from "./utils";
 
@@ -30,20 +30,20 @@ export async function executeAwaitedEvent(
 
     if (eventResult === null) {
       return {
-        _kind: "hold",
+        _kind: VertexResultEnum.HOLD,
       };
     }
 
     topics = contractInstance.interface.parseLog(eventResult).args;
   } catch (err) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: err as any,
     };
   }
 
   return {
-    _kind: "success",
+    _kind: VertexResultEnum.SUCCESS,
     result: {
       topics,
     },

--- a/packages/core/src/execution/dispatch/executeContractCall.ts
+++ b/packages/core/src/execution/dispatch/executeContractCall.ts
@@ -1,16 +1,19 @@
 import { Contract } from "ethers";
 
-import { ExecutionContext } from "types/deployment";
-import { ContractCall } from "types/executionGraph";
-import { VertexVisitResult, VertexResultEnum } from "types/graph";
+import type { ExecutionContext } from "types/deployment";
+import type {
+  ContractCall,
+  ExecutionVertexVisitResult,
+} from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeContractCall(
   { method, contract, args, value }: ContractCall,
-  resultAccumulator: Map<number, VertexVisitResult | null>,
+  resultAccumulator: Map<number, ExecutionVertexVisitResult | null>,
   { services, options }: ExecutionContext
-): Promise<VertexVisitResult> {
+): Promise<ExecutionVertexVisitResult> {
   const resolve = resolveFrom(resultAccumulator);
 
   const resolvedArgs = args.map(resolve).map(toAddress);

--- a/packages/core/src/execution/dispatch/executeContractCall.ts
+++ b/packages/core/src/execution/dispatch/executeContractCall.ts
@@ -2,7 +2,7 @@ import { Contract } from "ethers";
 
 import { ExecutionContext } from "types/deployment";
 import { ContractCall } from "types/executionGraph";
-import { VertexVisitResult } from "types/graph";
+import { VertexVisitResult, VertexResultEnum } from "types/graph";
 
 import { resolveFrom, toAddress } from "./utils";
 
@@ -29,7 +29,7 @@ export async function executeContractCall(
     txHash = await services.contracts.sendTx(unsignedTx, options);
   } catch (err) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: err as any,
     };
   }
@@ -38,12 +38,12 @@ export async function executeContractCall(
     await services.transactions.wait(txHash);
   } catch {
     return {
-      _kind: "hold",
+      _kind: VertexResultEnum.HOLD,
     };
   }
 
   return {
-    _kind: "success",
+    _kind: VertexResultEnum.SUCCESS,
     result: {
       hash: txHash,
     },

--- a/packages/core/src/execution/dispatch/executeContractDeploy.ts
+++ b/packages/core/src/execution/dispatch/executeContractDeploy.ts
@@ -2,7 +2,11 @@ import { ContractFactory, ethers } from "ethers";
 
 import { ExecutionContext } from "types/deployment";
 import { ContractDeploy } from "types/executionGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexVisitResult,
+  VertexResultEnum,
+} from "types/graph";
 import { collectLibrariesAndLink } from "utils/collectLibrariesAndLink";
 
 import { resolveFrom, toAddress } from "./utils";
@@ -39,7 +43,7 @@ export async function executeContractDeploy(
     txHash = await services.contracts.sendTx(deployTransaction, options);
   } catch (err) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: err as any,
     };
   }
@@ -49,12 +53,12 @@ export async function executeContractDeploy(
     receipt = await services.transactions.wait(txHash);
   } catch {
     return {
-      _kind: "hold",
+      _kind: VertexResultEnum.HOLD,
     };
   }
 
   return {
-    _kind: "success",
+    _kind: VertexResultEnum.SUCCESS,
     result: {
       name: artifact.contractName,
       abi: artifact.abi,

--- a/packages/core/src/execution/dispatch/executeContractDeploy.ts
+++ b/packages/core/src/execution/dispatch/executeContractDeploy.ts
@@ -1,21 +1,21 @@
 import { ContractFactory, ethers } from "ethers";
 
-import { ExecutionContext } from "types/deployment";
-import { ContractDeploy } from "types/executionGraph";
-import {
-  ResultsAccumulator,
-  VertexVisitResult,
-  VertexResultEnum,
-} from "types/graph";
+import type { ExecutionContext } from "types/deployment";
+import type {
+  ContractDeploy,
+  ExecutionResultsAccumulator,
+  ExecutionVertexVisitResult,
+} from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 import { collectLibrariesAndLink } from "utils/collectLibrariesAndLink";
 
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeContractDeploy(
   { artifact, args, libraries, value }: ContractDeploy,
-  resultAccumulator: ResultsAccumulator,
+  resultAccumulator: ExecutionResultsAccumulator,
   { services, options }: ExecutionContext
-): Promise<VertexVisitResult> {
+): Promise<ExecutionVertexVisitResult> {
   let txHash: string;
   try {
     const resolve = resolveFrom(resultAccumulator);

--- a/packages/core/src/execution/dispatch/executeDeployedContract.ts
+++ b/packages/core/src/execution/dispatch/executeDeployedContract.ts
@@ -1,18 +1,18 @@
-import { Services } from "services/types";
-import { DeployedContract } from "types/executionGraph";
-import {
-  ResultsAccumulator,
-  VertexVisitResult,
-  VertexResultEnum,
-} from "types/graph";
+import type { Services } from "services/types";
+import type {
+  DeployedContract,
+  ExecutionResultsAccumulator,
+  ExecutionVertexVisitResult,
+} from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeDeployedContract(
   { label, address, abi }: DeployedContract,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ExecutionResultsAccumulator,
   _: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ExecutionVertexVisitResult> {
   const resolve = resolveFrom(_resultAccumulator);
 
   const resolvedAddress = toAddress(resolve(address));

--- a/packages/core/src/execution/dispatch/executeDeployedContract.ts
+++ b/packages/core/src/execution/dispatch/executeDeployedContract.ts
@@ -1,6 +1,10 @@
 import { Services } from "services/types";
 import { DeployedContract } from "types/executionGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexVisitResult,
+  VertexResultEnum,
+} from "types/graph";
 
 import { resolveFrom, toAddress } from "./utils";
 
@@ -14,7 +18,7 @@ export async function executeDeployedContract(
   const resolvedAddress = toAddress(resolve(address));
 
   return {
-    _kind: "success",
+    _kind: VertexResultEnum.SUCCESS,
     result: {
       name: label,
       abi,

--- a/packages/core/src/execution/dispatch/executeLibraryDeploy.ts
+++ b/packages/core/src/execution/dispatch/executeLibraryDeploy.ts
@@ -2,7 +2,11 @@ import { ContractFactory, ethers } from "ethers";
 
 import { ExecutionContext } from "types/deployment";
 import { LibraryDeploy } from "types/executionGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexVisitResult,
+  VertexResultEnum,
+} from "types/graph";
 import { collectLibrariesAndLink } from "utils/collectLibrariesAndLink";
 
 import { resolveFrom, toAddress } from "./utils";
@@ -27,7 +31,7 @@ export async function executeLibraryDeploy(
     txHash = await services.contracts.sendTx(deployTransaction, options);
   } catch (err) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: err as any,
     };
   }
@@ -37,12 +41,12 @@ export async function executeLibraryDeploy(
     receipt = await services.transactions.wait(txHash);
   } catch {
     return {
-      _kind: "hold",
+      _kind: VertexResultEnum.HOLD,
     };
   }
 
   return {
-    _kind: "success",
+    _kind: VertexResultEnum.SUCCESS,
     result: {
       name: artifact.contractName,
       abi: artifact.abi,

--- a/packages/core/src/execution/dispatch/executeLibraryDeploy.ts
+++ b/packages/core/src/execution/dispatch/executeLibraryDeploy.ts
@@ -1,21 +1,21 @@
 import { ContractFactory, ethers } from "ethers";
 
-import { ExecutionContext } from "types/deployment";
-import { LibraryDeploy } from "types/executionGraph";
-import {
-  ResultsAccumulator,
-  VertexVisitResult,
-  VertexResultEnum,
-} from "types/graph";
+import type { ExecutionContext } from "types/deployment";
+import type {
+  ExecutionResultsAccumulator,
+  ExecutionVertexVisitResult,
+  LibraryDeploy,
+} from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 import { collectLibrariesAndLink } from "utils/collectLibrariesAndLink";
 
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeLibraryDeploy(
   { artifact, args }: LibraryDeploy,
-  resultAccumulator: ResultsAccumulator,
+  resultAccumulator: ExecutionResultsAccumulator,
   { services, options }: ExecutionContext
-): Promise<VertexVisitResult> {
+): Promise<ExecutionVertexVisitResult> {
   let txHash: string;
   try {
     const resolvedArgs = args

--- a/packages/core/src/execution/dispatch/executeSendETH.ts
+++ b/packages/core/src/execution/dispatch/executeSendETH.ts
@@ -2,7 +2,7 @@ import type { PopulatedTransaction } from "ethers";
 
 import { ExecutionContext } from "types/deployment";
 import { SentETH } from "types/executionGraph";
-import { VertexVisitResult } from "types/graph";
+import { VertexVisitResult, VertexResultEnum } from "types/graph";
 
 import { resolveFrom, toAddress } from "./utils";
 
@@ -22,7 +22,7 @@ export async function executeSendETH(
     txHash = await services.contracts.sendTx(tx, options);
   } catch (err) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: err as any,
     };
   }
@@ -31,14 +31,15 @@ export async function executeSendETH(
     await services.transactions.wait(txHash);
   } catch {
     return {
-      _kind: "hold",
+      _kind: VertexResultEnum.HOLD,
     };
   }
 
   return {
-    _kind: "success",
+    _kind: VertexResultEnum.SUCCESS,
     result: {
       hash: txHash,
+      value,
     },
   };
 }

--- a/packages/core/src/execution/dispatch/executeSendETH.ts
+++ b/packages/core/src/execution/dispatch/executeSendETH.ts
@@ -1,16 +1,16 @@
 import type { PopulatedTransaction } from "ethers";
 
-import { ExecutionContext } from "types/deployment";
-import { SentETH } from "types/executionGraph";
-import { VertexVisitResult, VertexResultEnum } from "types/graph";
+import type { ExecutionContext } from "types/deployment";
+import type { ExecutionVertexVisitResult, SentETH } from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeSendETH(
   { address, value }: SentETH,
-  resultAccumulator: Map<number, VertexVisitResult | null>,
+  resultAccumulator: Map<number, ExecutionVertexVisitResult | null>,
   { services, options }: ExecutionContext
-): Promise<VertexVisitResult> {
+): Promise<ExecutionVertexVisitResult> {
   const resolve = resolveFrom(resultAccumulator);
 
   const to = toAddress(resolve(address));

--- a/packages/core/src/execution/dispatch/executionDispatch.ts
+++ b/packages/core/src/execution/dispatch/executionDispatch.ts
@@ -1,6 +1,9 @@
-import { ExecutionContext } from "types/deployment";
-import { ExecutionVertex } from "types/executionGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import type { ExecutionContext } from "types/deployment";
+import type {
+  ExecutionResultsAccumulator,
+  ExecutionVertex,
+  ExecutionVertexVisitResult,
+} from "types/executionGraph";
 import { IgnitionError } from "utils/errors";
 
 import { executeAwaitedEvent } from "./executeAwaitedEvent";
@@ -12,9 +15,9 @@ import { executeSendETH } from "./executeSendETH";
 
 export function executionDispatch(
   executionVertex: ExecutionVertex,
-  resultAccumulator: ResultsAccumulator,
+  resultAccumulator: ExecutionResultsAccumulator,
   context: ExecutionContext
-): Promise<VertexVisitResult> {
+): Promise<ExecutionVertexVisitResult> {
   switch (executionVertex.type) {
     case "ContractDeploy":
       return executeContractDeploy(executionVertex, resultAccumulator, context);

--- a/packages/core/src/execution/dispatch/utils.ts
+++ b/packages/core/src/execution/dispatch/utils.ts
@@ -1,5 +1,7 @@
-import { ArgValue } from "types/executionGraph";
-import { ResultsAccumulator } from "types/graph";
+import type {
+  ArgValue,
+  ExecutionResultsAccumulator,
+} from "types/executionGraph";
 import { IgnitionError } from "utils/errors";
 import { isDependable, isEventParam, isProxy } from "utils/guards";
 
@@ -11,11 +13,14 @@ export function toAddress(v: any) {
   return v;
 }
 
-export function resolveFrom(context: ResultsAccumulator) {
+export function resolveFrom(context: ExecutionResultsAccumulator) {
   return (arg: ArgValue) => resolveFromContext(context, arg);
 }
 
-function resolveFromContext(context: ResultsAccumulator, arg: ArgValue): any {
+function resolveFromContext(
+  context: ExecutionResultsAccumulator,
+  arg: ArgValue
+): any {
   if (isProxy(arg)) {
     return resolveFromContext(context, arg.value);
   }

--- a/packages/core/src/execution/dispatch/utils.ts
+++ b/packages/core/src/execution/dispatch/utils.ts
@@ -44,7 +44,7 @@ function resolveFromContext(context: ResultsAccumulator, arg: ArgValue): any {
     );
   }
 
-  if (isEventParam(arg)) {
+  if (isEventParam(arg) && "topics" in entry.result) {
     return entry.result.topics[arg.label];
   }
 

--- a/packages/core/src/execution/execute.ts
+++ b/packages/core/src/execution/execute.ts
@@ -1,14 +1,14 @@
 import type { Deployment } from "deployment/Deployment";
 import { viewExecutionResults } from "deployment/utils";
-import { Services } from "services/types";
+import type { Services } from "services/types";
 import type { ExecutionOptions, ExecutionState } from "types/deployment";
-import { ExecutionVertexDispatcher } from "types/execution";
-import { ExecutionVertex } from "types/executionGraph";
+import type { ExecutionVertexDispatcher } from "types/execution";
 import type {
-  ResultsAccumulator,
-  VertexVisitResult,
-  VisitResult,
-} from "types/graph";
+  ExecutionResultsAccumulator,
+  ExecutionVertexVisitResult,
+  ExecutionVisitResult,
+  ExecutionVertex,
+} from "types/executionGraph";
 import { IgnitionError } from "utils/errors";
 
 import { ExecutionGraph } from "./ExecutionGraph";
@@ -18,7 +18,7 @@ import { allDependenciesCompleted, hashExecutionGraph } from "./utils";
 export async function execute(
   deployment: Deployment,
   options: ExecutionOptions
-): Promise<VisitResult> {
+): Promise<ExecutionVisitResult> {
   if (deployment.state.transform.executionGraph === null) {
     throw new IgnitionError("Cannot execute without an execution graph");
   }
@@ -36,7 +36,7 @@ export async function executeInBatches(
   executionGraph: ExecutionGraph,
   executionVertexDispatcher: ExecutionVertexDispatcher,
   options: ExecutionOptions
-): Promise<VisitResult> {
+): Promise<ExecutionVisitResult> {
   const executionGraphHash = hashExecutionGraph(executionGraph);
 
   await deployment.startExecutionPhase(executionGraphHash, options.force);
@@ -111,10 +111,10 @@ function calculateNextBatch(
 async function executeBatch(
   batch: number[],
   executionGraph: ExecutionGraph,
-  resultsAccumulator: ResultsAccumulator,
+  resultsAccumulator: ExecutionResultsAccumulator,
   deploymentStateUpdate: (
     vertexId: number,
-    result: VertexVisitResult
+    result: ExecutionVertexVisitResult
   ) => Promise<void>,
   { services }: { services: Services },
   executionVertexDispatcher: ExecutionVertexDispatcher,

--- a/packages/core/src/graph/visit.ts
+++ b/packages/core/src/graph/visit.ts
@@ -1,24 +1,24 @@
 import {
   IGraph,
-  ResultsAccumulator,
   VertexVisitResult,
+  ResultsAccumulator,
   VisitResult,
 } from "types/graph";
 import { IgnitionError } from "utils/errors";
 
-export async function visit<T, C>(
+export async function visit<T, C, TResult>(
   phase: "Execution" | "Validation",
   orderedVertexIds: number[],
   graph: IGraph<T>,
   context: C,
-  resultAccumulator: ResultsAccumulator,
+  resultAccumulator: ResultsAccumulator<TResult>,
   vistitorAction: (
     vertex: T,
-    resultAccumulator: ResultsAccumulator,
+    resultAccumulator: ResultsAccumulator<TResult>,
     context: C
-  ) => Promise<VertexVisitResult>,
+  ) => Promise<VertexVisitResult<TResult>>,
   afterAction?: (vertex: T, kind: "success" | "failure", err?: unknown) => void
-): Promise<VisitResult> {
+): Promise<VisitResult<TResult>> {
   for (const vertexId of orderedVertexIds) {
     const vertex = graph.vertexes.get(vertexId);
 

--- a/packages/core/src/graph/visit.ts
+++ b/packages/core/src/graph/visit.ts
@@ -50,7 +50,7 @@ export async function visit<T, C>(
       };
     }
 
-    resultAccumulator.set(vertexId, vertexVisitResult.result);
+    resultAccumulator.set(vertexId, vertexVisitResult);
 
     if (afterAction !== undefined) {
       afterAction(vertex, "success");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,10 +7,11 @@ export { serializeReplacer } from "utils/serialize";
 export { IgnitionError } from "utils/errors";
 export { TransactionsService } from "services/TransactionsService";
 export { ContractsService } from "services/ContractsService";
+export { VertexResultEnum } from "types/graph";
 
 export type {
   SerializedDeploymentResult,
-  SerializedFutureResult,
+  ContractInfo,
 } from "types/serialization";
 export type { Services } from "services/types";
 export type {
@@ -24,9 +25,8 @@ export type {
   DeploymentResult,
   UpdateUiAction,
 } from "types/deployment";
-export type { Module, ModuleDict, ModuleParams } from "types/module";
+export type { Module, ModuleDict, ModuleParams, Subgraph } from "types/module";
 export type {
-  Subgraph,
   ExternalParamValue,
   IDeploymentBuilder,
 } from "types/deploymentGraph";

--- a/packages/core/src/process/generateDeploymentGraphFrom.ts
+++ b/packages/core/src/process/generateDeploymentGraphFrom.ts
@@ -3,14 +3,14 @@ import type {
   DeploymentBuilderOptions,
   IDeploymentGraph,
 } from "types/deploymentGraph";
-import { FutureDict } from "types/future";
 import { Module, ModuleDict } from "types/module";
 import { IgnitionError } from "utils/errors";
+import { assertModuleReturnTypes } from "utils/guards";
 
 export function generateDeploymentGraphFrom<T extends ModuleDict>(
   ignitionModule: Module<T>,
   builderOptions: DeploymentBuilderOptions
-): { graph: IDeploymentGraph; moduleOutputs: FutureDict } {
+): { graph: IDeploymentGraph; moduleOutputs: T } {
   const graphBuilder = new DeploymentBuilder(builderOptions);
 
   const moduleOutputs = ignitionModule.action(graphBuilder);
@@ -20,6 +20,8 @@ export function generateDeploymentGraphFrom<T extends ModuleDict>(
       `The callback passed to 'buildModule' for ${ignitionModule.name} returns a Promise; async callbacks are not allowed in 'buildModule'.`
     );
   }
+
+  assertModuleReturnTypes(moduleOutputs);
 
   return { graph: graphBuilder.graph, moduleOutputs };
 }

--- a/packages/core/src/types/deployment.ts
+++ b/packages/core/src/types/deployment.ts
@@ -10,27 +10,16 @@ import {
   VertexVisitResultFailure,
   VertexVisitResultSuccess,
 } from "./graph";
-import { ModuleParams } from "./module";
-import {
-  SerializedDeploymentResult,
-  SerializedFutureResult,
-} from "./serialization";
+import { ModuleDict, ModuleParams } from "./module";
+import { SerializedDeploymentResult } from "./serialization";
 
 export type UpdateUiAction = (deployState: DeployState) => void;
 export type UiParamsClosure = (moduleParams?: ModuleParams) => UpdateUiAction;
 
-export interface IgnitionModuleResults {
-  load: (moduleId: string) => Promise<SerializedFutureResult | undefined>;
-  save: (
-    moduleId: string,
-    moduleResult: SerializedFutureResult
-  ) => Promise<void>;
-}
-
-export type DeploymentResult =
+export type DeploymentResult<T extends ModuleDict = ModuleDict> =
   | { _kind: "failure"; failures: [string, Error[]] }
   | { _kind: "hold"; holds: VertexDescriptor[] }
-  | { _kind: "success"; result: SerializedDeploymentResult };
+  | { _kind: "success"; result: SerializedDeploymentResult<T> };
 
 export type DeployPhase =
   | "uninitialized"

--- a/packages/core/src/types/deployment.ts
+++ b/packages/core/src/types/deployment.ts
@@ -1,17 +1,20 @@
 import type { BigNumber } from "ethers";
 
-import { Services } from "services/types";
+import type { Services } from "services/types";
 
-import { ExecutionVertex } from "./executionGraph";
-import {
+import type {
+  ExecutionVertex,
+  ExecutionVertexVisitResult,
+  VertexVisitResultSuccessResult,
+} from "./executionGraph";
+import type {
   IGraph,
   VertexDescriptor,
-  VertexVisitResult,
   VertexVisitResultFailure,
   VertexVisitResultSuccess,
 } from "./graph";
-import { ModuleDict, ModuleParams } from "./module";
-import { SerializedDeploymentResult } from "./serialization";
+import type { ModuleDict, ModuleParams } from "./module";
+import type { SerializedDeploymentResult } from "./serialization";
 
 export type UpdateUiAction = (deployState: DeployState) => void;
 export type UiParamsClosure = (moduleParams?: ModuleParams) => UpdateUiAction;
@@ -45,7 +48,7 @@ export type DeployStateExecutionCommand =
   | {
       type: "EXECUTION::SET_VERTEX_RESULT";
       vertexId: number;
-      result: VertexVisitResult;
+      result: ExecutionVertexVisitResult;
     };
 
 export type DeployStateCommand =
@@ -100,7 +103,7 @@ export interface VertexExecutionStateUnstarted {
 
 export interface VertexExecutionStateCompleted {
   status: VertexExecutionStatusCompleted;
-  result: VertexVisitResultSuccess;
+  result: VertexVisitResultSuccess<VertexVisitResultSuccessResult>;
 }
 
 export interface VertexExecutionStateFailed {

--- a/packages/core/src/types/deploymentGraph.ts
+++ b/packages/core/src/types/deploymentGraph.ts
@@ -189,11 +189,12 @@ export interface IDeploymentBuilder {
     options?: { after?: DeploymentGraphFuture[] }
   ): DeployedContract;
 
+  library(contractName: string, options?: ContractOptions): HardhatLibrary;
   library(
     contractName: string,
-    artifactOrOptions?: Artifact | ContractOptions,
+    artifact: Artifact,
     options?: ContractOptions
-  ): HardhatLibrary | ArtifactLibrary;
+  ): ArtifactLibrary;
 
   call(
     contractFuture: DeploymentGraphFuture,

--- a/packages/core/src/types/deploymentGraph.ts
+++ b/packages/core/src/types/deploymentGraph.ts
@@ -175,56 +175,58 @@ export interface IDeploymentBuilder {
   chainId: number;
   graph: IDeploymentGraph;
 
-  contract: (
+  contract(contractName: string, options?: ContractOptions): HardhatContract;
+  contract(
     contractName: string,
-    artifactOrOptions?: Artifact | ContractOptions,
+    artifact: Artifact,
     options?: ContractOptions
-  ) => HardhatContract | ArtifactContract;
+  ): ArtifactContract;
 
-  contractAt: (
+  contractAt(
     contractName: string,
     address: string | EventParamFuture,
     abi: any[],
     options?: { after?: DeploymentGraphFuture[] }
-  ) => DeployedContract;
+  ): DeployedContract;
 
-  library: (
+  library(
     contractName: string,
     artifactOrOptions?: Artifact | ContractOptions,
     options?: ContractOptions
-  ) => HardhatLibrary | ArtifactLibrary;
+  ): HardhatLibrary | ArtifactLibrary;
 
-  call: (
+  call(
     contractFuture: DeploymentGraphFuture,
     functionName: string,
     options: CallOptions
-  ) => ContractCall;
+  ): ContractCall;
 
-  event: (
+  event(
     contractFuture: ArtifactFuture,
     eventName: string,
     options: AwaitOptions
-  ) => EventFuture;
+  ): EventFuture;
 
-  sendETH: (sendTo: AddressResolvable, options: SendOptions) => SendFuture;
+  sendETH(sendTo: AddressResolvable, options: SendOptions): SendFuture;
 
-  getParam: (paramName: string) => RequiredParameter;
+  getParam(paramName: string): RequiredParameter;
 
-  getOptionalParam: (
+  getOptionalParam(
     paramName: string,
     defaultValue: ParameterValue
-  ) => OptionalParameter;
+  ): OptionalParameter;
 
-  getBytesForArtifact: (artifactName: string) => BytesFuture;
+  getBytesForArtifact(artifactName: string): BytesFuture;
 
-  useSubgraph: <T extends FutureDict>(
+  useSubgraph<T extends FutureDict>(
     subgraph: Subgraph<T>,
     options?: UseSubgraphOptions
-  ) => Virtual & T;
-  useModule: <T extends ModuleDict>(
+  ): Virtual & T;
+
+  useModule<T extends ModuleDict>(
     module: Subgraph<T>,
     options?: UseSubgraphOptions
-  ) => Virtual & T;
+  ): Virtual & T;
 }
 
 export interface Subgraph<T extends FutureDict> {

--- a/packages/core/src/types/deploymentGraph.ts
+++ b/packages/core/src/types/deploymentGraph.ts
@@ -24,7 +24,7 @@ import {
 } from "./future";
 import { AdjacencyList, VertexDescriptor } from "./graph";
 import { Artifact } from "./hardhat";
-import { ModuleDict } from "./module";
+import { ModuleDict, Subgraph } from "./module";
 
 export interface ScopeData {
   before: Virtual;
@@ -227,11 +227,6 @@ export interface IDeploymentBuilder {
     module: Subgraph<T>,
     options?: UseSubgraphOptions
   ): Virtual & T;
-}
-
-export interface Subgraph<T extends FutureDict> {
-  name: string;
-  action: (builder: IDeploymentBuilder) => T;
 }
 
 export interface DeploymentBuilderOptions {

--- a/packages/core/src/types/execution.ts
+++ b/packages/core/src/types/execution.ts
@@ -1,11 +1,14 @@
-import { ExecutionContext } from "./deployment";
-import { ExecutionVertex } from "./executionGraph";
-import { ResultsAccumulator, VertexVisitResult } from "./graph";
+import type { ExecutionContext } from "./deployment";
+import type {
+  ExecutionResultsAccumulator,
+  ExecutionVertex,
+  ExecutionVertexVisitResult,
+} from "./executionGraph";
 
 export type BatcherResult =
   | {
       _kind: "success";
-      context: Map<number, VertexVisitResult>;
+      context: Map<number, ExecutionVertexVisitResult>;
     }
   | {
       _kind: "failure";
@@ -14,6 +17,6 @@ export type BatcherResult =
 
 export type ExecutionVertexDispatcher = (
   vertex: ExecutionVertex,
-  resultAccumulator: ResultsAccumulator,
+  resultAccumulator: ExecutionResultsAccumulator,
   context: ExecutionContext
-) => Promise<VertexVisitResult>;
+) => Promise<ExecutionVertexVisitResult>;

--- a/packages/core/src/types/executionGraph.ts
+++ b/packages/core/src/types/executionGraph.ts
@@ -1,4 +1,4 @@
-import type { BigNumber } from "ethers";
+import type { BigNumber, ethers } from "ethers";
 
 import { LibraryMap } from "./deploymentGraph";
 import {
@@ -7,7 +7,13 @@ import {
   DeploymentGraphFuture,
   EventParamFuture,
 } from "./future";
-import { AdjacencyList, VertexDescriptor } from "./graph";
+import {
+  AdjacencyList,
+  ResultsAccumulator,
+  VertexDescriptor,
+  VertexVisitResult,
+  VisitResult,
+} from "./graph";
 import { Artifact } from "./hardhat";
 
 export interface IExecutionGraph {
@@ -80,3 +86,53 @@ export interface SentETH extends VertexDescriptor {
   address: AddressResolvable;
   value: BigNumber;
 }
+
+export interface ContractDeploySuccess {
+  name: string;
+  abi: any[];
+  bytecode: string;
+  address: string;
+  value: ethers.BigNumber;
+}
+
+export interface DeployedContractSuccess {
+  name: string;
+  abi: any[];
+  address: string;
+}
+
+export interface LibraryDeploySuccess {
+  name: string;
+  abi: any[];
+  bytecode: string;
+  address: string;
+}
+
+export interface AwaitedEventSuccess {
+  topics: ethers.utils.Result;
+}
+
+export interface ContractCallSuccess {
+  hash: string;
+}
+
+export interface SendETHSuccess {
+  hash: string;
+  value: ethers.BigNumber;
+}
+
+export type VertexVisitResultSuccessResult =
+  | ContractDeploySuccess
+  | DeployedContractSuccess
+  | LibraryDeploySuccess
+  | AwaitedEventSuccess
+  | ContractCallSuccess
+  | SendETHSuccess;
+
+export type ExecutionVertexVisitResult =
+  VertexVisitResult<VertexVisitResultSuccessResult>;
+
+export type ExecutionResultsAccumulator =
+  ResultsAccumulator<VertexVisitResultSuccessResult>;
+
+export type ExecutionVisitResult = VisitResult<VertexVisitResultSuccessResult>;

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -1,4 +1,4 @@
-import { Artifact } from "./hardhat";
+import type { Artifact } from "./hardhat";
 
 export interface HardhatContract {
   vertexId: number;

--- a/packages/core/src/types/graph.ts
+++ b/packages/core/src/types/graph.ts
@@ -1,3 +1,5 @@
+import { ethers } from "ethers";
+
 export interface VertexDescriptor {
   id: number;
   label: string;
@@ -15,18 +17,77 @@ export interface IGraph<T> {
 
 export type VertexGraph = IGraph<VertexDescriptor>;
 
-export interface VertexVisitResultSuccess {
-  _kind: "success";
-  result: any;
+export enum VertexResultEnum {
+  SUCCESS = "success",
+  FAILURE = "failure",
+  HOLD = "hold",
 }
 
+export interface VertexVisitSuccess {
+  _kind: VertexResultEnum.SUCCESS;
+}
+
+export interface ContractDeploySuccess extends VertexVisitSuccess {
+  result: {
+    name: string;
+    abi: any[];
+    bytecode: string;
+    address: string;
+    value: ethers.BigNumber;
+  };
+}
+
+export interface DeployedContractSuccess extends VertexVisitSuccess {
+  result: {
+    name: string;
+    abi: any[];
+    address: string;
+  };
+}
+
+export interface LibraryDeploySuccess extends VertexVisitSuccess {
+  result: {
+    name: string;
+    abi: any[];
+    bytecode: string;
+    address: string;
+  };
+}
+
+export interface AwaitedEventSuccess extends VertexVisitSuccess {
+  result: {
+    topics: ethers.utils.Result;
+  };
+}
+
+export interface ContractCallSuccess extends VertexVisitSuccess {
+  result: {
+    hash: string;
+  };
+}
+
+export interface SendETHSuccess extends VertexVisitSuccess {
+  result: {
+    hash: string;
+    value: ethers.BigNumber;
+  };
+}
+
+export type VertexVisitResultSuccess =
+  | ContractDeploySuccess
+  | DeployedContractSuccess
+  | LibraryDeploySuccess
+  | AwaitedEventSuccess
+  | ContractCallSuccess
+  | SendETHSuccess;
+
 export interface VertexVisitResultFailure {
-  _kind: "failure";
+  _kind: VertexResultEnum.FAILURE;
   failure: Error;
 }
 
 export interface VertexVisitResultHold {
-  _kind: "hold";
+  _kind: VertexResultEnum.HOLD;
 }
 
 export type VertexVisitResult =

--- a/packages/core/src/types/graph.ts
+++ b/packages/core/src/types/graph.ts
@@ -1,5 +1,3 @@
-import { ethers } from "ethers";
-
 export interface VertexDescriptor {
   id: number;
   label: string;
@@ -23,63 +21,10 @@ export enum VertexResultEnum {
   HOLD = "hold",
 }
 
-export interface VertexVisitSuccess {
+export interface VertexVisitResultSuccess<T> {
   _kind: VertexResultEnum.SUCCESS;
+  result: T;
 }
-
-export interface ContractDeploySuccess extends VertexVisitSuccess {
-  result: {
-    name: string;
-    abi: any[];
-    bytecode: string;
-    address: string;
-    value: ethers.BigNumber;
-  };
-}
-
-export interface DeployedContractSuccess extends VertexVisitSuccess {
-  result: {
-    name: string;
-    abi: any[];
-    address: string;
-  };
-}
-
-export interface LibraryDeploySuccess extends VertexVisitSuccess {
-  result: {
-    name: string;
-    abi: any[];
-    bytecode: string;
-    address: string;
-  };
-}
-
-export interface AwaitedEventSuccess extends VertexVisitSuccess {
-  result: {
-    topics: ethers.utils.Result;
-  };
-}
-
-export interface ContractCallSuccess extends VertexVisitSuccess {
-  result: {
-    hash: string;
-  };
-}
-
-export interface SendETHSuccess extends VertexVisitSuccess {
-  result: {
-    hash: string;
-    value: ethers.BigNumber;
-  };
-}
-
-export type VertexVisitResultSuccess =
-  | ContractDeploySuccess
-  | DeployedContractSuccess
-  | LibraryDeploySuccess
-  | AwaitedEventSuccess
-  | ContractCallSuccess
-  | SendETHSuccess;
 
 export interface VertexVisitResultFailure {
   _kind: VertexResultEnum.FAILURE;
@@ -90,15 +35,15 @@ export interface VertexVisitResultHold {
   _kind: VertexResultEnum.HOLD;
 }
 
-export type VertexVisitResult =
-  | VertexVisitResultSuccess
+export type VertexVisitResult<T> =
+  | VertexVisitResultSuccess<T>
   | VertexVisitResultFailure
   | VertexVisitResultHold;
 
-export type VisitResult =
+export type VisitResult<T> =
   | {
       _kind: "success";
-      result: ResultsAccumulator;
+      result: ResultsAccumulator<T>;
     }
   | {
       _kind: "failure";
@@ -109,4 +54,4 @@ export type VisitResult =
       holds: VertexDescriptor[];
     };
 
-export type ResultsAccumulator = Map<number, VertexVisitResult | null>;
+export type ResultsAccumulator<T> = Map<number, VertexVisitResult<T> | null>;

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -2,11 +2,16 @@ import type { ExternalParamValue, IDeploymentBuilder } from "./deploymentGraph";
 import type {
   ContractFuture,
   FutureDict,
+  LibraryFuture,
   ProxyFuture,
   Virtual,
 } from "./future";
 
-export type ModuleReturnValue = ContractFuture | Virtual | ProxyFuture;
+export type ModuleReturnValue =
+  | ContractFuture
+  | LibraryFuture
+  | Virtual
+  | ProxyFuture;
 
 export interface ModuleDict {
   [key: string]: ModuleReturnValue;

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -1,17 +1,23 @@
-import type { ExternalParamValue, Subgraph } from "./deploymentGraph";
+import type { ExternalParamValue, IDeploymentBuilder } from "./deploymentGraph";
 import type {
-  CallableFuture,
-  EventFuture,
+  ContractFuture,
   FutureDict,
   ProxyFuture,
   Virtual,
 } from "./future";
 
-export interface ModuleDict extends FutureDict {
-  [key: string]: CallableFuture | Virtual | ProxyFuture | EventFuture;
+export type ModuleReturnValue = ContractFuture | Virtual | ProxyFuture;
+
+export interface ModuleDict {
+  [key: string]: ModuleReturnValue;
 }
 
 export type Module<T extends ModuleDict> = Subgraph<T>;
+
+export interface Subgraph<T extends FutureDict> {
+  name: string;
+  action: (builder: IDeploymentBuilder) => T;
+}
 
 export interface ModuleData {
   result: Virtual & ModuleDict;

--- a/packages/core/src/types/serialization.ts
+++ b/packages/core/src/types/serialization.ts
@@ -1,28 +1,11 @@
-import type { ethers } from "ethers";
+import type { ModuleDict } from "./module";
 
-export type SerializedFutureResult =
-  | { _kind: "string"; value: string }
-  | { _kind: "number"; value: number }
-  | { _kind: "contract"; value: Contract }
-  | { _kind: "tx"; value: Tx }
-  | { _kind: "event"; value: Event };
-
-export interface SerializedDeploymentResult {
-  [key: string]: SerializedFutureResult;
-}
-
-export type FutureOutput = string | number | Contract | Tx | Event;
-
-export interface Contract {
+export interface ContractInfo {
   name: string;
   address: string;
   abi: any[];
 }
 
-export interface Tx {
-  hash: string;
-}
-
-export interface Event {
-  topics: ethers.utils.Result;
-}
+export type SerializedDeploymentResult<T extends ModuleDict> = {
+  [K in keyof T]: ContractInfo;
+};

--- a/packages/core/src/types/validation.ts
+++ b/packages/core/src/types/validation.ts
@@ -1,0 +1,7 @@
+import { ResultsAccumulator, VertexVisitResult, VisitResult } from "./graph";
+
+export type ValidationVisitResult = VisitResult<undefined>;
+
+export type ValidationVertexVisitResult = VertexVisitResult<undefined>;
+
+export type ValidationResultsAccumulator = ResultsAccumulator<undefined>;

--- a/packages/core/src/utils/guards.ts
+++ b/packages/core/src/utils/guards.ts
@@ -147,9 +147,19 @@ export function isContract(
   return future.type === "contract";
 }
 
+export function isLibrary(
+  future: DeploymentGraphFuture
+): future is ContractFuture {
+  if (isProxy(future)) {
+    return isLibrary(future.value);
+  }
+
+  return future.type === "library";
+}
+
 export function assertModuleReturnTypes<T extends ModuleDict>(moduleResult: T) {
   for (const future of Object.values(moduleResult)) {
-    if (isContract(future)) {
+    if (isContract(future) || isLibrary(future)) {
       continue;
     }
 

--- a/packages/core/src/utils/guards.ts
+++ b/packages/core/src/utils/guards.ts
@@ -24,6 +24,7 @@ import type {
   ContractFuture,
 } from "types/future";
 import { Artifact } from "types/hardhat";
+import { ModuleDict } from "types/module";
 
 import { IgnitionError } from "./errors";
 
@@ -144,6 +145,18 @@ export function isContract(
   }
 
   return future.type === "contract";
+}
+
+export function assertModuleReturnTypes<T extends ModuleDict>(moduleResult: T) {
+  for (const future of Object.values(moduleResult)) {
+    if (isContract(future)) {
+      continue;
+    }
+
+    throw new IgnitionError(
+      `Cannot return Future of type "${future.type}" from a module`
+    );
+  }
 }
 
 export function assertUnknownDeploymentVertexType(

--- a/packages/core/src/utils/serialize.ts
+++ b/packages/core/src/utils/serialize.ts
@@ -1,42 +1,5 @@
 import { serializeError } from "serialize-error";
 
-import { FutureOutput, SerializedFutureResult } from "types/serialization";
-
-import { IgnitionError } from "./errors";
-
-export function serializeFutureOutput(x: FutureOutput): SerializedFutureResult {
-  if (typeof x === "string") {
-    return { _kind: "string" as const, value: x };
-  } else if (typeof x === "number") {
-    return { _kind: "number" as const, value: x };
-  } else if ("address" in x) {
-    return { _kind: "contract" as const, value: x };
-  } else if ("hash" in x) {
-    return { _kind: "tx" as const, value: x };
-  } else if ("topics" in x) {
-    return { _kind: "event" as const, value: x };
-  }
-
-  const exhaustiveCheck: never = x;
-  throw new IgnitionError(`Unexpected serialization type ${exhaustiveCheck}`);
-}
-
-export function deserializeFutureOutput(x: any) {
-  if (x === null || x === undefined) {
-    throw new IgnitionError(
-      "[deserializeFutureOutput] value is null or undefined"
-    );
-  }
-
-  if (!("_kind" in x)) {
-    throw new IgnitionError(
-      "[deserializeFutureOutput] value was not serialized by Ignition"
-    );
-  }
-
-  return x.value;
-}
-
 /**
  * When stringifying core state, use this as the replacer.
  */

--- a/packages/core/src/validation/dispatch/helpers.ts
+++ b/packages/core/src/validation/dispatch/helpers.ts
@@ -1,7 +1,7 @@
 import type { Services } from "services/types";
 import { InternalParamValue } from "types/deploymentGraph";
 import type { CallableFuture } from "types/future";
-import { VertexVisitResultFailure } from "types/graph";
+import { VertexResultEnum, VertexVisitResultFailure } from "types/graph";
 import { IgnitionError, InvalidArtifactError } from "utils/errors";
 import { isBytesArg } from "utils/guards";
 import { resolveProxyValue } from "utils/proxy";
@@ -69,7 +69,7 @@ export async function validateBytesForArtifact(
   }
 
   return {
-    _kind: "failure",
+    _kind: VertexResultEnum.FAILURE,
     failure: new InvalidArtifactError(bytesArgs[bytesDoesNotExistIndex].label),
   };
 }

--- a/packages/core/src/validation/dispatch/validateArtifactContract.ts
+++ b/packages/core/src/validation/dispatch/validateArtifactContract.ts
@@ -58,6 +58,6 @@ export async function validateArtifactContract(
 
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateArtifactContract.ts
+++ b/packages/core/src/validation/dispatch/validateArtifactContract.ts
@@ -2,7 +2,11 @@ import { ethers, BigNumber } from "ethers";
 
 import { Services } from "services/types";
 import { ArtifactContractDeploymentVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
 import { IgnitionError, InvalidArtifactError } from "utils/errors";
 import { isArtifact, isParameter } from "utils/guards";
 
@@ -15,7 +19,7 @@ export async function validateArtifactContract(
 ): Promise<VertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: new IgnitionError(`For contract 'value' must be a BigNumber`),
     };
   }
@@ -33,7 +37,7 @@ export async function validateArtifactContract(
 
   if (!artifactExists) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: new InvalidArtifactError(vertex.label),
     };
   }
@@ -45,15 +49,15 @@ export async function validateArtifactContract(
 
   if (argsLength !== expectedArgsLength) {
     return {
-      _kind: "failure",
-      failure: new Error(
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(
         `The constructor of the contract '${vertex.label}' expects ${expectedArgsLength} arguments but ${argsLength} were given`
       ),
     };
   }
 
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateArtifactContract.ts
+++ b/packages/core/src/validation/dispatch/validateArtifactContract.ts
@@ -2,11 +2,11 @@ import { ethers, BigNumber } from "ethers";
 
 import { Services } from "services/types";
 import { ArtifactContractDeploymentVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { IgnitionError, InvalidArtifactError } from "utils/errors";
 import { isArtifact, isParameter } from "utils/guards";
 
@@ -14,9 +14,9 @@ import { validateBytesForArtifact } from "./helpers";
 
 export async function validateArtifactContract(
   vertex: ArtifactContractDeploymentVertex,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ValidationResultsAccumulator,
   _context: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
       _kind: VertexResultEnum.FAILURE,

--- a/packages/core/src/validation/dispatch/validateArtifactLibrary.ts
+++ b/packages/core/src/validation/dispatch/validateArtifactLibrary.ts
@@ -2,7 +2,12 @@ import { ethers } from "ethers";
 
 import { Services } from "services/types";
 import { ArtifactLibraryDeploymentVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
+import { IgnitionError } from "utils/errors";
 import { isArtifact } from "utils/guards";
 
 import { validateBytesForArtifact } from "./helpers";
@@ -25,8 +30,10 @@ export async function validateArtifactLibrary(
 
   if (!artifactExists) {
     return {
-      _kind: "failure",
-      failure: new Error(`Artifact not provided for library '${vertex.label}'`),
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(
+        `Artifact not provided for library '${vertex.label}'`
+      ),
     };
   }
 
@@ -37,15 +44,15 @@ export async function validateArtifactLibrary(
 
   if (argsLength !== expectedArgsLength) {
     return {
-      _kind: "failure",
-      failure: new Error(
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(
         `The constructor of the library '${vertex.label}' expects ${expectedArgsLength} arguments but ${argsLength} were given`
       ),
     };
   }
 
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateArtifactLibrary.ts
+++ b/packages/core/src/validation/dispatch/validateArtifactLibrary.ts
@@ -2,11 +2,11 @@ import { ethers } from "ethers";
 
 import { Services } from "services/types";
 import { ArtifactLibraryDeploymentVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { IgnitionError } from "utils/errors";
 import { isArtifact } from "utils/guards";
 
@@ -14,9 +14,9 @@ import { validateBytesForArtifact } from "./helpers";
 
 export async function validateArtifactLibrary(
   vertex: ArtifactLibraryDeploymentVertex,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ValidationResultsAccumulator,
   _context: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   const invalidBytes = await validateBytesForArtifact(
     vertex.args,
     _context.services

--- a/packages/core/src/validation/dispatch/validateArtifactLibrary.ts
+++ b/packages/core/src/validation/dispatch/validateArtifactLibrary.ts
@@ -53,6 +53,6 @@ export async function validateArtifactLibrary(
 
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateCall.ts
+++ b/packages/core/src/validation/dispatch/validateCall.ts
@@ -2,11 +2,11 @@ import { ethers, BigNumber } from "ethers";
 
 import { Services } from "services/types";
 import { CallDeploymentVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { IgnitionError, InvalidArtifactError } from "utils/errors";
 import { isParameter } from "utils/guards";
 
@@ -17,9 +17,9 @@ import {
 
 export async function validateCall(
   vertex: CallDeploymentVertex,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ValidationResultsAccumulator,
   context: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
       _kind: VertexResultEnum.FAILURE,

--- a/packages/core/src/validation/dispatch/validateCall.ts
+++ b/packages/core/src/validation/dispatch/validateCall.ts
@@ -95,6 +95,6 @@ export async function validateCall(
 
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateCall.ts
+++ b/packages/core/src/validation/dispatch/validateCall.ts
@@ -2,7 +2,11 @@ import { ethers, BigNumber } from "ethers";
 
 import { Services } from "services/types";
 import { CallDeploymentVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
 import { IgnitionError, InvalidArtifactError } from "utils/errors";
 import { isParameter } from "utils/guards";
 
@@ -18,7 +22,7 @@ export async function validateCall(
 ): Promise<VertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: new IgnitionError(`For call 'value' must be a BigNumber`),
     };
   }
@@ -41,7 +45,7 @@ export async function validateCall(
 
   if (artifactAbi === undefined) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: new InvalidArtifactError(contractName),
     };
   }
@@ -60,8 +64,8 @@ export async function validateCall(
 
   if (functionFragments.length === 0) {
     return {
-      _kind: "failure",
-      failure: new Error(
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(
         `Contract '${contractName}' doesn't have a function ${vertex.method}`
       ),
     };
@@ -74,15 +78,15 @@ export async function validateCall(
   if (matchingFunctionFragments.length === 0) {
     if (functionFragments.length === 1) {
       return {
-        _kind: "failure",
-        failure: new Error(
+        _kind: VertexResultEnum.FAILURE,
+        failure: new IgnitionError(
           `Function ${vertex.method} in contract ${contractName} expects ${functionFragments[0].inputs.length} arguments but ${argsLength} were given`
         ),
       };
     } else {
       return {
-        _kind: "failure",
-        failure: new Error(
+        _kind: VertexResultEnum.FAILURE,
+        failure: new IgnitionError(
           `Function ${vertex.method} in contract ${contractName} is overloaded, but no overload expects ${argsLength} arguments`
         ),
       };
@@ -90,7 +94,7 @@ export async function validateCall(
   }
 
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateDeployedContract.ts
+++ b/packages/core/src/validation/dispatch/validateDeployedContract.ts
@@ -25,6 +25,6 @@ export async function validateDeployedContract(
 
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateDeployedContract.ts
+++ b/packages/core/src/validation/dispatch/validateDeployedContract.ts
@@ -2,7 +2,12 @@ import { isAddress } from "@ethersproject/address";
 
 import { Services } from "services/types";
 import { DeployedContractDeploymentVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
+import { IgnitionError } from "utils/errors";
 
 export async function validateDeployedContract(
   vertex: DeployedContractDeploymentVertex,
@@ -11,15 +16,15 @@ export async function validateDeployedContract(
 ): Promise<VertexVisitResult> {
   if (typeof vertex.address === "string" && !isAddress(vertex.address)) {
     return {
-      _kind: "failure",
-      failure: new Error(
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(
         `The existing contract ${vertex.label} has an invalid address ${vertex.address}`
       ),
     };
   }
 
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateDeployedContract.ts
+++ b/packages/core/src/validation/dispatch/validateDeployedContract.ts
@@ -2,18 +2,18 @@ import { isAddress } from "@ethersproject/address";
 
 import { Services } from "services/types";
 import { DeployedContractDeploymentVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { IgnitionError } from "utils/errors";
 
 export async function validateDeployedContract(
   vertex: DeployedContractDeploymentVertex,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ValidationResultsAccumulator,
   _context: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   if (typeof vertex.address === "string" && !isAddress(vertex.address)) {
     return {
       _kind: VertexResultEnum.FAILURE,

--- a/packages/core/src/validation/dispatch/validateEvent.ts
+++ b/packages/core/src/validation/dispatch/validateEvent.ts
@@ -103,6 +103,6 @@ export async function validateEvent(
 
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateEvent.ts
+++ b/packages/core/src/validation/dispatch/validateEvent.ts
@@ -2,11 +2,11 @@ import { ethers } from "ethers";
 
 import { Services } from "services/types";
 import { EventVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { IgnitionError } from "utils/errors";
 
 import {
@@ -16,9 +16,9 @@ import {
 
 export async function validateEvent(
   vertex: EventVertex,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ValidationResultsAccumulator,
   context: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   const invalidBytes = await validateBytesForArtifact(
     vertex.args,
     context.services

--- a/packages/core/src/validation/dispatch/validateEvent.ts
+++ b/packages/core/src/validation/dispatch/validateEvent.ts
@@ -2,7 +2,12 @@ import { ethers } from "ethers";
 
 import { Services } from "services/types";
 import { EventVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
+import { IgnitionError } from "utils/errors";
 
 import {
   resolveArtifactForCallableFuture,
@@ -27,8 +32,8 @@ export async function validateEvent(
   if (typeof vertex.address === "string") {
     if (!ethers.utils.isAddress(vertex.address)) {
       return {
-        _kind: "failure",
-        failure: new Error(`Invalid address ${vertex.address}`),
+        _kind: VertexResultEnum.FAILURE,
+        failure: new IgnitionError(`Invalid address ${vertex.address}`),
       };
     }
 
@@ -41,8 +46,8 @@ export async function validateEvent(
 
     if (artifactAbi === undefined) {
       return {
-        _kind: "failure",
-        failure: new Error(
+        _kind: VertexResultEnum.FAILURE,
+        failure: new IgnitionError(
           `Artifact with name '${vertex.address.label}' doesn't exist`
         ),
       };
@@ -65,8 +70,8 @@ export async function validateEvent(
     const contractName = vertex.label.split("/")[0];
 
     return {
-      _kind: "failure",
-      failure: new Error(
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(
         `Contract '${contractName}' doesn't have an event ${vertex.event}`
       ),
     };
@@ -81,15 +86,15 @@ export async function validateEvent(
       const contractName = vertex.label.split("/")[0];
 
       return {
-        _kind: "failure",
-        failure: new Error(
+        _kind: VertexResultEnum.FAILURE,
+        failure: new IgnitionError(
           `Event ${vertex.event} in contract ${contractName} expects ${eventFragments[0].inputs.length} arguments but ${argsLength} were given`
         ),
       };
     } else {
       return {
-        _kind: "failure",
-        failure: new Error(
+        _kind: VertexResultEnum.FAILURE,
+        failure: new IgnitionError(
           `Event ${vertex.event} in contract is overloaded, but no overload expects ${argsLength} arguments`
         ),
       };
@@ -97,7 +102,7 @@ export async function validateEvent(
   }
 
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateHardhatContract.ts
+++ b/packages/core/src/validation/dispatch/validateHardhatContract.ts
@@ -2,11 +2,11 @@ import { ethers, BigNumber } from "ethers";
 
 import { Services } from "services/types";
 import { HardhatContractDeploymentVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { IgnitionError, InvalidArtifactError } from "utils/errors";
 import { isParameter } from "utils/guards";
 
@@ -14,9 +14,9 @@ import { validateBytesForArtifact } from "./helpers";
 
 export async function validateHardhatContract(
   vertex: HardhatContractDeploymentVertex,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ValidationResultsAccumulator,
   { services }: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
       _kind: VertexResultEnum.FAILURE,

--- a/packages/core/src/validation/dispatch/validateHardhatContract.ts
+++ b/packages/core/src/validation/dispatch/validateHardhatContract.ts
@@ -58,6 +58,6 @@ export async function validateHardhatContract(
 
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateHardhatContract.ts
+++ b/packages/core/src/validation/dispatch/validateHardhatContract.ts
@@ -2,7 +2,11 @@ import { ethers, BigNumber } from "ethers";
 
 import { Services } from "services/types";
 import { HardhatContractDeploymentVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
 import { IgnitionError, InvalidArtifactError } from "utils/errors";
 import { isParameter } from "utils/guards";
 
@@ -15,7 +19,7 @@ export async function validateHardhatContract(
 ): Promise<VertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: new IgnitionError(`For contract 'value' must be a BigNumber`),
     };
   }
@@ -32,7 +36,7 @@ export async function validateHardhatContract(
 
   if (!artifactExists) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: new InvalidArtifactError(vertex.contractName),
     };
   }
@@ -45,15 +49,15 @@ export async function validateHardhatContract(
 
   if (argsLength !== expectedArgsLength) {
     return {
-      _kind: "failure",
-      failure: new Error(
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(
         `The constructor of the contract '${vertex.contractName}' expects ${expectedArgsLength} arguments but ${argsLength} were given`
       ),
     };
   }
 
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateHardhatLibrary.ts
+++ b/packages/core/src/validation/dispatch/validateHardhatLibrary.ts
@@ -50,6 +50,6 @@ export async function validateHardhatLibrary(
 
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateHardhatLibrary.ts
+++ b/packages/core/src/validation/dispatch/validateHardhatLibrary.ts
@@ -2,20 +2,20 @@ import { ethers } from "ethers";
 
 import { Services } from "services/types";
 import { HardhatLibraryDeploymentVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { IgnitionError, InvalidArtifactError } from "utils/errors";
 
 import { validateBytesForArtifact } from "./helpers";
 
 export async function validateHardhatLibrary(
   vertex: HardhatLibraryDeploymentVertex,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ValidationResultsAccumulator,
   { services }: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   const invalidBytes = await validateBytesForArtifact(vertex.args, services);
 
   if (invalidBytes !== null) {

--- a/packages/core/src/validation/dispatch/validateHardhatLibrary.ts
+++ b/packages/core/src/validation/dispatch/validateHardhatLibrary.ts
@@ -2,8 +2,12 @@ import { ethers } from "ethers";
 
 import { Services } from "services/types";
 import { HardhatLibraryDeploymentVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
-import { InvalidArtifactError } from "utils/errors";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
+import { IgnitionError, InvalidArtifactError } from "utils/errors";
 
 import { validateBytesForArtifact } from "./helpers";
 
@@ -24,7 +28,7 @@ export async function validateHardhatLibrary(
 
   if (!artifactExists) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: new InvalidArtifactError(vertex.libraryName),
     };
   }
@@ -37,15 +41,15 @@ export async function validateHardhatLibrary(
 
   if (argsLength !== expectedArgsLength) {
     return {
-      _kind: "failure",
-      failure: new Error(
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(
         `The constructor of the library '${vertex.libraryName}' expects ${expectedArgsLength} arguments but ${argsLength} were given`
       ),
     };
   }
 
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateSendETH.ts
+++ b/packages/core/src/validation/dispatch/validateSendETH.ts
@@ -1,18 +1,18 @@
 import { ethers, BigNumber } from "ethers";
 
 import { SendVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { IgnitionError } from "utils/errors";
 import { isParameter } from "utils/guards";
 
 export async function validateSendETH(
   vertex: SendVertex,
-  _resultAccumulator: ResultsAccumulator
-): Promise<VertexVisitResult> {
+  _resultAccumulator: ValidationResultsAccumulator
+): Promise<ValidationVertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
       _kind: VertexResultEnum.FAILURE,

--- a/packages/core/src/validation/dispatch/validateSendETH.ts
+++ b/packages/core/src/validation/dispatch/validateSendETH.ts
@@ -32,6 +32,6 @@ export async function validateSendETH(
 
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateSendETH.ts
+++ b/packages/core/src/validation/dispatch/validateSendETH.ts
@@ -1,7 +1,11 @@
 import { ethers, BigNumber } from "ethers";
 
 import { SendVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
 import { IgnitionError } from "utils/errors";
 import { isParameter } from "utils/guards";
 
@@ -11,7 +15,7 @@ export async function validateSendETH(
 ): Promise<VertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
     return {
-      _kind: "failure",
+      _kind: VertexResultEnum.FAILURE,
       failure: new IgnitionError(`For send 'value' must be a BigNumber`),
     };
   }
@@ -21,13 +25,13 @@ export async function validateSendETH(
     !ethers.utils.isAddress(vertex.address)
   ) {
     return {
-      _kind: "failure",
-      failure: new Error(`"${vertex.address}" is not a valid address`),
+      _kind: VertexResultEnum.FAILURE,
+      failure: new IgnitionError(`"${vertex.address}" is not a valid address`),
     };
   }
 
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateVirtual.ts
+++ b/packages/core/src/validation/dispatch/validateVirtual.ts
@@ -1,6 +1,10 @@
 import { Services } from "services/types";
 import { DeploymentGraphVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ResultsAccumulator,
+  VertexResultEnum,
+  VertexVisitResult,
+} from "types/graph";
 
 export async function validateVirtual(
   _deploymentVertex: DeploymentGraphVertex,
@@ -8,7 +12,7 @@ export async function validateVirtual(
   _context: { services: Services }
 ): Promise<VertexVisitResult> {
   return {
-    _kind: "success",
-    result: undefined,
+    _kind: VertexResultEnum.SUCCESS,
+    result: undefined as any,
   };
 }

--- a/packages/core/src/validation/dispatch/validateVirtual.ts
+++ b/packages/core/src/validation/dispatch/validateVirtual.ts
@@ -13,6 +13,6 @@ export async function validateVirtual(
 ): Promise<ValidationVertexVisitResult> {
   return {
     _kind: VertexResultEnum.SUCCESS,
-    result: undefined as any,
+    result: undefined,
   };
 }

--- a/packages/core/src/validation/dispatch/validateVirtual.ts
+++ b/packages/core/src/validation/dispatch/validateVirtual.ts
@@ -1,16 +1,16 @@
 import { Services } from "services/types";
 import { DeploymentGraphVertex } from "types/deploymentGraph";
+import { VertexResultEnum } from "types/graph";
 import {
-  ResultsAccumulator,
-  VertexResultEnum,
-  VertexVisitResult,
-} from "types/graph";
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 
 export async function validateVirtual(
   _deploymentVertex: DeploymentGraphVertex,
-  _resultAccumulator: ResultsAccumulator,
+  _resultAccumulator: ValidationResultsAccumulator,
   _context: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   return {
     _kind: VertexResultEnum.SUCCESS,
     result: undefined as any,

--- a/packages/core/src/validation/dispatch/validationDispatch.ts
+++ b/packages/core/src/validation/dispatch/validationDispatch.ts
@@ -1,6 +1,9 @@
 import { Services } from "services/types";
 import { DeploymentGraphVertex } from "types/deploymentGraph";
-import { ResultsAccumulator, VertexVisitResult } from "types/graph";
+import {
+  ValidationResultsAccumulator,
+  ValidationVertexVisitResult,
+} from "types/validation";
 import { assertUnknownDeploymentVertexType } from "utils/guards";
 
 import { validateArtifactContract } from "./validateArtifactContract";
@@ -15,9 +18,9 @@ import { validateVirtual } from "./validateVirtual";
 
 export function validationDispatch(
   deploymentVertex: DeploymentGraphVertex,
-  resultAccumulator: ResultsAccumulator,
+  resultAccumulator: ValidationResultsAccumulator,
   context: { services: Services }
-): Promise<VertexVisitResult> {
+): Promise<ValidationVertexVisitResult> {
   switch (deploymentVertex.type) {
     case "ArtifactContract":
       return validateArtifactContract(

--- a/packages/core/src/validation/validateDeploymentGraph.ts
+++ b/packages/core/src/validation/validateDeploymentGraph.ts
@@ -2,7 +2,7 @@ import { getSortedVertexIdsFrom } from "graph/utils";
 import { visit } from "graph/visit";
 import { Services } from "services/types";
 import { IDeploymentGraph } from "types/deploymentGraph";
-import { VertexVisitResult, VisitResult } from "types/graph";
+import { ValidationVisitResult } from "types/validation";
 import { IgnitionError } from "utils/errors";
 
 import { validationDispatch } from "./dispatch/validationDispatch";
@@ -10,7 +10,7 @@ import { validationDispatch } from "./dispatch/validationDispatch";
 export async function validateDeploymentGraph(
   deploymentGraph: IDeploymentGraph,
   services: Services
-): Promise<VisitResult> {
+): Promise<ValidationVisitResult> {
   try {
     const orderedVertexIds = getSortedVertexIdsFrom(deploymentGraph);
 
@@ -19,7 +19,7 @@ export async function validateDeploymentGraph(
       orderedVertexIds,
       deploymentGraph,
       { services },
-      new Map<number, VertexVisitResult | null>(),
+      new Map<number, null>(),
       validationDispatch
     );
   } catch (err) {

--- a/packages/core/test/deploymentBuilder/buildModule.ts
+++ b/packages/core/test/deploymentBuilder/buildModule.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 
 import { buildModule } from "dsl/buildModule";
 import { generateDeploymentGraphFrom } from "process/generateDeploymentGraphFrom";
+import { IgnitionError } from "utils/errors";
 
 describe("deployment builder - buildModule", () => {
   it("should throw if build module is given an async callback", () => {
@@ -20,7 +21,7 @@ describe("deployment builder - buildModule", () => {
   it("should throw if build module throws an exception", () => {
     assert.throws(() => {
       const badAsyncModule = buildModule("BadAsyncModule", () => {
-        throw new Error("User thrown error");
+        throw new IgnitionError("User thrown error");
       });
 
       return generateDeploymentGraphFrom(badAsyncModule, {

--- a/packages/core/test/deploymentBuilder/libraries.ts
+++ b/packages/core/test/deploymentBuilder/libraries.ts
@@ -35,7 +35,7 @@ describe("deployment builder - libraries", () => {
             },
           });
 
-          return { safeMath, contract };
+          return { contract };
         }
       );
 

--- a/packages/core/test/deploymentBuilder/libraries.ts
+++ b/packages/core/test/deploymentBuilder/libraries.ts
@@ -35,7 +35,7 @@ describe("deployment builder - libraries", () => {
             },
           });
 
-          return { contract };
+          return { safeMath, contract };
         }
       );
 

--- a/packages/core/test/deploymentBuilder/useModule.ts
+++ b/packages/core/test/deploymentBuilder/useModule.ts
@@ -490,7 +490,7 @@ describe("deployment builder - useModule", () => {
     });
   });
 
-  describe("returning non contract/library futures from within a module", () => {
+  describe("returning non contract futures from within a module", () => {
     // @ts-ignore
     let returnsWrongFutureTypeModule: Module<{
       token: CallableFuture | Virtual | ProxyFuture | EventFuture;

--- a/packages/core/test/deploymentBuilder/useModule.ts
+++ b/packages/core/test/deploymentBuilder/useModule.ts
@@ -491,6 +491,7 @@ describe("deployment builder - useModule", () => {
   });
 
   describe("returning non contract/library futures from within a module", () => {
+    // @ts-ignore
     let returnsWrongFutureTypeModule: Module<{
       token: CallableFuture | Virtual | ProxyFuture | EventFuture;
     }>;
@@ -526,6 +527,7 @@ describe("deployment builder - useModule", () => {
     it("should throw", () => {
       assert.throws(
         () =>
+          // @ts-ignore
           generateDeploymentGraphFrom(returnsWrongFutureTypeModule, {
             chainId: 31,
           }),

--- a/packages/core/test/execution/batching.ts
+++ b/packages/core/test/execution/batching.ts
@@ -6,7 +6,7 @@ import { Deployment } from "deployment/Deployment";
 import { ExecutionGraph } from "execution/ExecutionGraph";
 import { executeInBatches } from "execution/execute";
 import { ContractDeploy, ExecutionVertex } from "types/executionGraph";
-import { VertexVisitResult } from "types/graph";
+import { VertexResultEnum, VertexVisitResult } from "types/graph";
 import { ICommandJournal } from "types/journal";
 
 import { buildAdjacencyListFrom } from "../graph/helpers";
@@ -49,7 +49,7 @@ describe("Execution - batching", () => {
       deployment,
       executionGraph,
       async (): Promise<VertexVisitResult> => {
-        return { _kind: "success", result: true };
+        return { _kind: VertexResultEnum.SUCCESS, result: {} as any };
       },
       {} as any
     );

--- a/packages/core/test/execution/batching.ts
+++ b/packages/core/test/execution/batching.ts
@@ -5,8 +5,12 @@ import { BigNumber } from "ethers";
 import { Deployment } from "deployment/Deployment";
 import { ExecutionGraph } from "execution/ExecutionGraph";
 import { executeInBatches } from "execution/execute";
-import { ContractDeploy, ExecutionVertex } from "types/executionGraph";
-import { VertexResultEnum, VertexVisitResult } from "types/graph";
+import type {
+  ContractDeploy,
+  ExecutionVertex,
+  ExecutionVertexVisitResult,
+} from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 import { ICommandJournal } from "types/journal";
 
 import { buildAdjacencyListFrom } from "../graph/helpers";
@@ -48,7 +52,7 @@ describe("Execution - batching", () => {
     const result = await executeInBatches(
       deployment,
       executionGraph,
-      async (): Promise<VertexVisitResult> => {
+      async (): Promise<ExecutionVertexVisitResult> => {
         return { _kind: VertexResultEnum.SUCCESS, result: {} as any };
       },
       {} as any

--- a/packages/core/test/execution/dispatch.ts
+++ b/packages/core/test/execution/dispatch.ts
@@ -8,6 +8,7 @@ import { ExecutionGraph } from "execution/ExecutionGraph";
 import { execute } from "execution/execute";
 import { Services, TransactionOptions } from "services/types";
 import { ExecutionVertex } from "types/executionGraph";
+import { VertexResultEnum } from "types/graph";
 import { Artifact } from "types/hardhat";
 import { ICommandJournal } from "types/journal";
 
@@ -73,7 +74,7 @@ describe("Execution - dispatch", () => {
     }
 
     assert.deepStrictEqual(response.result.get(0), {
-      _kind: "success",
+      _kind: VertexResultEnum.SUCCESS,
       result: {
         abi: [],
         address: "0xAddr",
@@ -133,7 +134,7 @@ describe("Execution - dispatch", () => {
     }
 
     assert.deepStrictEqual(response.result.get(0), {
-      _kind: "success",
+      _kind: VertexResultEnum.SUCCESS,
       result: {
         abi: [],
         address: "0xAddr",
@@ -234,7 +235,7 @@ describe("Execution - dispatch", () => {
     }
 
     assert.deepStrictEqual(response.result.get(1), {
-      _kind: "success",
+      _kind: VertexResultEnum.SUCCESS,
       result: {
         hash: "0x2",
       },
@@ -366,7 +367,7 @@ describe("Execution - dispatch", () => {
       }
 
       assert.deepStrictEqual(response.result.get(2), {
-        _kind: "success",
+        _kind: VertexResultEnum.SUCCESS,
         result: {
           topics: ["0x0000000000000000000000000000000000000003"],
         },
@@ -421,7 +422,7 @@ describe("Execution - dispatch", () => {
     }
 
     assert.deepStrictEqual(response.result.get(0), {
-      _kind: "success",
+      _kind: VertexResultEnum.SUCCESS,
       result: {
         name: "Foo",
         abi: [],

--- a/packages/core/test/execution/rerun.ts
+++ b/packages/core/test/execution/rerun.ts
@@ -104,7 +104,7 @@ describe("Reruning execution", () => {
 
     it("should record complete on first run", async () => {
       // Act
-      const [result] = await ignition.deploy(myModule, {} as any);
+      const result = await ignition.deploy(myModule, {} as any);
 
       // Assert
       assert.equal(result._kind, "success");
@@ -118,7 +118,7 @@ describe("Reruning execution", () => {
       await ignition.deploy(myModule, {} as any);
 
       // Act
-      const [redeployResult] = await ignition.deploy(myModule, {} as any);
+      const redeployResult = await ignition.deploy(myModule, {} as any);
 
       // Assert
       assert.equal(redeployResult._kind, "success");
@@ -135,12 +135,12 @@ describe("Reruning execution", () => {
         return assert.fail("Not a successful deploy");
       }
 
-      if (redeployResult.result.token._kind !== "contract") {
+      if (!redeployResult.result.token.address) {
         return assert.fail("Unable to retrieve the token contract result");
       }
 
       assert.equal(
-        redeployResult.result.token.value.address,
+        redeployResult.result.token.address,
         "0x1F98431c8aD98523631AE4a59f267346ea31F984"
       );
     });
@@ -231,7 +231,7 @@ describe("Reruning execution", () => {
 
     it("should record hold on first run", async () => {
       // Act
-      const [result] = await ignition.deploy(myModule, {} as any);
+      const result = await ignition.deploy(myModule, {} as any);
 
       // Assert
       assert.equal(result._kind, "hold");
@@ -252,7 +252,7 @@ describe("Reruning execution", () => {
       await ignition.deploy(myModule, {} as any);
 
       // Act
-      const [redeployResult] = await ignition.deploy(myModule, {} as any);
+      const redeployResult = await ignition.deploy(myModule, {} as any);
 
       // Assert
       // only the original two transactions, no more
@@ -265,12 +265,12 @@ describe("Reruning execution", () => {
         return assert.fail("Not a successful deploy");
       }
 
-      if (redeployResult.result.token._kind !== "contract") {
+      if (!redeployResult.result.token.address) {
         return assert.fail("Unable to retrieve the token contract result");
       }
 
       assert.equal(
-        redeployResult.result.token.value.address,
+        redeployResult.result.token.address,
         "0x1F98431c8aD98523631AE4a59f267346ea31F984"
       );
     });
@@ -294,7 +294,7 @@ describe("Reruning execution", () => {
         journal: new MemoryCommandJournal(),
       });
 
-      const [result] = await ignition.deploy(myModule, {} as any);
+      const result = await ignition.deploy(myModule, {} as any);
 
       assert.equal(result._kind, "hold");
     });
@@ -357,7 +357,7 @@ describe("Reruning execution", () => {
 
     it("should record fail on first run", async () => {
       // Act
-      const [result] = await ignition.deploy(myModule, {} as any);
+      const result = await ignition.deploy(myModule, {} as any);
 
       // Assert
       assert.equal(result._kind, "failure");
@@ -383,7 +383,7 @@ describe("Reruning execution", () => {
       await ignition.deploy(myModule, {} as any);
 
       // Act
-      const [redeployResult] = await ignition.deploy(myModule, {} as any);
+      const redeployResult = await ignition.deploy(myModule, {} as any);
 
       // Assert
       // the second transaction is successfully sent
@@ -394,12 +394,12 @@ describe("Reruning execution", () => {
         return assert.fail("Not a successful deploy");
       }
 
-      if (redeployResult.result.token._kind !== "contract") {
+      if (!redeployResult.result.token.address) {
         return assert.fail("Unable to retrieve the token contract result");
       }
 
       assert.equal(
-        redeployResult.result.token.value.address,
+        redeployResult.result.token.address,
         "0x1F98431c8aD98523631AE4a59f267346ea31F984"
       );
     });
@@ -425,7 +425,7 @@ describe("Reruning execution", () => {
       await ignition.deploy(someModule, {} as any);
 
       // Act
-      const [modifiedResult] = await ignition.deploy(modifiedModule, {} as any);
+      const modifiedResult = await ignition.deploy(modifiedModule, {} as any);
 
       // Assert
       // the second transaction is not sent

--- a/packages/core/test/execution/rerun.ts
+++ b/packages/core/test/execution/rerun.ts
@@ -150,7 +150,7 @@ describe("Reruning execution", () => {
       await ignition.deploy(myModule, {} as any);
 
       // Act
-      const [redeployResult] = await ignition.deploy(myModule, {
+      const redeployResult = await ignition.deploy(myModule, {
         force: true,
       } as any);
 

--- a/packages/core/test/state-reducer/execution.ts
+++ b/packages/core/test/state-reducer/execution.ts
@@ -7,6 +7,7 @@ import {
 } from "deployment/deployStateReducer";
 import { buildModule } from "dsl/buildModule";
 import { DeployState } from "types/deployment";
+import { VertexResultEnum } from "types/graph";
 
 import { applyActions, resolveExecutionGraphFor } from "./utils";
 
@@ -122,8 +123,8 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 0,
           result: {
-            _kind: "success",
-            result: { someValue: "example" },
+            _kind: VertexResultEnum.SUCCESS,
+            result: { hash: "example" },
           },
         },
       ]);
@@ -135,8 +136,8 @@ describe("deployment state reducer", () => {
       assert.deepStrictEqual(state.execution.vertexes[0], {
         status: "COMPLETED",
         result: {
-          _kind: "success",
-          result: { someValue: "example" },
+          _kind: VertexResultEnum.SUCCESS,
+          result: { hash: "example" },
         },
       });
     });
@@ -158,8 +159,8 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 0,
           result: {
-            _kind: "success",
-            result: { someValue: "example" },
+            _kind: VertexResultEnum.SUCCESS,
+            result: { hash: "example" },
           },
         },
       ]);
@@ -170,8 +171,8 @@ describe("deployment state reducer", () => {
       assert.deepStrictEqual(state.execution.vertexes[0], {
         status: "COMPLETED",
         result: {
-          _kind: "success",
-          result: { someValue: "example" },
+          _kind: VertexResultEnum.SUCCESS,
+          result: { hash: "example" },
         },
       });
     });
@@ -194,8 +195,8 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 0,
           result: {
-            _kind: "success",
-            result: { someValue: "example" },
+            _kind: VertexResultEnum.SUCCESS,
+            result: { hash: "example" },
           },
         },
 
@@ -207,16 +208,16 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 1,
           result: {
-            _kind: "success",
-            result: { someValue: "example" },
+            _kind: VertexResultEnum.SUCCESS,
+            result: { hash: "example" },
           },
         },
         {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 2,
           result: {
-            _kind: "success",
-            result: { someValue: "example" },
+            _kind: VertexResultEnum.SUCCESS,
+            result: { hash: "example" },
           },
         },
 
@@ -228,8 +229,8 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 3,
           result: {
-            _kind: "success",
-            result: { someValue: "example" },
+            _kind: VertexResultEnum.SUCCESS,
+            result: { hash: "example" },
           },
         },
       ]);
@@ -268,8 +269,8 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 0,
           result: {
-            _kind: "success",
-            result: { someValue: "example" },
+            _kind: VertexResultEnum.SUCCESS,
+            result: { hash: "example" },
           },
         },
 
@@ -281,7 +282,7 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 1,
           result: {
-            _kind: "hold",
+            _kind: VertexResultEnum.HOLD,
           },
         },
       ]);
@@ -318,8 +319,8 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 0,
           result: {
-            _kind: "success",
-            result: { someValue: "example" },
+            _kind: VertexResultEnum.SUCCESS,
+            result: { hash: "example" },
           },
         },
 
@@ -331,7 +332,7 @@ describe("deployment state reducer", () => {
           type: "EXECUTION::SET_VERTEX_RESULT",
           vertexId: 1,
           result: {
-            _kind: "failure",
+            _kind: VertexResultEnum.FAILURE,
             failure: new Error("No connection"),
           },
         },
@@ -348,7 +349,7 @@ describe("deployment state reducer", () => {
       assert.deepStrictEqual(state.execution.vertexes[1], {
         status: "FAILED",
         result: {
-          _kind: "failure",
+          _kind: VertexResultEnum.FAILURE,
           failure: new Error("No connection"),
         },
       });

--- a/packages/core/test/validation.ts
+++ b/packages/core/test/validation.ts
@@ -163,9 +163,9 @@ describe("Validation", () => {
   describe("artifact library deploy", () => {
     it("should validate a correct artifact library deploy", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        m.library("Example", exampleArtifact);
+        const example = m.library("Example", exampleArtifact);
 
-        return {};
+        return { example };
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {
@@ -186,11 +186,11 @@ describe("Validation", () => {
 
     it("should not validate a artifact library deploy with the wrong number of args", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        m.library("Example", exampleArtifact, {
+        const example = m.library("Example", exampleArtifact, {
           args: [1, 2, 3],
         });
 
-        return {};
+        return { example };
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {
@@ -223,11 +223,11 @@ describe("Validation", () => {
 
     it("should not validate a artifact library deploy with a non-existent bytes artifact arg", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        m.library("Example", exampleArtifact, {
+        const example = m.library("Example", exampleArtifact, {
           args: [1, 2, m.getBytesForArtifact("Nonexistant")],
         });
 
-        return {};
+        return { example };
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {
@@ -1104,9 +1104,9 @@ describe("Validation", () => {
   describe("hardhat library deploy", () => {
     it("should validate a correct deploy", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        m.library("Example");
+        const example = m.library("Example");
 
-        return {};
+        return { example };
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {
@@ -1131,9 +1131,9 @@ describe("Validation", () => {
 
     it("should not validate a library deploy on a non-existant hardhat library", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        m.library("Nonexistant");
+        const nonexistant = m.library("Nonexistant");
 
-        return {};
+        return { nonexistant };
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {

--- a/packages/core/test/validation.ts
+++ b/packages/core/test/validation.ts
@@ -163,9 +163,9 @@ describe("Validation", () => {
   describe("artifact library deploy", () => {
     it("should validate a correct artifact library deploy", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.library("Example", exampleArtifact);
+        m.library("Example", exampleArtifact);
 
-        return { example };
+        return {};
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {
@@ -186,11 +186,11 @@ describe("Validation", () => {
 
     it("should not validate a artifact library deploy with the wrong number of args", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.library("Example", exampleArtifact, {
+        m.library("Example", exampleArtifact, {
           args: [1, 2, 3],
         });
 
-        return { example };
+        return {};
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {
@@ -223,11 +223,11 @@ describe("Validation", () => {
 
     it("should not validate a artifact library deploy with a non-existent bytes artifact arg", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.library("Example", exampleArtifact, {
+        m.library("Example", exampleArtifact, {
           args: [1, 2, m.getBytesForArtifact("Nonexistant")],
         });
 
-        return { example };
+        return {};
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {
@@ -1104,9 +1104,9 @@ describe("Validation", () => {
   describe("hardhat library deploy", () => {
     it("should validate a correct deploy", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.library("Example");
+        m.library("Example");
 
-        return { example };
+        return {};
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {
@@ -1131,9 +1131,9 @@ describe("Validation", () => {
 
     it("should not validate a library deploy on a non-existant hardhat library", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const nonexistant = m.library("Nonexistant");
+        m.library("Nonexistant");
 
-        return { nonexistant };
+        return {};
       });
 
       const { graph } = generateDeploymentGraphFrom(singleModule, {

--- a/packages/hardhat-plugin/src/load-module.ts
+++ b/packages/hardhat-plugin/src/load-module.ts
@@ -34,7 +34,7 @@ export function loadModule(
 
   const module = require(fullpathToModule);
 
-  return module;
+  return module.default ?? module;
 }
 
 function resolveFullPathToModule(

--- a/packages/hardhat-plugin/test/CommandJournal.ts
+++ b/packages/hardhat-plugin/test/CommandJournal.ts
@@ -1,5 +1,8 @@
 /* eslint-disable import/no-unused-modules */
-import { DeployStateExecutionCommand } from "@ignored/ignition-core";
+import {
+  DeployStateExecutionCommand,
+  VertexResultEnum,
+} from "@ignored/ignition-core";
 import { assert } from "chai";
 import { BigNumber } from "ethers";
 import fs from "fs";
@@ -25,7 +28,7 @@ describe("File based command journal", () => {
         type: "EXECUTION::SET_VERTEX_RESULT",
         vertexId: 0,
         result: {
-          _kind: "success",
+          _kind: VertexResultEnum.SUCCESS,
           result: {
             name: "Example",
             abi: [
@@ -50,7 +53,7 @@ describe("File based command journal", () => {
         type: "EXECUTION::SET_VERTEX_RESULT",
         vertexId: 1,
         result: {
-          _kind: "success",
+          _kind: VertexResultEnum.SUCCESS,
           result: {
             hash: "0x7058ee5c5c027de2480a3d559695d0a1311763c5dcb3d301ee1203cc44a9031d",
           },
@@ -60,7 +63,7 @@ describe("File based command journal", () => {
         type: "EXECUTION::SET_VERTEX_RESULT",
         vertexId: 2,
         result: {
-          _kind: "failure",
+          _kind: VertexResultEnum.FAILURE,
           failure: {} as any, // new Error("Example Error"),
         },
       },
@@ -68,7 +71,7 @@ describe("File based command journal", () => {
         type: "EXECUTION::SET_VERTEX_RESULT",
         vertexId: 3,
         result: {
-          _kind: "hold",
+          _kind: VertexResultEnum.HOLD,
         },
       },
     ];

--- a/packages/hardhat-plugin/test/existing-contract.ts
+++ b/packages/hardhat-plugin/test/existing-contract.ts
@@ -10,6 +10,11 @@ describe("existing contract", () => {
   it("should be able to use an existing contract", async function () {
     await this.hre.run("compile", { quiet: true });
 
+    const { abi: barAbi } = await this.hre.artifacts.readArtifact("Bar");
+    const { abi: usesContractAbi } = await this.hre.artifacts.readArtifact(
+      "UsesContract"
+    );
+
     const firstResult = await deployModule(this.hre, (m) => {
       const bar = m.contract("Bar");
       const usesContract = m.contract("UsesContract", {
@@ -22,9 +27,7 @@ describe("existing contract", () => {
     assert.isDefined(firstResult.bar.address);
     assert.isDefined(firstResult.usesContract.address);
     const barAddress: string = firstResult.bar.address;
-    const barAbi: any[] = firstResult.bar.abi;
     const usesContractAddress: string = firstResult.usesContract.address;
-    const usesContractAbi: any[] = firstResult.usesContract.abi;
 
     const result = await deployModule(this.hre, (m) => {
       const bar = m.contractAt("Bar", barAddress, barAbi);

--- a/packages/hardhat-plugin/test/helpers.ts
+++ b/packages/hardhat-plugin/test/helpers.ts
@@ -1,5 +1,4 @@
 import {
-  SerializedFutureResult,
   SerializedDeploymentResult,
   DeploymentResult,
   Module,
@@ -43,9 +42,9 @@ type ExpectedDeploymentState = Record<string, ExpectedModuleResult>;
  * result of each future is of the correct type, and it can also run
  * some custom predicate logic on the result to further verify it.
  */
-export async function assertDeploymentState(
+export async function assertDeploymentState<T extends ModuleDict>(
   hre: any,
-  result: SerializedDeploymentResult,
+  result: SerializedDeploymentResult<T>,
   expectedResult: ExpectedDeploymentState
 ) {
   const modulesResults = Object.entries(result);
@@ -114,10 +113,10 @@ export async function deployModules<T extends ModuleDict>(
   hre: any,
   userModules: Array<Module<T>>,
   expectedBlocks: number[]
-): Promise<SerializedDeploymentResult> {
+): Promise<SerializedDeploymentResult<T>> {
   await hre.run("compile", { quiet: true });
 
-  const deploymentResultPromise: Promise<DeploymentResult> = hre.run(
+  const deploymentResultPromise: Promise<DeploymentResult<T>> = hre.run(
     "deploy:deploy-modules",
     {
       userModules,
@@ -180,7 +179,7 @@ async function waitForPendingTxs(
   }
 }
 
-async function assertContract(hre: any, futureResult: SerializedFutureResult) {
+async function assertContract(hre: any, futureResult: any) {
   if (futureResult._kind !== "contract") {
     assert.fail(
       `Expected future result to be a contract, but got ${futureResult._kind}`

--- a/packages/hardhat-plugin/test/libraries.ts
+++ b/packages/hardhat-plugin/test/libraries.ts
@@ -18,15 +18,11 @@ describe("libraries", () => {
         },
       });
 
-      return { rubbishMath, dependsOnLib };
+      return { dependsOnLib };
     });
 
     assert.isDefined(result);
-    const math = result.rubbishMath;
     const contractThatDependsOnLib = result.dependsOnLib;
-
-    const addition = await math.add(1, 2);
-    assert.equal(addition, 3);
 
     const libBasedAddtion = await contractThatDependsOnLib.addThreeNumbers(
       1,
@@ -52,15 +48,11 @@ describe("libraries", () => {
         },
       });
 
-      return { rubbishMath, dependsOnLib };
+      return { dependsOnLib };
     });
 
     assert.isDefined(result);
-    const math = result.rubbishMath;
     const contractThatDependsOnLib = result.dependsOnLib;
-
-    const addition = await math.add(1, 2);
-    assert.equal(addition, 3);
 
     const libBasedAddtion = await contractThatDependsOnLib.addThreeNumbers(
       1,

--- a/packages/hardhat-plugin/test/libraries.ts
+++ b/packages/hardhat-plugin/test/libraries.ts
@@ -18,7 +18,7 @@ describe("libraries", () => {
         },
       });
 
-      return { dependsOnLib };
+      return { rubbishMath, dependsOnLib };
     });
 
     assert.isDefined(result);
@@ -48,7 +48,7 @@ describe("libraries", () => {
         },
       });
 
-      return { dependsOnLib };
+      return { rubbishMath, dependsOnLib };
     });
 
     assert.isDefined(result);

--- a/packages/tsconfig.settings.json
+++ b/packages/tsconfig.settings.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "declaration": true,
+    "declarationMap": true,
     "types": [],
     "sourceMap": true
   }


### PR DESCRIPTION
- fully support using Ignition with typescript projects
- properly overloading `m.contract(...)` and `m.library(...)` for automatic return value typing
- refactored internal serialization to be more straightforward and type-friendly
- refactored module return types to ensure proper typing in typescript tests
- enforce only allowing contracts (and proxies/virtuals) to be returned from a module 
- added a typescript example project 

Closes #101 
Closes #140 