### PR TITLE
chore: bump version to v0.0.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           node-version: 14
           cache: npm
-      - name: npm 7
-        run: npm i -g npm@7
+      - name: npm latest
+        run: npm i -g npm@8 && npm i -g npm@latest
       - name: Install
         run: npm install
       - name: Build
@@ -41,8 +41,8 @@ jobs:
         with:
           node-version: 14
           cache: npm
-      - name: npm 7
-        run: npm i -g npm@7
+      - name: npm latest
+        run: npm i -g npm
       - name: Install
         run: npm install
       - name: Build
@@ -68,8 +68,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: npm
-      - name: npm 7
-        run: npm i -g npm@7
+      - name: npm latest
+        run: npm i -g npm
       - name: Install
         run: npm install
       - name: Build

--- a/examples/create2/package.json
+++ b/examples/create2/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "hardhat": "^2.10.0",
-    "@ignored/hardhat-ignition": "^0.0.7"
+    "@ignored/hardhat-ignition": "^0.0.8"
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.7.3"

--- a/examples/ens/package.json
+++ b/examples/ens/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.7",
+    "@ignored/hardhat-ignition": "^0.0.8",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/multisig/package.json
+++ b/examples/multisig/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.7",
+    "@ignored/hardhat-ignition": "^0.0.8",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.7",
+    "@ignored/hardhat-ignition": "^0.0.8",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/uniswap/package.json
+++ b/examples/uniswap/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.7",
+    "@ignored/hardhat-ignition": "^0.0.8",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@openzeppelin/contracts": "4.7.3"
       },
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.0.7",
+        "@ignored/hardhat-ignition": "^0.0.8",
         "hardhat": "^2.10.0"
       }
     },
@@ -53,7 +53,7 @@
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.7",
+        "@ignored/hardhat-ignition": "^0.0.8",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -88,7 +88,7 @@
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.7",
+        "@ignored/hardhat-ignition": "^0.0.8",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -120,7 +120,7 @@
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.7",
+        "@ignored/hardhat-ignition": "^0.0.8",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -162,7 +162,7 @@
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.7",
+        "@ignored/hardhat-ignition": "^0.0.8",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -3990,9 +3990,9 @@
       "dev": true
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -5297,9 +5297,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001451",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz",
-      "integrity": "sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==",
+      "version": "1.0.30001453",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001453.tgz",
+      "integrity": "sha512-R9o/uySW38VViaTrOtwfbFEiBFUh7ST3uIG4OEymIG3/uKdHDO4xk/FaqfUw0d+irSUyFPy3dZszf9VvSTPnsA==",
       "dev": true,
       "funding": [
         {
@@ -6018,6 +6018,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -6136,6 +6145,58 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
       "devOptional": true
+    },
+    "node_modules/cytoscape": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.23.0.tgz",
+      "integrity": "sha512-gRZqJj/1kiAVPkrVFvz/GccxsXhF3Qwpptl32gKKypO4IlqnKBjTOu+HbXtEggSGzC5KCaHp3/F7GgENrtsFkA==",
+      "dev": true,
+      "dependencies": {
+        "heap": "^0.2.6",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true
     },
     "node_modules/d": {
       "version": "1.0.1",
@@ -6548,12 +6609,12 @@
       }
     },
     "node_modules/dagre-d3-es": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.6.tgz",
-      "integrity": "sha512-CaaE/nZh205ix+Up4xsnlGmpog5GGm81Upi2+/SBHxwNwrccBb3K51LzjZ1U6hgvOlAEUsVWf1xSTzCyKpJ6+Q==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.8.tgz",
+      "integrity": "sha512-eykdoYQ4FwCJinEYS0gPL2f2w+BPbSLvnQSJ3Ye1vAoPjdkq6xIMKBv+UkICd3qZE26wBKIn3p+6n0QC7R1LyA==",
       "dev": true,
       "dependencies": {
-        "d3": "^7.7.0",
+        "d3": "^7.8.2",
         "lodash-es": "^4.17.21"
       }
     },
@@ -6695,9 +6756,9 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
@@ -6865,9 +6926,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.1.tgz",
-      "integrity": "sha512-ewwFzHzrrneRjxzmK6oVz/rZn9VWspGFRDb4/rRtIsM1n36t9AKma/ye8syCpcw+XJ25kOK/hOG7t1j2I2yBqA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.3.tgz",
+      "integrity": "sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ==",
       "dev": true
     },
     "node_modules/domutils": {
@@ -6914,9 +6975,15 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.294",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.294.tgz",
-      "integrity": "sha512-PuHZB3jEN7D8WPPjLmBQAsqQz8tWHlkkB4n0E2OYw8RwVdmBYV0Wn+rUFH8JqYyIRb4HQhhedgxlZL163wqLrQ==",
+      "version": "1.4.299",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.299.tgz",
+      "integrity": "sha512-lQ7ijJghH6pCGbfWXr6EY+KYCMaRSjgsY925r1p/TlpSfVM1VjHTcn1gAc15VM4uwti283X6QtjPTXdpoSGiZQ==",
+      "dev": true
+    },
+    "node_modules/elkjs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -8010,9 +8077,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.1.tgz",
+      "integrity": "sha512-3ZggxvMv5EEY1ssUVyHSVt0oPreyBfbUi1XikJVfjFiBeBDLdrb0IWoDiEwqT/2sUQi0TGaWtFhOGDD8RTpXgQ==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -11759,6 +11826,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true
+    },
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -12092,20 +12165,25 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-9.3.0.tgz",
-      "integrity": "sha512-mGl0BM19TD/HbU/LmlaZbjBi//tojelg8P/mxD6pPZTAYaI+VawcyBdqRsoUHSc7j71PrMdJ3HBadoQNdvP5cg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-9.4.0.tgz",
+      "integrity": "sha512-4PWbOND7CNRbjHrdG3WUUGBreKAFVnMhdlPjttuUkeHbCQmAHkwzSh5dGwbrKmXGRaR4uTvfFVYzUcg++h0DkA==",
       "dev": true,
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
+        "cytoscape": "^3.23.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.1.0",
         "d3": "^7.0.0",
-        "dagre-d3-es": "7.0.6",
-        "dompurify": "2.4.1",
+        "dagre-d3-es": "7.0.8",
+        "dompurify": "2.4.3",
+        "elkjs": "^0.8.2",
         "khroma": "^2.0.0",
         "lodash-es": "^4.17.21",
-        "moment-mini": "^2.24.0",
+        "moment": "^2.29.4",
         "non-layered-tidy-tree-layout": "^2.0.2",
         "stylis": "^4.1.2",
+        "ts-dedent": "^2.2.0",
         "uuid": "^9.0.0"
       }
     },
@@ -12479,11 +12557,14 @@
         "node": ">=10"
       }
     },
-    "node_modules/moment-mini": {
+    "node_modules/moment": {
       "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment-mini/-/moment-mini-2.29.4.tgz",
-      "integrity": "sha512-uhXpYwHFeiTbY9KSgPPRoo1nt8OxNVdMVoTBYHfSEKeRkIkwGpO+gERmhuhBtzfaeOyTkykSrm2+noJBgqt3Hg==",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -16680,6 +16761,15 @@
         "write-markdown": "dist/write-markdown.js"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-essentials": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
@@ -17057,9 +17147,9 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/undici": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
-      "integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.19.1.tgz",
+      "integrity": "sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -18289,7 +18379,7 @@
     },
     "packages/core": {
       "name": "@ignored/ignition-core",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "5.6.1",
@@ -18366,7 +18456,7 @@
     },
     "packages/hardhat-plugin": {
       "name": "@ignored/hardhat-ignition",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.2",
@@ -18380,7 +18470,7 @@
         "serialize-error": "8.1.0"
       },
       "devDependencies": {
-        "@ignored/ignition-core": "^0.0.7",
+        "@ignored/ignition-core": "^0.0.8",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@types/chai": "^4.2.22",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "clean": "wsrun --exclude-missing --serial clean"
   },
   "devDependencies": {
-    "wsrun": "^5.2.4",
     "@typescript-eslint/eslint-plugin": "4.31.2",
     "@typescript-eslint/parser": "4.31.2",
     "eslint": "^7.32.0",
@@ -35,6 +34,7 @@
     "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-prettier": "4.0.0",
     "prettier": "2.4.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "wsrun": "^5.2.4"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.0.8 - 2023-02-16
+
+### Changed
+
+- Rename config option `gasIncrementPerRetry` to `gasPriceIncrementPerRetry` for clarity ([#143](https://github.com/NomicFoundation/ignition/pull/143))
+
+### Fixed
+
+- Ban passing async functions to `buildModule` ([#138](https://github.com/NomicFoundation/ignition/issues/138))
+
 ## 0.0.7 - 2023-01-31
 
 ### Fixed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/ignition-core",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.0.8 - 2023-02-16
+
+### Added
+
+- Allow file paths to ignition modules on cli to support cli completions for file discovery ([#102](https://github.com/NomicFoundation/ignition/issues/102))
+
+### Changed
+
+- Rename config option `gasIncrementPerRetry` to `gasPriceIncrementPerRetry` for clarity ([#143](https://github.com/NomicFoundation/ignition/pull/143))
+
+### Fixed
+
+- Improve error messages display during module validation ([#141](https://github.com/NomicFoundation/ignition/issues/141))
+- Ban passing async functions to `buildModule` ([#138](https://github.com/NomicFoundation/ignition/issues/138))
+
 ## 0.0.7 - 2023-01-31
 
 ### Fixed

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/hardhat-ignition",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",
@@ -33,7 +33,7 @@
     "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {
-    "@ignored/ignition-core": "^0.0.7",
+    "@ignored/ignition-core": "^0.0.8",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@types/chai": "^4.2.22",


### PR DESCRIPTION
## 0.0.8 - 2023-02-16

### Added

- Allow file paths to ignition modules on cli to support cli completions for file discovery  ([#102](https://github.com/NomicFoundation/ignition/issues/102))

### Changed

- Rename config option `gasIncrementPerRetry` to `gasPriceIncrementPerRetry` for clarity ([#143](https://github.com/NomicFoundation/ignition/pull/143))

### Fixed

- Improve error messages display during module validation ([#141](https://github.com/NomicFoundation/ignition/issues/141))
- Ban passing async functions to `buildModule` ([#138](https://github.com/NomicFoundation/ignition/issues/138))
