### PR TITLE
refactor: pass providers to Ignition constructor

### DIFF
--- a/packages/core/src/Ignition.ts
+++ b/packages/core/src/Ignition.ts
@@ -38,18 +38,34 @@ export class Ignition {
   private _uiRenderer: UpdateUiAction;
   private _journal: ICommandJournal;
 
-  constructor({
+  public static create({
     providers,
-    uiRenderer,
-    journal,
+    uiRenderer = () => {},
+    journal = new NoopCommandJournal(),
   }: {
     providers: Providers;
     uiRenderer?: UpdateUiAction;
     journal?: ICommandJournal;
   }) {
-    this._services = createServices(providers);
-    this._uiRenderer = uiRenderer ?? (() => {});
-    this._journal = journal ?? new NoopCommandJournal();
+    return new Ignition({
+      services: createServices(providers),
+      uiRenderer,
+      journal,
+    });
+  }
+
+  protected constructor({
+    services,
+    uiRenderer,
+    journal,
+  }: {
+    services: Services;
+    uiRenderer: UpdateUiAction;
+    journal: ICommandJournal;
+  }) {
+    this._services = services;
+    this._uiRenderer = uiRenderer;
+    this._journal = journal;
   }
 
   public async deploy<T extends ModuleDict>(

--- a/packages/core/src/Ignition.ts
+++ b/packages/core/src/Ignition.ts
@@ -25,9 +25,11 @@ import { hashExecutionGraph } from "./internal/execution/utils";
 import { NoopCommandJournal } from "./internal/journal/NoopCommandJournal";
 import { generateDeploymentGraphFrom } from "./internal/process/generateDeploymentGraphFrom";
 import { transformDeploymentGraphToExecutionGraph } from "./internal/process/transformDeploymentGraphToExecutionGraph";
+import { createServices } from "./internal/services/createServices";
 import { Services } from "./internal/types/services";
 import { resolveProxyValue } from "./internal/utils/proxy";
 import { validateDeploymentGraph } from "./internal/validation/validateDeploymentGraph";
+import { Providers } from "./types/providers";
 
 const log = setupDebug("ignition:main");
 
@@ -37,15 +39,15 @@ export class Ignition {
   private _journal: ICommandJournal;
 
   constructor({
-    services,
+    providers,
     uiRenderer,
     journal,
   }: {
-    services: Services;
+    providers: Providers;
     uiRenderer?: UpdateUiAction;
     journal?: ICommandJournal;
   }) {
-    this._services = services;
+    this._services = createServices(providers);
     this._uiRenderer = uiRenderer ?? (() => {});
     this._journal = journal ?? new NoopCommandJournal();
   }

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,4 +1,3 @@
 export { viewExecutionResults } from "./internal/deployment/utils";
-export { createServices } from "./internal/services/createServices";
 export { VertexResultEnum } from "./internal/types/graph";
 export { serializeReplacer } from "./internal/utils/serialize";

--- a/packages/core/test/execution/rerun.ts
+++ b/packages/core/test/execution/rerun.ts
@@ -9,6 +9,7 @@ import { TransactionsService } from "../../src/internal/services/TransactionsSer
 import { Artifact } from "../../src/types/hardhat";
 import { Providers } from "../../src/types/providers";
 import { getMockServices } from "../helpers";
+import { setupIgnitionWithOverrideServices } from "../helpers/setupIgnitionWithOverrideServices";
 import { MemoryCommandJournal } from "../util/MemoryCommandJournal";
 
 describe("Rerunning execution", () => {
@@ -62,7 +63,7 @@ describe("Rerunning execution", () => {
         return { token };
       });
 
-      ignition = new Ignition({
+      ignition = setupIgnitionWithOverrideServices({
         services: {
           ...getMockServices(),
           artifacts: {
@@ -193,7 +194,7 @@ describe("Rerunning execution", () => {
         ["0x0000000000000000000000000000000000000003"]
       );
 
-      ignition = new Ignition({
+      ignition = setupIgnitionWithOverrideServices({
         services: {
           ...getMockServices(),
           artifacts: {
@@ -291,7 +292,7 @@ describe("Rerunning execution", () => {
         return { token };
       });
 
-      ignition = new Ignition({
+      ignition = setupIgnitionWithOverrideServices({
         services: {
           ...getMockServices(),
           artifacts: {
@@ -335,7 +336,7 @@ describe("Rerunning execution", () => {
         return { token };
       });
 
-      ignition = new Ignition({
+      ignition = setupIgnitionWithOverrideServices({
         services: {
           ...getMockServices(),
           artifacts: {

--- a/packages/core/test/execution/rerun.ts
+++ b/packages/core/test/execution/rerun.ts
@@ -9,7 +9,7 @@ import { TransactionsService } from "../../src/internal/services/TransactionsSer
 import { Artifact } from "../../src/types/hardhat";
 import { Providers } from "../../src/types/providers";
 import { getMockServices } from "../helpers";
-import { setupIgnitionWithOverrideServices } from "../helpers/setupIgnitionWithOverrideServices";
+import { setupIgnitionWith } from "../helpers/setupIgnitionWith";
 import { MemoryCommandJournal } from "../util/MemoryCommandJournal";
 
 describe("Rerunning execution", () => {
@@ -63,7 +63,7 @@ describe("Rerunning execution", () => {
         return { token };
       });
 
-      ignition = setupIgnitionWithOverrideServices({
+      ignition = setupIgnitionWith({
         services: {
           ...getMockServices(),
           artifacts: {
@@ -194,7 +194,7 @@ describe("Rerunning execution", () => {
         ["0x0000000000000000000000000000000000000003"]
       );
 
-      ignition = setupIgnitionWithOverrideServices({
+      ignition = setupIgnitionWith({
         services: {
           ...getMockServices(),
           artifacts: {
@@ -292,7 +292,7 @@ describe("Rerunning execution", () => {
         return { token };
       });
 
-      ignition = setupIgnitionWithOverrideServices({
+      ignition = setupIgnitionWith({
         services: {
           ...getMockServices(),
           artifacts: {
@@ -336,7 +336,7 @@ describe("Rerunning execution", () => {
         return { token };
       });
 
-      ignition = setupIgnitionWithOverrideServices({
+      ignition = setupIgnitionWith({
         services: {
           ...getMockServices(),
           artifacts: {

--- a/packages/core/test/helpers/getMockProviders.ts
+++ b/packages/core/test/helpers/getMockProviders.ts
@@ -1,0 +1,100 @@
+import { ethers } from "ethers";
+
+import { IgnitionError } from "../../src/errors";
+import { ExternalParamValue } from "../../src/internal/types/deploymentGraph";
+import { Artifact } from "../../src/types/hardhat";
+import { ModuleParams } from "../../src/types/module";
+import {
+  AccountsProvider,
+  ArtifactsProvider,
+  ConfigProvider,
+  EIP1193Provider,
+  GasProvider,
+  HasParamResult,
+  Providers,
+  TransactionsProvider,
+} from "../../src/types/providers";
+
+export function getMockProviders(): Providers {
+  const mockProviders: Providers = {
+    artifacts: new MockArtifactsProvider(),
+    ethereumProvider: new MockEthereumProvider(),
+    gasProvider: new MockGasProvider(),
+    transactions: new MockTransactionsProvider(),
+    config: new MockConfigProvider(),
+    accounts: new MockAccountsProvider(),
+  };
+
+  return mockProviders;
+}
+
+class MockArtifactsProvider implements ArtifactsProvider {
+  public async getArtifact(_name: string): Promise<Artifact> {
+    throw new IgnitionError("Method not implemented.");
+  }
+  public async getAllArtifacts(): Promise<Artifact[]> {
+    throw new IgnitionError("Method not implemented.");
+  }
+  public async hasArtifact(_name: string): Promise<boolean> {
+    return false;
+  }
+}
+
+class MockEthereumProvider implements EIP1193Provider {
+  public async request(_args: {
+    method: string;
+    params?: unknown[] | undefined;
+  }): Promise<unknown> {
+    throw new IgnitionError("Method not implemented.");
+  }
+}
+
+class MockGasProvider implements GasProvider {
+  public estimateGasLimit(
+    _tx: ethers.providers.TransactionRequest
+  ): Promise<ethers.BigNumber> {
+    throw new IgnitionError("Method not implemented.");
+  }
+
+  public estimateGasPrice(): Promise<ethers.BigNumber> {
+    throw new IgnitionError("Method not implemented.");
+  }
+}
+
+class MockTransactionsProvider implements TransactionsProvider {
+  public isConfirmed(_txHash: string): Promise<boolean> {
+    throw new IgnitionError("Method not implemented.");
+  }
+
+  public isMined(_txHash: string): Promise<boolean> {
+    throw new IgnitionError("Method not implemented.");
+  }
+}
+
+class MockConfigProvider implements ConfigProvider {
+  public parameters: ModuleParams | undefined;
+
+  public setParams(_parameters: {
+    [key: string]: ExternalParamValue;
+  }): Promise<void> {
+    throw new IgnitionError("Method not implemented.");
+  }
+
+  public getParam(_paramName: string): Promise<ExternalParamValue> {
+    throw new IgnitionError("Method not implemented.");
+  }
+
+  public hasParam(_paramName: string): Promise<HasParamResult> {
+    throw new IgnitionError("Method not implemented.");
+  }
+}
+
+class MockAccountsProvider implements AccountsProvider {
+  public getAccounts(): Promise<string[]> {
+    throw new Error("Method not implemented.");
+  }
+
+  public getSigner(_address: string): Promise<ethers.Signer> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/core/test/helpers/getMockServices.ts
+++ b/packages/core/test/helpers/getMockServices.ts
@@ -1,0 +1,98 @@
+import { ethers } from "ethers";
+
+import { IgnitionError } from "../../src/errors";
+import {
+  IAccountsService,
+  IArtifactsService,
+  IConfigService,
+  IContractsService,
+  INetworkService,
+  ITransactionsService,
+  Services,
+  TransactionOptions,
+} from "../../src/internal/types/services";
+import { Artifact } from "../../src/types/hardhat";
+import { HasParamResult } from "../../src/types/providers";
+
+export function getMockServices() {
+  const mockServices: Services = {
+    network: new MockNetworkService(),
+    contracts: new MockContractsService(),
+    artifacts: new MockArtifactsService(),
+    transactions: new MockTransactionService(),
+    config: new MockConfigService(),
+    accounts: new MockAccountsService(),
+  };
+
+  return mockServices;
+}
+
+class MockNetworkService implements INetworkService {
+  public async getChainId(): Promise<number> {
+    return 31337;
+  }
+}
+
+class MockContractsService implements IContractsService {
+  private contractCount: number;
+
+  constructor() {
+    this.contractCount = 0;
+  }
+
+  public async sendTx(
+    _deployTransaction: ethers.providers.TransactionRequest,
+    _txOptions?: TransactionOptions | undefined
+  ): Promise<string> {
+    this.contractCount++;
+
+    return `0x0000${this.contractCount}`;
+  }
+}
+
+class MockArtifactsService implements IArtifactsService {
+  public getAllArtifacts(): Promise<Artifact[]> {
+    throw new Error("Method not implemented.");
+  }
+
+  public async hasArtifact(_name: string): Promise<boolean> {
+    return true;
+  }
+
+  public getArtifact(_name: string): Promise<Artifact> {
+    throw new IgnitionError("Method not implemented.");
+  }
+}
+
+class MockTransactionService implements ITransactionsService {
+  public wait(_txHash: string): Promise<ethers.providers.TransactionReceipt> {
+    return {} as any;
+  }
+
+  public waitForEvent(
+    _filter: ethers.EventFilter,
+    _durationMs: number
+  ): Promise<ethers.providers.Log> {
+    throw new IgnitionError("Method not implemented.");
+  }
+}
+
+class MockConfigService implements IConfigService {
+  public getParam(_paramName: string): Promise<string | number> {
+    throw new IgnitionError("Method not implemented.");
+  }
+
+  public hasParam(_paramName: string): Promise<HasParamResult> {
+    throw new IgnitionError("Method not implemented.");
+  }
+}
+
+class MockAccountsService implements IAccountsService {
+  public getAccounts(): Promise<string[]> {
+    throw new IgnitionError("Method not implemented.");
+  }
+
+  public getSigner(_address: string): Promise<ethers.Signer> {
+    throw new IgnitionError("Method not implemented.");
+  }
+}

--- a/packages/core/test/helpers/setupIgnitionWith.ts
+++ b/packages/core/test/helpers/setupIgnitionWith.ts
@@ -15,7 +15,7 @@ class TestIgnition extends Ignition {
   }
 }
 
-export function setupIgnitionWithOverrideServices({
+export function setupIgnitionWith({
   services,
   journal,
 }: {

--- a/packages/core/test/helpers/setupIgnitionWithOverrideServices.ts
+++ b/packages/core/test/helpers/setupIgnitionWithOverrideServices.ts
@@ -1,8 +1,19 @@
 import { ICommandJournal } from "../../src";
 import { Ignition } from "../../src/Ignition";
+import { NoopCommandJournal } from "../../src/internal/journal/NoopCommandJournal";
 import { Services } from "../../src/internal/types/services";
 
-import { getMockProviders } from "./getMockProviders";
+class TestIgnition extends Ignition {
+  constructor({
+    services,
+    journal = new NoopCommandJournal(),
+  }: {
+    services: Services;
+    journal?: ICommandJournal;
+  }) {
+    super({ services, uiRenderer: () => {}, journal });
+  }
+}
 
 export function setupIgnitionWithOverrideServices({
   services,
@@ -11,9 +22,5 @@ export function setupIgnitionWithOverrideServices({
   services: Services;
   journal?: ICommandJournal;
 }) {
-  const ignition = new Ignition({ providers: getMockProviders(), journal });
-
-  (ignition as any)._services = services;
-
-  return ignition;
+  return new TestIgnition({ services, journal });
 }

--- a/packages/core/test/helpers/setupIgnitionWithOverrideServices.ts
+++ b/packages/core/test/helpers/setupIgnitionWithOverrideServices.ts
@@ -1,0 +1,19 @@
+import { ICommandJournal } from "../../src";
+import { Ignition } from "../../src/Ignition";
+import { Services } from "../../src/internal/types/services";
+
+import { getMockProviders } from "./getMockProviders";
+
+export function setupIgnitionWithOverrideServices({
+  services,
+  journal,
+}: {
+  services: Services;
+  journal?: ICommandJournal;
+}) {
+  const ignition = new Ignition({ providers: getMockProviders(), journal });
+
+  (ignition as any)._services = services;
+
+  return ignition;
+}

--- a/packages/core/test/options.ts
+++ b/packages/core/test/options.ts
@@ -7,6 +7,7 @@ import { buildModule, Ignition } from "../src";
 import { Artifact } from "../src/types/hardhat";
 
 import { getMockServices } from "./helpers";
+import { setupIgnitionWithOverrideServices } from "./helpers/setupIgnitionWithOverrideServices";
 
 describe("deploy options", () => {
   const tokenArtifact: Artifact = {
@@ -49,7 +50,7 @@ describe("deploy options", () => {
   before(async function () {
     const services = getMockServices();
 
-    ignition = new Ignition({
+    ignition = setupIgnitionWithOverrideServices({
       services: {
         ...services,
         accounts: {

--- a/packages/core/test/options.ts
+++ b/packages/core/test/options.ts
@@ -7,7 +7,7 @@ import { buildModule, Ignition } from "../src";
 import { Artifact } from "../src/types/hardhat";
 
 import { getMockServices } from "./helpers";
-import { setupIgnitionWithOverrideServices } from "./helpers/setupIgnitionWithOverrideServices";
+import { setupIgnitionWith } from "./helpers/setupIgnitionWith";
 
 describe("deploy options", () => {
   const tokenArtifact: Artifact = {
@@ -50,7 +50,7 @@ describe("deploy options", () => {
   before(async function () {
     const services = getMockServices();
 
-    ignition = setupIgnitionWithOverrideServices({
+    ignition = setupIgnitionWith({
       services: {
         ...services,
         accounts: {

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -55,7 +55,7 @@ export class IgnitionWrapper {
         ? new CommandJournal(chainId, deployParams?.journalPath)
         : undefined);
 
-    const ignition = new Ignition({
+    const ignition = Ignition.create({
       providers: this._providers,
       uiRenderer: showUi
         ? renderToCli(initializeRenderState(), deployParams?.parameters)
@@ -106,7 +106,7 @@ export class IgnitionWrapper {
   }
 
   public async plan<T extends ModuleDict>(ignitionModule: Module<T>) {
-    const ignition = new Ignition({
+    const ignition = Ignition.create({
       providers: this._providers,
     });
 


### PR DESCRIPTION
In place of services, pass providers then immediately convert them. This has the advantage of only exporting one set of concepts (i.e. low level providers) rather than two (providers and higher level services), particularly as one leverages the other.

The consequence of this approach though is that the providers are too low level for clean mocking in our core tests. The services are the more appropriate seam. By switching to providers in the `Ignition` constructor we lose that injection seam. This has been worked around with a utility function that sets up Ignition but overrides the services so that mocked services can continue to be used in tests.

Part of #171.