### PR TITLE
chore: bump version to v0.0.9

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -5,12 +5,15 @@ To publish ignition:
 1. git fetch, Checkout out `main`, then ensure your branch is up to date `git pull --ff-only`
 2. Run a full check, stopping on failure: `npm run fullcheck`
 3. Create a release branch `git checkout -b release/yyyy-mm-dd`
-4. Under `./packages/core`, update the package version based on semver if appropriate.
-5. Under `./packages/hardhat-plugin`, update the package version based on semver if appropriate.
-6. Update dependency package versions in examples to match
-7. Update the `CHANGELOG.md` under `./packages/core`.
-8. Update the `CHANGELOG.md` under `./packages/hardhat-plugin`.
-9. Commit the version update `git commit`:
+4. Update the `CHANGELOG.md` under `./packages/core`.
+5. Update the `CHANGELOG.md` under `./packages/hardhat-plugin`.
+6. Update the package versions based on semver: `npm version --no-git-tag-version --workspaces patch #minor #major`
+7. Update the version of dependencies:
+
+- cores version in hardhat-ignition devDeps and peerDeps
+- examples version of hardhat-ignition
+
+8. Commit the version update `git commit`:
 
 ```
 chore: bump version to vX.X.X
@@ -19,10 +22,10 @@ Update the packages versions and changelogs for the `X.X.X -
 yyyy-mm-dd` release.
 ```
 
-10. Push the release branch and open a pull request, the PR description should match the changelogs
-11. On a successful check, `rebase merge` the release branch into main
-12. Switch to main branch and pull the latest changes
-13. Git tag the version, `g tag -a v0.x.x -m "v0.x.x"` and push the tag `git push --follow-tags`
-14. Publish `core` if appropriate: `npm publish`
-15. Publish `hardhat-plugin` if appropriate: `npm publish`
-16. Create a release on github off of the pushed tag
+9. Push the release branch and open a pull request, the PR description should match the changelogs
+10. On a successful check, `rebase merge` the release branch into main
+11. Switch to main branch and pull the latest changes
+12. Git tag the version, `g tag -a v0.x.x -m "v0.x.x"` and push the tag `git push --follow-tags`
+13. Publish `core` if appropriate: `npm publish`
+14. Publish `hardhat-plugin` if appropriate: `npm publish`
+15. Create a release on github off of the pushed tag

--- a/examples/create2/package.json
+++ b/examples/create2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-create2-example",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.9",
   "scripts": {
     "test:examples": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "hardhat": "^2.10.0",
-    "@ignored/hardhat-ignition": "^0.0.8"
+    "@ignored/hardhat-ignition": "^0.0.9"
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.7.3"

--- a/examples/ens/package.json
+++ b/examples/ens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-ens-example",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.9",
   "scripts": {
     "test:examples": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.8",
+    "@ignored/hardhat-ignition": "^0.0.9",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/multisig/package.json
+++ b/examples/multisig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-example-multisig",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.9",
   "scripts": {
     "test:examples": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.8",
+    "@ignored/hardhat-ignition": "^0.0.9",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-sample-example",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.9",
   "scripts": {
     "test:examples": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.8",
+    "@ignored/hardhat-ignition": "^0.0.9",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/ts-sample/package.json
+++ b/examples/ts-sample/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-ts-sample-example",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.9",
   "scripts": {
     "test:examples": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.8",
+    "@ignored/hardhat-ignition": "^0.0.9",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/examples/uniswap/package.json
+++ b/examples/uniswap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-uniswap-example",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.9",
   "scripts": {
     "test:examples": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@ethersproject/abi": "5.7.0",
     "@ethersproject/providers": "5.7.2",
-    "@ignored/hardhat-ignition": "^0.0.8",
+    "@ignored/hardhat-ignition": "^0.0.9",
     "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
     "@nomicfoundation/hardhat-network-helpers": "1.0.6",
     "@nomicfoundation/hardhat-toolbox": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "root",
-  "version": "0.0.0",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "0.0.0",
       "license": "SEE LICENSE IN EACH PACKAGE'S LICENSE FILE",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "4.31.2",
@@ -29,12 +28,12 @@
     },
     "examples/create2": {
       "name": "@nomicfoundation/ignition-create2-example",
-      "version": "0.0.1",
+      "version": "0.0.9",
       "dependencies": {
         "@openzeppelin/contracts": "4.7.3"
       },
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.0.8",
+        "@ignored/hardhat-ignition": "^0.0.9",
         "hardhat": "^2.10.0"
       }
     },
@@ -45,14 +44,14 @@
     },
     "examples/ens": {
       "name": "@nomicfoundation/ignition-ens-example",
-      "version": "0.0.1",
+      "version": "0.0.9",
       "dependencies": {
         "@ensdomains/ens-contracts": "0.0.11"
       },
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.8",
+        "@ignored/hardhat-ignition": "^0.0.9",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -80,14 +79,14 @@
     },
     "examples/multisig": {
       "name": "@nomicfoundation/ignition-example-multisig",
-      "version": "0.0.1",
+      "version": "0.0.9",
       "dependencies": {
         "@openzeppelin/contracts": "^4.3.2"
       },
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.8",
+        "@ignored/hardhat-ignition": "^0.0.9",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -115,11 +114,11 @@
     },
     "examples/sample": {
       "name": "@nomicfoundation/ignition-sample-example",
-      "version": "0.0.1",
+      "version": "0.0.9",
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.8",
+        "@ignored/hardhat-ignition": "^0.0.9",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -147,11 +146,11 @@
     },
     "examples/ts-sample": {
       "name": "@nomicfoundation/ignition-ts-sample-example",
-      "version": "0.0.1",
+      "version": "0.0.9",
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.8",
+        "@ignored/hardhat-ignition": "^0.0.9",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -396,7 +395,7 @@
     },
     "examples/uniswap": {
       "name": "@nomicfoundation/ignition-uniswap-example",
-      "version": "0.0.1",
+      "version": "0.0.9",
       "dependencies": {
         "@openzeppelin/contracts": "npm:@openzeppelin/contracts@3.4.2-solc-0.7",
         "@uniswap/swap-router-contracts": "1.1.0",
@@ -410,7 +409,7 @@
       "devDependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/providers": "5.7.2",
-        "@ignored/hardhat-ignition": "^0.0.8",
+        "@ignored/hardhat-ignition": "^0.0.9",
         "@nomicfoundation/hardhat-chai-matchers": "1.0.4",
         "@nomicfoundation/hardhat-network-helpers": "1.0.6",
         "@nomicfoundation/hardhat-toolbox": "2.0.0",
@@ -18362,7 +18361,7 @@
     },
     "packages/core": {
       "name": "@ignored/ignition-core",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "5.6.1",
@@ -18440,7 +18439,7 @@
     },
     "packages/hardhat-plugin": {
       "name": "@ignored/hardhat-ignition",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.2",
@@ -18454,7 +18453,7 @@
         "serialize-error": "8.1.0"
       },
       "devDependencies": {
-        "@ignored/ignition-core": "^0.0.8",
+        "@ignored/ignition-core": "^0.0.9",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@types/chai": "^4.2.22",
@@ -18495,7 +18494,7 @@
         "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
       },
       "peerDependencies": {
-        "@ignored/ignition-core": "^0.0.7",
+        "@ignored/ignition-core": "^0.0.9",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "hardhat": "^2.12.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "root",
-  "version": "0.0.0",
   "author": "Nomic Foundation",
   "license": "SEE LICENSE IN EACH PACKAGE'S LICENSE FILE",
   "private": true,

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.0.9 - 2023-03-02
+
+### Added
+
+- Support defining modules in typescript ([#101](https://github.com/NomicFoundation/ignition/issues/101))
+- Allow rerunning deployment while ignoring journal history through a `--force` flag ([#132](https://github.com/NomicFoundation/ignition/issues/132))
+
 ## 0.0.8 - 2023-02-16
 
 ### Changed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/ignition-core",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.0.9 - 2023-03-02
+
+### Added
+
+- Support defining modules in typescript ([#101](https://github.com/NomicFoundation/ignition/issues/101))
+- Allow rerunning deployment while ignoring journal history through a `--force` flag ([#132](https://github.com/NomicFoundation/ignition/issues/132))
+
+### Changed
+
+- Do not ask for confirmation when deploying to a hardhat node ([#134](https://github.com/NomicFoundation/ignition/issues/134))
+
 ## 0.0.8 - 2023-02-16
 
 ### Added

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/hardhat-ignition",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",
@@ -33,7 +33,7 @@
     "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {
-    "@ignored/ignition-core": "^0.0.8",
+    "@ignored/ignition-core": "^0.0.9",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@types/chai": "^4.2.22",
@@ -71,7 +71,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@ignored/ignition-core": "^0.0.7",
+    "@ignored/ignition-core": "^0.0.9",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "hardhat": "^2.12.0"
   },


### PR DESCRIPTION
## 0.0.9 - 2023-03-02

### Added

- Support defining modules in typescript ([#101](https://github.com/NomicFoundation/ignition/issues/101))
- Allow rerunning deployment while ignoring journal history through a `--force` flag ([#132](https://github.com/NomicFoundation/ignition/issues/132))

### Changed

- Do not ask for confirmation when deploying to a hardhat node ([#134](https://github.com/NomicFoundation/ignition/issues/134))
