### PR TITLE
feat: force flag on deploy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
     {
       "name": "Debug core tests",
       "internalConsoleOptions": "openOnSessionStart",
-      "program": "${workspaceFolder}/packages/core/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "request": "launch",
       "skipFiles": ["<node_internals>/**"],
       "type": "node",

--- a/docs/getting-started-guide.md
+++ b/docs/getting-started-guide.md
@@ -38,7 +38,7 @@ $ npx hardhat
 Add **Ignition** to your **Hardhat** project by installing the plugin:
 
 ```bash
-npm install @ignored/hardhat-ignition
+npm install --save-dev @ignored/hardhat-ignition
 ```
 
 Modify your `hardhat.config.js` file, to include **Ignition**:

--- a/docs/running-a-deployment.md
+++ b/docs/running-a-deployment.md
@@ -117,4 +117,10 @@ Each run logs its events to a journal file (recorded in a sibling file to the mo
 
 > **NOTE**: Changes to modules between runs of a deployment are not currently supported
 
+To start a deployment again, ignoring the state from previous runs and rerunning the entirety of the module, the force flag can be used:
+
+```
+npx hardhat deploy MyModule.js --network localhost --force
+```
+
 For non-development network deployments, this means some form of deployment freezing will be recommended that records relevant information such as contract abi, deployed address and network. These files will be recommended to be committed into project repositories as well.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18396,7 +18396,7 @@
         "@types/chai-as-promised": "^7.1.5",
         "@types/debug": "^4.1.7",
         "@types/fs-extra": "^9.0.13",
-        "@types/mocha": "^9.0.0",
+        "@types/mocha": "9.1.1",
         "@types/node": "12.20.25",
         "@types/object-hash": "^2.2.1",
         "@types/react": "^17.0.35",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     "test:debug": "DEBUG='ignition:*' npm run test",
     "test:build": "tsc --project ./test/",
     "ui-samples": "TS_NODE_TRANSPILE_ONLY=1 ts-node ui-samples/index.tsx",
-    "test:coverage": "nyc mocha \"test/**/*.ts\"",
+    "test:coverage": "nyc mocha --recursive \"test/**/*.ts\"",
     "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {
@@ -39,7 +39,7 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/debug": "^4.1.7",
     "@types/fs-extra": "^9.0.13",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "9.1.1",
     "@types/node": "12.20.25",
     "@types/object-hash": "^2.2.1",
     "@types/react": "^17.0.35",

--- a/packages/core/src/Ignition.ts
+++ b/packages/core/src/Ignition.ts
@@ -31,6 +31,7 @@ export interface IgnitionDeployOptions {
   gasPriceIncrementPerRetry: BigNumber | null;
   pollingInterval: number;
   eventDuration: number;
+  force: boolean;
 }
 
 type ModuleOutputs = Record<string, any>;
@@ -104,6 +105,7 @@ export class Ignition {
         gasPriceIncrementPerRetry: options.gasPriceIncrementPerRetry,
         pollingInterval: options.pollingInterval,
         eventDuration: options.eventDuration,
+        force: options.force,
       });
 
       return this._buildOutputFrom(executionResult, moduleOutputs);

--- a/packages/core/src/deployment/Deployment.ts
+++ b/packages/core/src/deployment/Deployment.ts
@@ -110,10 +110,11 @@ export class Deployment {
     });
   }
 
-  public startExecutionPhase(executionGraphHash: string) {
+  public startExecutionPhase(executionGraphHash: string, force: boolean) {
     return this._runDeploymentCommand("Starting Execution", {
       type: "EXECUTION::START",
       executionGraphHash,
+      force,
     });
   }
 

--- a/packages/core/src/deployment/deployStateReducer.ts
+++ b/packages/core/src/deployment/deployStateReducer.ts
@@ -96,7 +96,8 @@ export function deployStateReducer(
         initialiseExecutionStateFrom(
           state.transform.executionGraph,
           action.executionGraphHash,
-          state.execution
+          state.execution,
+          action.force
         ),
         action
       );
@@ -131,12 +132,13 @@ export function deployStateReducer(
 function initialiseExecutionStateFrom(
   executionGraph: ExecutionGraph,
   executionGraphHash: string,
-  previousExecutionState: ExecutionState
+  previousExecutionState: ExecutionState,
+  force: boolean
 ): ExecutionState {
   const vertexes = Array.from(executionGraph.vertexes.keys()).reduce<{
     [key: number]: VertexExecutionState;
   }>((acc, id) => {
-    if (previousExecutionState.vertexes[id]?.status === "COMPLETED") {
+    if (!force && previousExecutionState.vertexes[id]?.status === "COMPLETED") {
       return { ...acc, [id]: previousExecutionState.vertexes[id] };
     }
 

--- a/packages/core/src/execution/execute.ts
+++ b/packages/core/src/execution/execute.ts
@@ -39,7 +39,7 @@ export async function executeInBatches(
 ): Promise<VisitResult> {
   const executionGraphHash = hashExecutionGraph(executionGraph);
 
-  await deployment.startExecutionPhase(executionGraphHash);
+  await deployment.startExecutionPhase(executionGraphHash, options.force);
 
   while (deployment.hasUnstarted()) {
     const batch = calculateNextBatch(

--- a/packages/core/src/types/deployment.ts
+++ b/packages/core/src/types/deployment.ts
@@ -47,6 +47,7 @@ export type DeployStateExecutionCommand =
   | {
       type: "EXECUTION::START";
       executionGraphHash: string;
+      force: boolean;
     }
   | {
       type: "EXECUTION::SET_BATCH";
@@ -162,6 +163,7 @@ export interface ExecutionOptions {
   gasPriceIncrementPerRetry: BigNumber | null;
   pollingInterval: number;
   eventDuration: number;
+  force: boolean;
 }
 
 export interface ExecutionContext {

--- a/packages/core/test/execution/rerun.ts
+++ b/packages/core/test/execution/rerun.ts
@@ -84,6 +84,16 @@ describe("Reruning execution", () => {
                 return {};
               }
 
+              if (tx === "0x00003") {
+                return {
+                  contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+                };
+              }
+
+              if (tx === "0x00004") {
+                return {};
+              }
+
               throw new Error(`Unexpected transaction sent: ${tx}`);
             },
           },
@@ -133,6 +143,19 @@ describe("Reruning execution", () => {
         redeployResult.result.token.value.address,
         "0x1F98431c8aD98523631AE4a59f267346ea31F984"
       );
+    });
+
+    it("should rerun all on-chain transactions on second run if force enabled", async () => {
+      // Arrange
+      await ignition.deploy(myModule, {} as any);
+
+      // Act
+      const [redeployResult] = await ignition.deploy(myModule, {
+        force: true,
+      } as any);
+
+      // Assert
+      assert.equal(redeployResult._kind, "success");
     });
   });
 

--- a/packages/core/test/state-reducer/execution.ts
+++ b/packages/core/test/state-reducer/execution.ts
@@ -55,6 +55,7 @@ describe("deployment state reducer", () => {
       state = deployStateReducer(state, {
         type: "EXECUTION::START",
         executionGraphHash: "XXX",
+        force: false,
       });
     });
 
@@ -90,6 +91,7 @@ describe("deployment state reducer", () => {
         {
           type: "EXECUTION::START",
           executionGraphHash: "XXX",
+          force: false,
         },
         {
           type: "EXECUTION::SET_BATCH",
@@ -110,6 +112,7 @@ describe("deployment state reducer", () => {
         {
           type: "EXECUTION::START",
           executionGraphHash: "XXX",
+          force: false,
         },
         {
           type: "EXECUTION::SET_BATCH",
@@ -145,6 +148,7 @@ describe("deployment state reducer", () => {
         {
           type: "EXECUTION::START",
           executionGraphHash: "XXX",
+          force: false,
         },
         {
           type: "EXECUTION::SET_BATCH",
@@ -179,6 +183,7 @@ describe("deployment state reducer", () => {
         {
           type: "EXECUTION::START",
           executionGraphHash: "XXX",
+          force: false,
         },
 
         {
@@ -252,6 +257,7 @@ describe("deployment state reducer", () => {
         {
           type: "EXECUTION::START",
           executionGraphHash: "XXX",
+          force: false,
         },
 
         {
@@ -301,6 +307,7 @@ describe("deployment state reducer", () => {
         {
           type: "EXECUTION::START",
           executionGraphHash: "XXX",
+          force: false,
         },
 
         {

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -25,7 +25,10 @@ export class IgnitionWrapper {
   constructor(
     private _providers: Providers,
     private _ethers: HardhatEthers,
-    private _deployOptions: Omit<IgnitionDeployOptions, keyof { ui?: boolean }>
+    private _deployOptions: Omit<
+      IgnitionDeployOptions,
+      keyof { force?: boolean }
+    >
   ) {}
 
   public async deploy<T extends ModuleDict>(
@@ -35,9 +38,11 @@ export class IgnitionWrapper {
       journalPath?: string | undefined;
       ui?: boolean;
       journal?: ICommandJournal;
+      force?: boolean;
     }
   ): Promise<DeployResult> {
     const showUi = deployParams?.ui ?? false;
+    const force = deployParams?.force ?? false;
 
     const services = createServices(this._providers);
     const chainId = await services.network.getChainId();
@@ -58,10 +63,10 @@ export class IgnitionWrapper {
       await this._providers.config.setParams(deployParams.parameters);
     }
 
-    const [deploymentResult] = await ignition.deploy(
-      ignitionModule,
-      this._deployOptions
-    );
+    const [deploymentResult] = await ignition.deploy(ignitionModule, {
+      ...this._deployOptions,
+      force,
+    });
 
     if (deploymentResult._kind === "hold") {
       const heldVertexes = deploymentResult.holds;

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -85,12 +85,14 @@ task("deploy")
     "parameters",
     "A JSON object as a string, of the module parameters, or a relative path to a JSON file"
   )
+  .addFlag("force", "restart the deployment ignoring previous history")
   .setAction(
     async (
       {
         moduleNameOrPath,
         parameters: parametersInput,
-      }: { moduleNameOrPath: string; parameters?: string },
+        force,
+      }: { moduleNameOrPath: string; parameters?: string; force: boolean },
       hre
     ) => {
       if (hre.network.name !== "hardhat") {
@@ -147,6 +149,7 @@ task("deploy")
           parameters,
           journalPath,
           ui: DISPLAY_UI,
+          force,
         });
       } catch (err) {
         if (DISPLAY_UI) {

--- a/packages/hardhat-plugin/test/CommandJournal.ts
+++ b/packages/hardhat-plugin/test/CommandJournal.ts
@@ -19,7 +19,7 @@ describe("File based command journal", () => {
     const journal = new CommandJournal(31337, tempCommandFilePath);
 
     const commands: DeployStateExecutionCommand[] = [
-      { type: "EXECUTION::START", executionGraphHash: "XXX" },
+      { type: "EXECUTION::START", executionGraphHash: "XXX", force: false },
       { type: "EXECUTION::SET_BATCH", batch: [0, 1, 2, 3] },
       {
         type: "EXECUTION::SET_VERTEX_RESULT",
@@ -93,7 +93,7 @@ describe("File based command journal", () => {
     );
 
     const commands: DeployStateExecutionCommand[] = [
-      { type: "EXECUTION::START", executionGraphHash: "XXX" },
+      { type: "EXECUTION::START", executionGraphHash: "XXX", force: false },
     ];
 
     for (const command of commands) {


### PR DESCRIPTION
Support `--force` on deploy to ignore previous deployment runs and start again as if from a clean deployment. The history in the journal is kept but each action in the execution graph will be executed.

Resolves #132.