### PR TITLE
fix: change warning check to chain

### DIFF
--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -95,11 +95,11 @@ task("deploy")
       }: { moduleNameOrPath: string; parameters?: string; force: boolean },
       hre
     ) => {
-      if (hre.network.name !== "hardhat") {
-        const chainId = await hre.network.provider.request({
-          method: "eth_chainId",
-        });
+      const chainId = await hre.network.provider.request({
+        method: "eth_chainId",
+      });
 
+      if (Number(chainId) !== 31337) {
         const prompt = await prompts({
           type: "confirm",
           name: "networkConfirmation",

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -95,17 +95,17 @@ task("deploy")
       }: { moduleNameOrPath: string; parameters?: string; force: boolean },
       hre
     ) => {
-      const chainId = await hre.network.provider.request({
-        method: "eth_chainId",
-      });
+      const chainId = Number(
+        await hre.network.provider.request({
+          method: "eth_chainId",
+        })
+      );
 
-      if (Number(chainId) !== 31337) {
+      if (chainId !== 31337) {
         const prompt = await prompts({
           type: "confirm",
           name: "networkConfirmation",
-          message: `Confirm deploy to network ${hre.network.name} (${Number(
-            chainId
-          )})?`,
+          message: `Confirm deploy to network ${hre.network.name} (${chainId})?`,
           initial: false,
         });
 


### PR DESCRIPTION
Switch from network name to chain id for the warning check on deploying to real networks. We do not ask when:

* running ephemerally
* running in tests
* running against local node

Fixes #134.