### PR TITLE
refactor(core): remove dep on hardhat

### DIFF
--- a/config/eslint/.eslintrc.js
+++ b/config/eslint/.eslintrc.js
@@ -20,12 +20,7 @@ module.exports = {
     project: "./tsconfig.json",
     tsConfigRootDir: "./",
   },
-  plugins: [
-    "@nomiclabs/eslint-plugin-hardhat-internal-rules",
-    "eslint-plugin-import",
-    "@typescript-eslint",
-    "mocha",
-  ],
+  plugins: ["eslint-plugin-import", "@typescript-eslint", "mocha"],
   rules: {
     "import/no-unused-modules": [
       1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2736,12 +2736,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@nomiclabs/eslint-plugin-hardhat-internal-rules": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/eslint-plugin-hardhat-internal-rules/-/eslint-plugin-hardhat-internal-rules-1.0.2.tgz",
-      "integrity": "sha512-x0iaAQXCiDHZw+TEk2gnV7OdBI9OGBtAT5yYab3Bzpoiic4040TcUthEsysXLZTnIouSfZRh6PZh7tJV0dmo/A==",
-      "dev": true
-    },
     "node_modules/@nomiclabs/hardhat-ethers": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.2.tgz",
@@ -18374,7 +18368,6 @@
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
-        "@nomiclabs/eslint-plugin-hardhat-internal-rules": "^1.0.2",
         "@types/chai": "^4.2.22",
         "@types/chai-as-promised": "^7.1.5",
         "@types/debug": "^4.1.7",
@@ -18396,7 +18389,6 @@
         "eslint-plugin-mocha": "^9.0.0",
         "eslint-plugin-prettier": "4.0.0",
         "fast-glob": "^3.2.12",
-        "hardhat": "^2.12.0",
         "mocha": "^9.1.3",
         "nyc": "15.1.0",
         "prettier": "2.4.1",
@@ -18409,9 +18401,6 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.12.0"
       }
     },
     "packages/core/node_modules/strip-bom": {

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
     createDefaultProgram: true,
   },
   rules: {
-    "@nomiclabs/hardhat-internal-rules/only-hardhat-plugin-error": "error",
     "no-console": "error",
   },
   ignorePatterns: ["post-build.js"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "1.0.2",
-    "@nomiclabs/eslint-plugin-hardhat-internal-rules": "^1.0.2",
     "@types/chai": "^4.2.22",
     "@types/chai-as-promised": "^7.1.5",
     "@types/debug": "^4.1.7",
@@ -57,7 +56,6 @@
     "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-prettier": "4.0.0",
     "fast-glob": "^3.2.12",
-    "hardhat": "^2.12.0",
     "mocha": "^9.1.3",
     "nyc": "15.1.0",
     "prettier": "2.4.1",
@@ -67,9 +65,6 @@
     "ts-node": "10.8.1",
     "tsconfig-paths": "^4.1.0",
     "typescript": "^4.7.4"
-  },
-  "peerDependencies": {
-    "hardhat": "^2.12.0"
   },
   "dependencies": {
     "@ethersproject/address": "5.6.1",

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -1,15 +1,16 @@
 import { BigNumber } from "ethers";
-import { HardhatPluginError } from "hardhat/plugins";
 
-export class IgnitionError extends HardhatPluginError {
+export class IgnitionError extends Error {
   constructor(message: string) {
-    super("ignition", message);
+    super(message);
+
+    this.name = this.constructor.name;
   }
 }
 
-export class IgnitionValidationError extends HardhatPluginError {
+export class IgnitionValidationError extends IgnitionError {
   constructor(message: string) {
-    super("ignition", message);
+    super(message);
 
     // This is required to allow calls to `resetStackFrom`,
     // otherwise the function is not available on the
@@ -23,18 +24,10 @@ export class IgnitionValidationError extends HardhatPluginError {
    * api, so that the stack leads directly to the line in the module
    * the user called (i.e. `m.contract(...)`)
    *
-   * This is a hack to workaround the stack manipulation
-   * that `HardhatPluginError` does.
-   *
    * @param f the function to hide all of the stacktrace above
    */
   public resetStackFrom(f: () => any) {
     Error.captureStackTrace(this, f);
-
-    // the base custom error from HH stores off the stack
-    // it uses to `_stack`, so we need to override this
-    // as well ... even though it is private.
-    (this as any)._stack = this.stack ?? "";
   }
 }
 

--- a/packages/core/test/.eslintrc.js
+++ b/packages/core/test/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
     sourceType: "module",
   },
   rules: {
-    "@nomiclabs/hardhat-internal-rules/only-hardhat-plugin-error": "off",
     "import/no-extraneous-dependencies": [
       "error",
       {


### PR DESCRIPTION
Instead of throwing hh errors, we throw our own ignition core errors, this allows us to remove hardhat as a dependency. This is ideal as ignition core should not force you to use hardhat even implicitly.

Resolves #163.