### PR TITLE
refactor: remove export of individual services

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,6 +1,4 @@
 export { viewExecutionResults } from "./internal/deployment/utils";
 export { createServices } from "./internal/services/createServices";
-export { serializeReplacer } from "./internal/utils/serialize";
-export { TransactionsService } from "./internal/services/TransactionsService";
-export { ContractsService } from "./internal/services/ContractsService";
 export { VertexResultEnum } from "./internal/types/graph";
+export { serializeReplacer } from "./internal/utils/serialize";

--- a/packages/core/test/options.ts
+++ b/packages/core/test/options.ts
@@ -1,0 +1,127 @@
+/* eslint-disable import/no-unused-modules */
+
+import { assert } from "chai";
+import { BigNumber, ethers } from "ethers";
+
+import { buildModule, Ignition } from "../src";
+import { Artifact } from "../src/types/hardhat";
+
+import { getMockServices } from "./helpers";
+
+describe("deploy options", () => {
+  const tokenArtifact: Artifact = {
+    contractName: "Token",
+    abi: [
+      {
+        name: "ConfigComplete",
+        type: "event",
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: "address",
+            name: "name",
+            type: "address",
+          },
+        ],
+      },
+      {
+        inputs: [
+          {
+            internalType: "uint256",
+            name: "supply",
+            type: "uint256",
+          },
+        ],
+        name: "configure",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+      },
+    ],
+    bytecode: "0x0000000001",
+    linkReferences: {},
+  };
+
+  let ignition: Ignition;
+  let capturedTxOptions: any = null;
+
+  before(async function () {
+    const services = getMockServices();
+
+    ignition = new Ignition({
+      services: {
+        ...services,
+        accounts: {
+          ...services.accounts,
+          getAccounts: async () => {
+            return ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"];
+          },
+          getSigner: async (_address: string) => {
+            return new ethers.VoidSigner(_address);
+          },
+        },
+        artifacts: {
+          hasArtifact: async () => true,
+          getArtifact: async () => tokenArtifact,
+          getAllArtifacts: async () => [tokenArtifact],
+        },
+        transactions: {
+          ...services.transactions,
+          wait: async () => ({
+            blockHash: "",
+            blockNumber: 0,
+            confirmations: 0,
+            from: "",
+            byzantium: true,
+            contractAddress: "",
+            cumulativeGasUsed: BigNumber.from(0),
+            effectiveGasPrice: BigNumber.from(0),
+            gasUsed: BigNumber.from(0),
+            logs: [],
+            logsBloom: "",
+            to: "",
+            transactionHash: "",
+            transactionIndex: 0,
+            type: 0,
+          }),
+        },
+        contracts: {
+          ...services.contracts,
+          sendTx: async (_tran, txOptions) => {
+            capturedTxOptions = txOptions;
+            return "0xb75381e904154b34814d387c29e1927449edd98d30f5e310f25e9b1f19b0b077";
+          },
+        },
+      },
+    });
+
+    const module = buildModule("Example", (m) => {
+      m.contract("Token");
+
+      return {};
+    });
+
+    const result = await ignition.deploy(module, {
+      maxRetries: 1,
+      gasPriceIncrementPerRetry: BigNumber.from(1000),
+      pollingInterval: 4,
+      eventDuration: 10000,
+      networkName: "test-network",
+      force: false,
+      txPollingInterval: 4,
+    });
+
+    assert.equal(result._kind, "success");
+  });
+
+  it("should pass the options through to the transaction service", async function () {
+    assert.equal(capturedTxOptions.maxRetries, 1);
+    assert(BigNumber.isBigNumber(capturedTxOptions.gasPriceIncrementPerRetry));
+    assert(
+      BigNumber.from(capturedTxOptions.gasPriceIncrementPerRetry).eq(1000)
+    );
+    assert.equal(capturedTxOptions.pollingInterval, 4);
+    assert.equal(capturedTxOptions.eventDuration, 10000);
+  });
+});

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -23,14 +23,16 @@ type DeployResult<T extends ModuleDict> = {
   [K in keyof T]: Contract;
 };
 
+export type IgnitionWrapperOptions = Omit<
+  IgnitionDeployOptions,
+  keyof { force?: boolean }
+>;
+
 export class IgnitionWrapper {
   constructor(
     private _providers: Providers,
     private _ethers: HardhatEthers,
-    private _deployOptions: Omit<
-      IgnitionDeployOptions,
-      keyof { force?: boolean }
-    >
+    public options: IgnitionWrapperOptions
   ) {}
 
   public async deploy<T extends ModuleDict>(
@@ -68,7 +70,7 @@ export class IgnitionWrapper {
     }
 
     const deploymentResult = await ignition.deploy(ignitionModule, {
-      ...this._deployOptions,
+      ...this.options,
       force,
     });
 


### PR DESCRIPTION
The ContractServices and TransactionServices exports were only for test use.

The existing test of config has been split, the integration tests have been reduced to very simple checks that we load options for Ignition properly. The config tests proper have been shifted to core but now only test from the `Ignition` object being initialized to the config options use. Combined these give _close_ to equivalent coverage.

Part of #171.