### PR TITLE
fix: support lib vertexes in plan

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,6 @@ export { IgnitionError, IgnitionValidationError } from "./utils/errors";
 export { TransactionsService } from "./services/TransactionsService";
 export { ContractsService } from "./services/ContractsService";
 export { VertexResultEnum } from "./types/graph";
-
 export type {
   SerializedDeploymentResult,
   ContractInfo,
@@ -34,6 +33,7 @@ export type {
 export type {
   ExternalParamValue,
   IDeploymentBuilder,
+  DeploymentGraphVertex,
 } from "./types/deploymentGraph";
 export type { FutureDict } from "./types/future";
 export type { IgnitionPlan } from "./types/plan";

--- a/packages/hardhat-plugin/esbuild.js
+++ b/packages/hardhat-plugin/esbuild.js
@@ -2,7 +2,7 @@ const esbuild = require("esbuild");
 const fs = require("fs-extra");
 const path = require("path");
 
-const outdir = path.resolve(__dirname, "dist/plan/assets");
+const outdir = path.resolve(__dirname, "dist/src/plan/assets");
 const srcdir = path.resolve(__dirname, "src/plan/assets");
 
 const entryPoints = fs.readdirSync(srcdir).flatMap((f) => {
@@ -15,12 +15,19 @@ const entryPoints = fs.readdirSync(srcdir).flatMap((f) => {
   return fs.readdirSync(p).map((v) => `${p}/${v}`);
 });
 
-esbuild.build({
-  outdir,
-  entryPoints,
-  bundle: true,
-  loader: {
-    ".html": "copy",
-    ".png": "copy",
-  },
+const main = async () => {
+  await esbuild.build({
+    outdir,
+    entryPoints,
+    bundle: true,
+    loader: {
+      ".html": "copy",
+      ".png": "copy",
+    },
+  });
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
 });

--- a/packages/hardhat-plugin/src/plan/assets/bundle.ts
+++ b/packages/hardhat-plugin/src/plan/assets/bundle.ts
@@ -12,7 +12,9 @@ window.onload = () => {
     const classList = [...vertexElement.classList.values()];
 
     for (const className of classList) {
-      if (/^(deploy|call|transfer|event)/.test(className)) {
+      if (
+        /^(deploy-contract|deploy-library|call|transfer|event)/.test(className)
+      ) {
         const actionElement = document.getElementById(`action-${className}`);
         const vertexClassString = [...classList, "hovering"].join(" ");
 

--- a/packages/hardhat-plugin/src/plan/assets/templates/vertex.html
+++ b/packages/hardhat-plugin/src/plan/assets/templates/vertex.html
@@ -6,7 +6,7 @@
   <body class="pure-g">
     <div class="pure-u-1-1">
       <div class="title-bar">
-        <h1 class="header">Contract %type% - %label%</h1>
+        <h1 class="header">%typeText% - %label%</h1>
       </div>
     </div>
     <div class="pure-u-1-1">

--- a/packages/hardhat-plugin/src/plan/index.ts
+++ b/packages/hardhat-plugin/src/plan/index.ts
@@ -88,6 +88,7 @@ export class Renderer {
 
     for (const vertex of this.plan.deploymentGraph.vertexes.values()) {
       const type = utils.parseType(vertex);
+      const typeText = utils.toTypeText(type);
       const label = vertex.label;
 
       const params = utils.getParams(vertex);
@@ -103,7 +104,15 @@ export class Renderer {
 
       const vertexOutput = this._templates.vertex.replace(
         regex,
-        utils.replacer({ type, label, networkName, networkId, params, value })
+        utils.replacer({
+          type,
+          typeText,
+          label,
+          networkName,
+          networkId,
+          params,
+          value,
+        })
       );
 
       this._writeModuleHTML(vertex.id, vertexOutput);


### PR DESCRIPTION
Enforce the vertex types support through the type system. Include the library vertexes as a type of deploy.

Change the templating to include the new type strings.

Fixes #131.

## Preview

![image](https://user-images.githubusercontent.com/24030/225060771-0fd37be3-2340-4fcd-a476-39739c218a70.png)
