### PR TITLE
improvement: validation errors

### DIFF
--- a/packages/core/src/Ignition.ts
+++ b/packages/core/src/Ignition.ts
@@ -136,7 +136,7 @@ export class Ignition {
 
     const chainId = await this._services.network.getChainId();
 
-    const { graph: deploymentGraph } = generateDeploymentGraphFrom(
+    const { graph: deploymentGraph, callPoints } = generateDeploymentGraphFrom(
       deploymentModule,
       {
         chainId,
@@ -145,6 +145,7 @@ export class Ignition {
 
     const validationResult = await validateDeploymentGraph(
       deploymentGraph,
+      callPoints,
       this._services
     );
 
@@ -171,14 +172,18 @@ export class Ignition {
     ignitionModule: Module<T>
   ): Promise<{ result: any; moduleOutputs: T }> {
     log("Generate deployment graph from module");
-    const { graph: deploymentGraph, moduleOutputs } =
-      generateDeploymentGraphFrom(ignitionModule, {
-        chainId: deployment.state.details.chainId,
-      });
+    const {
+      graph: deploymentGraph,
+      callPoints,
+      moduleOutputs,
+    } = generateDeploymentGraphFrom(ignitionModule, {
+      chainId: deployment.state.details.chainId,
+    });
 
     await deployment.startValidation();
     const validationResult = await validateDeploymentGraph(
       deploymentGraph,
+      callPoints,
       deployment.services
     );
 

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -58,6 +58,15 @@ import { resolveProxyDependency } from "utils/proxy";
 import { DeploymentGraph } from "./DeploymentGraph";
 import { ScopeStack } from "./ScopeStack";
 
+type DeploymentApiPublicFunctions =
+  | InstanceType<typeof DeploymentBuilder>["contract"]
+  | InstanceType<typeof DeploymentBuilder>["library"]
+  | InstanceType<typeof DeploymentBuilder>["contractAt"]
+  | InstanceType<typeof DeploymentBuilder>["call"]
+  | InstanceType<typeof DeploymentBuilder>["event"]
+  | InstanceType<typeof DeploymentBuilder>["sendETH"]
+  | InstanceType<typeof DeploymentBuilder>["useModule"];
+
 const DEFAULT_VALUE = ethers.utils.parseUnits("0");
 
 function parseEventParams(
@@ -575,20 +584,18 @@ export class DeploymentBuilder implements IDeploymentBuilder {
 
   private static _captureCallPoint(
     callPoints: CallPoints,
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    f: Function,
+    f: DeploymentApiPublicFunctions,
     vertexId: number
   ) {
     const potentialValidationError = new IgnitionValidationError("");
-    potentialValidationError.resetStackFrom(f);
+    potentialValidationError.resetStackFrom(f as any);
     callPoints[vertexId] = potentialValidationError;
   }
 
   private static _addVertex(
     graph: DeploymentGraph,
     callPoints: CallPoints,
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    f: Function,
+    f: DeploymentApiPublicFunctions,
     depNode: DeploymentGraphVertex
   ) {
     DeploymentBuilder._captureCallPoint(callPoints, f, depNode.id);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ export { buildSubgraph } from "dsl/buildSubgraph";
 export { viewExecutionResults } from "deployment/utils";
 export { createServices } from "services/createServices";
 export { serializeReplacer } from "utils/serialize";
-export { IgnitionError } from "utils/errors";
+export { IgnitionError, IgnitionValidationError } from "utils/errors";
 export { TransactionsService } from "services/TransactionsService";
 export { ContractsService } from "services/ContractsService";
 export { VertexResultEnum } from "types/graph";

--- a/packages/core/src/process/generateDeploymentGraphFrom.ts
+++ b/packages/core/src/process/generateDeploymentGraphFrom.ts
@@ -1,5 +1,6 @@
 import { DeploymentBuilder } from "dsl/DeploymentBuilder";
 import type {
+  CallPoints,
   DeploymentBuilderOptions,
   IDeploymentGraph,
 } from "types/deploymentGraph";
@@ -10,7 +11,7 @@ import { assertModuleReturnTypes } from "utils/guards";
 export function generateDeploymentGraphFrom<T extends ModuleDict>(
   ignitionModule: Module<T>,
   builderOptions: DeploymentBuilderOptions
-): { graph: IDeploymentGraph; moduleOutputs: T } {
+): { graph: IDeploymentGraph; callPoints: CallPoints; moduleOutputs: T } {
   const graphBuilder = new DeploymentBuilder(builderOptions);
 
   const moduleOutputs = ignitionModule.action(graphBuilder);
@@ -23,7 +24,11 @@ export function generateDeploymentGraphFrom<T extends ModuleDict>(
 
   assertModuleReturnTypes(moduleOutputs);
 
-  return { graph: graphBuilder.graph, moduleOutputs };
+  return {
+    graph: graphBuilder.graph,
+    callPoints: graphBuilder.callPoints,
+    moduleOutputs,
+  };
 }
 
 function isPromise(promise: any) {

--- a/packages/core/src/types/deploymentGraph.ts
+++ b/packages/core/src/types/deploymentGraph.ts
@@ -233,3 +233,7 @@ export interface IDeploymentBuilder {
 export interface DeploymentBuilderOptions {
   chainId: number;
 }
+
+export interface CallPoints {
+  [key: number]: Error;
+}

--- a/packages/core/src/types/validation.ts
+++ b/packages/core/src/types/validation.ts
@@ -1,3 +1,6 @@
+import { Services } from "services/types";
+
+import { CallPoints } from "./deploymentGraph";
 import { ResultsAccumulator, VertexVisitResult, VisitResult } from "./graph";
 
 export type ValidationVisitResult = VisitResult<undefined>;
@@ -5,3 +8,8 @@ export type ValidationVisitResult = VisitResult<undefined>;
 export type ValidationVertexVisitResult = VertexVisitResult<undefined>;
 
 export type ValidationResultsAccumulator = ResultsAccumulator<undefined>;
+
+export interface ValidationDispatchContext {
+  services: Services;
+  callPoints: CallPoints;
+}

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -28,11 +28,13 @@ export class IgnitionValidationError extends HardhatPluginError {
    *
    * @param f the function to hide all of the stacktrace above
    */
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  public resetStackFrom(f: Function) {
+  public resetStackFrom(f: () => any) {
     Error.captureStackTrace(this, f);
-    // @ts-ignore
-    this._stack = this.stack ?? "";
+
+    // the base custom error from HH stores off the stack
+    // it uses to `_stack`, so we need to override this
+    // as well ... even though it is private.
+    (this as any)._stack = this.stack ?? "";
   }
 }
 

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -1,15 +1,38 @@
 import { BigNumber } from "ethers";
 import { HardhatPluginError } from "hardhat/plugins";
 
-export class InvalidArtifactError extends HardhatPluginError {
-  constructor(name: string) {
-    super("ignition", `Artifact with name '${name}' doesn't exist`);
-  }
-}
-
 export class IgnitionError extends HardhatPluginError {
   constructor(message: string) {
     super("ignition", message);
+  }
+}
+
+export class IgnitionValidationError extends HardhatPluginError {
+  constructor(message: string) {
+    super("ignition", message);
+
+    // This is required to allow calls to `resetStackFrom`,
+    // otherwise the function is not available on the
+    // error instance
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  /**
+   * Reset the stack hiding parts that are bellow the given function.
+   * The intention is the function should be part of the user callable
+   * api, so that the stack leads directly to the line in the module
+   * the user called (i.e. `m.contract(...)`)
+   *
+   * This is a hack to workaround the stack manipulation
+   * that `HardhatPluginError` does.
+   *
+   * @param f the function to hide all of the stacktrace above
+   */
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  public resetStackFrom(f: Function) {
+    Error.captureStackTrace(this, f);
+    // @ts-ignore
+    this._stack = this.stack ?? "";
   }
 }
 

--- a/packages/core/src/validation/dispatch/helpers.ts
+++ b/packages/core/src/validation/dispatch/helpers.ts
@@ -1,14 +1,8 @@
 import type { Services } from "services/types";
 import {
-  ArtifactContractDeploymentVertex,
-  ArtifactLibraryDeploymentVertex,
-  CallDeploymentVertex,
   CallPoints,
-  DeployedContractDeploymentVertex,
-  EventVertex,
-  HardhatContractDeploymentVertex,
-  HardhatLibraryDeploymentVertex,
-  SendVertex,
+  DeploymentGraphVertex,
+  InternalParamValue,
 } from "types/deploymentGraph";
 import type { CallableFuture } from "types/future";
 import { VertexResultEnum, VertexVisitResultFailure } from "types/graph";
@@ -67,13 +61,7 @@ export async function validateBytesForArtifact({
   callPoints,
   services,
 }: {
-  vertex:
-    | ArtifactContractDeploymentVertex
-    | HardhatContractDeploymentVertex
-    | EventVertex
-    | CallDeploymentVertex
-    | ArtifactLibraryDeploymentVertex
-    | HardhatLibraryDeploymentVertex;
+  vertex: DeploymentGraphVertex & { args: InternalParamValue[] };
   callPoints: CallPoints;
   services: Services;
 }): Promise<VertexVisitResultFailure | null> {
@@ -97,15 +85,7 @@ export async function validateBytesForArtifact({
 }
 
 export function buildValidationError(
-  vertex:
-    | ArtifactContractDeploymentVertex
-    | HardhatContractDeploymentVertex
-    | EventVertex
-    | CallDeploymentVertex
-    | ArtifactLibraryDeploymentVertex
-    | HardhatLibraryDeploymentVertex
-    | DeployedContractDeploymentVertex
-    | SendVertex,
+  vertex: DeploymentGraphVertex,
   message: string,
   callPoints: CallPoints
 ): VertexVisitResultFailure {

--- a/packages/core/src/validation/dispatch/validateDeployedContract.ts
+++ b/packages/core/src/validation/dispatch/validateDeployedContract.ts
@@ -1,26 +1,26 @@
 import { isAddress } from "@ethersproject/address";
 
-import { Services } from "services/types";
 import { DeployedContractDeploymentVertex } from "types/deploymentGraph";
 import { VertexResultEnum } from "types/graph";
 import {
+  ValidationDispatchContext,
   ValidationResultsAccumulator,
   ValidationVertexVisitResult,
 } from "types/validation";
-import { IgnitionError } from "utils/errors";
+
+import { buildValidationError } from "./helpers";
 
 export async function validateDeployedContract(
   vertex: DeployedContractDeploymentVertex,
   _resultAccumulator: ValidationResultsAccumulator,
-  _context: { services: Services }
+  { callPoints }: ValidationDispatchContext
 ): Promise<ValidationVertexVisitResult> {
   if (typeof vertex.address === "string" && !isAddress(vertex.address)) {
-    return {
-      _kind: VertexResultEnum.FAILURE,
-      failure: new IgnitionError(
-        `The existing contract ${vertex.label} has an invalid address ${vertex.address}`
-      ),
-    };
+    return buildValidationError(
+      vertex,
+      `The existing contract ${vertex.label} has an invalid address ${vertex.address}`,
+      callPoints
+    );
   }
 
   return {

--- a/packages/core/src/validation/dispatch/validateSendETH.ts
+++ b/packages/core/src/validation/dispatch/validateSendETH.ts
@@ -3,31 +3,36 @@ import { ethers, BigNumber } from "ethers";
 import { SendVertex } from "types/deploymentGraph";
 import { VertexResultEnum } from "types/graph";
 import {
+  ValidationDispatchContext,
   ValidationResultsAccumulator,
   ValidationVertexVisitResult,
 } from "types/validation";
-import { IgnitionError } from "utils/errors";
 import { isParameter } from "utils/guards";
+
+import { buildValidationError } from "./helpers";
 
 export async function validateSendETH(
   vertex: SendVertex,
-  _resultAccumulator: ValidationResultsAccumulator
+  _resultAccumulator: ValidationResultsAccumulator,
+  { callPoints }: ValidationDispatchContext
 ): Promise<ValidationVertexVisitResult> {
   if (!BigNumber.isBigNumber(vertex.value) && !isParameter(vertex.value)) {
-    return {
-      _kind: VertexResultEnum.FAILURE,
-      failure: new IgnitionError(`For send 'value' must be a BigNumber`),
-    };
+    return buildValidationError(
+      vertex,
+      `For send 'value' must be a BigNumber`,
+      callPoints
+    );
   }
 
   if (
     typeof vertex.address === "string" &&
     !ethers.utils.isAddress(vertex.address)
   ) {
-    return {
-      _kind: VertexResultEnum.FAILURE,
-      failure: new IgnitionError(`"${vertex.address}" is not a valid address`),
-    };
+    return buildValidationError(
+      vertex,
+      `"${vertex.address}" is not a valid address`,
+      callPoints
+    );
   }
 
   return {

--- a/packages/core/src/validation/dispatch/validateVirtual.ts
+++ b/packages/core/src/validation/dispatch/validateVirtual.ts
@@ -1,7 +1,7 @@
-import { Services } from "services/types";
 import { DeploymentGraphVertex } from "types/deploymentGraph";
 import { VertexResultEnum } from "types/graph";
 import {
+  ValidationDispatchContext,
   ValidationResultsAccumulator,
   ValidationVertexVisitResult,
 } from "types/validation";
@@ -9,7 +9,7 @@ import {
 export async function validateVirtual(
   _deploymentVertex: DeploymentGraphVertex,
   _resultAccumulator: ValidationResultsAccumulator,
-  _context: { services: Services }
+  _context: ValidationDispatchContext
 ): Promise<ValidationVertexVisitResult> {
   return {
     _kind: VertexResultEnum.SUCCESS,

--- a/packages/core/src/validation/dispatch/validationDispatch.ts
+++ b/packages/core/src/validation/dispatch/validationDispatch.ts
@@ -1,6 +1,6 @@
-import { Services } from "services/types";
 import { DeploymentGraphVertex } from "types/deploymentGraph";
 import {
+  ValidationDispatchContext,
   ValidationResultsAccumulator,
   ValidationVertexVisitResult,
 } from "types/validation";
@@ -19,7 +19,7 @@ import { validateVirtual } from "./validateVirtual";
 export function validationDispatch(
   deploymentVertex: DeploymentGraphVertex,
   resultAccumulator: ValidationResultsAccumulator,
-  context: { services: Services }
+  context: ValidationDispatchContext
 ): Promise<ValidationVertexVisitResult> {
   switch (deploymentVertex.type) {
     case "ArtifactContract":
@@ -59,7 +59,7 @@ export function validationDispatch(
     case "Event":
       return validateEvent(deploymentVertex, resultAccumulator, context);
     case "SendETH":
-      return validateSendETH(deploymentVertex, resultAccumulator);
+      return validateSendETH(deploymentVertex, resultAccumulator, context);
     default:
       assertUnknownDeploymentVertexType(deploymentVertex);
   }

--- a/packages/core/src/validation/validateDeploymentGraph.ts
+++ b/packages/core/src/validation/validateDeploymentGraph.ts
@@ -1,7 +1,7 @@
 import { getSortedVertexIdsFrom } from "graph/utils";
 import { visit } from "graph/visit";
 import { Services } from "services/types";
-import { IDeploymentGraph } from "types/deploymentGraph";
+import { CallPoints, IDeploymentGraph } from "types/deploymentGraph";
 import { ValidationVisitResult } from "types/validation";
 import { IgnitionError } from "utils/errors";
 
@@ -9,6 +9,7 @@ import { validationDispatch } from "./dispatch/validationDispatch";
 
 export async function validateDeploymentGraph(
   deploymentGraph: IDeploymentGraph,
+  callPoints: CallPoints,
   services: Services
 ): Promise<ValidationVisitResult> {
   try {
@@ -18,7 +19,7 @@ export async function validateDeploymentGraph(
       "Validation",
       orderedVertexIds,
       deploymentGraph,
-      { services },
+      { services, callPoints },
       new Map<number, null>(),
       validationDispatch
     );

--- a/packages/core/test/state-reducer/utils.ts
+++ b/packages/core/test/state-reducer/utils.ts
@@ -38,6 +38,7 @@ export async function resolveExecutionGraphFor(module: Module<any>) {
 
   const { _kind: validationKind } = await validateDeploymentGraph(
     deploymentGraph,
+    {},
     mockServices
   );
 

--- a/packages/hardhat-plugin/src/buildIgnitionProvidersFrom.ts
+++ b/packages/hardhat-plugin/src/buildIgnitionProvidersFrom.ts
@@ -7,7 +7,13 @@ export function buildIgnitionProvidersFrom(hre: HardhatRuntimeEnvironment) {
   const providers: Providers = {
     artifacts: {
       getArtifact: (name: string) => hre.artifacts.readArtifact(name),
-      hasArtifact: (name: string) => hre.artifacts.artifactExists(name),
+      hasArtifact: async (name: string) => {
+        try {
+          return await hre.artifacts.artifactExists(name);
+        } catch (err) {
+          return false;
+        }
+      },
     },
     gasProvider: {
       estimateGasLimit: async (tx: any) => {

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -83,7 +83,11 @@ export class IgnitionWrapper {
     }
 
     if (deploymentResult._kind === "failure") {
-      const [moduleId, failures] = deploymentResult.failures;
+      const [failureType, failures] = deploymentResult.failures;
+
+      if (failures.length === 1) {
+        throw failures[0];
+      }
 
       let failuresMessage = "";
       for (const failure of failures) {
@@ -91,7 +95,7 @@ export class IgnitionWrapper {
       }
 
       throw new IgnitionError(
-        `Execution failed for module '${moduleId}':\n\n${failuresMessage}`
+        `${failureType} for module '${ignitionModule.name}':\n\n${failuresMessage}`
       );
     }
 

--- a/packages/hardhat-plugin/src/ui/components/ValidationFailedPanel.tsx
+++ b/packages/hardhat-plugin/src/ui/components/ValidationFailedPanel.tsx
@@ -1,5 +1,6 @@
-import { DeployState } from "@ignored/ignition-core";
+import { DeployState, IgnitionValidationError } from "@ignored/ignition-core";
 import { Box, Text } from "ink";
+import { relative } from "path";
 
 export const ValidationFailedPanel = ({
   deployState,
@@ -10,7 +11,7 @@ export const ValidationFailedPanel = ({
     <Box flexDirection="column">
       <Text>
         Ignition validation <Text color="red">failed</Text> for module{" "}
-        {deployState.details.moduleName}
+        <Text bold>{deployState.details.moduleName}</Text>
       </Text>
 
       <Box flexDirection="column" marginTop={1}>
@@ -22,6 +23,58 @@ export const ValidationFailedPanel = ({
   );
 };
 
-export const ErrorBox = ({ error }: { error: Error }) => {
-  return <Text>{error.message}</Text>;
+export const ErrorBox: React.FC<{ error: Error }> = ({ error }) => {
+  return (
+    <Text>
+      <ErrorFileLocation error={error} /> - <Text color="red">error:</Text>{" "}
+      {error.message}
+    </Text>
+  );
+};
+
+export const ErrorFileLocation: React.FC<{ error: Error }> = ({ error }) => {
+  if (!(error instanceof IgnitionValidationError)) {
+    return null;
+  }
+
+  const { file, line, column } = parseFileLink(error);
+
+  if (file === "") {
+    return null;
+  }
+
+  return (
+    <Text>
+      <Text color={"cyanBright"}>{file}</Text>:
+      <Text color={"yellowBright"}>{line}</Text>:
+      <Text color={"yellowBright"}>{column}</Text>
+    </Text>
+  );
+};
+
+const parseFileLink = (
+  error: Error
+): { file: string; line: string; column: string } => {
+  try {
+    // @ts-ignore
+    // eslint-disable-next-line no-console
+    const stack = error.stack.split("\n")[1];
+
+    const regexp = /\s*at Object.action \D([^:]+):([^:]+):([^:]+)\)$/gm;
+    const matches = stack.matchAll(regexp);
+
+    let file: string = "";
+    let line: string = "";
+    let column: string = "";
+
+    for (const match of matches) {
+      file = match[1];
+      line = match[2];
+      column = match[3];
+    }
+
+    return { file: relative(process.cwd(), file), line, column };
+  } catch {
+    return { file: "", line: "", column: "" };
+  }
 };


### PR DESCRIPTION
Show the file/line/column against each validation error. The display allows cmd+click in the vscode terminal.

## Preview

![image](https://user-images.githubusercontent.com/24030/222777144-08dfa468-d853-44ab-8b74-5dcad9d71cd8.png)

## Implementation Details

To support this we capture a potential validation error when the deployment builder action is called. These potential errors are passed to the validation phase, one for each vertex. If a validation check fails we use the pre-captured error so that the stack trace shows the correct point in the module.

We have to do some magic in IgnitionValidationError. Firstly we need to externally rewrite the stack via a function call `resetStackFrom`, this is because Hardhat Errors manipulate the  stack themselves. To allow calling a custom function on the error, we need to manipulate the prototype because ... javascript.

Resolves https://github.com/NomicFoundation/ignition/issues/87.