### PR TITLE
refactor: add tsdocs for public api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,9 @@ out
 .nuxt
 dist
 
+# Typedocs documentation files
+typedocs/
+
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,6 +29,42 @@
         "showReuseMessage": true,
         "clear": false
       }
+    },
+    {
+      "type": "npm",
+      "script": "api-extractor",
+      "group": {
+        "kind": "none",
+        "isDefault": false
+      },
+      "label": "api-extractor",
+      "detail": "Run api-extractor to check API",
+      "presentation": {
+        "echo": true,
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/packages/core"
+      },
+      "problemMatcher": {
+        "owner": "api-extractor",
+        "source": "api-extractor",
+        "fileLocation": ["relative", "${workspaceFolder}/packages/core"],
+        "pattern": [
+          {
+            "regexp": "^(Warning|Error): ([\\w/.]+):(\\d+):(\\d+) - \\((.*)\\) (.*)$",
+            "file": 2,
+            "line": 3,
+            "column": 4,
+            "code": 5,
+            "message": 6
+          }
+        ]
+      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "root",
       "license": "SEE LICENSE IN EACH PACKAGE'S LICENSE FILE",
       "devDependencies": {
+        "@microsoft/api-extractor": "7.34.4",
         "@typescript-eslint/eslint-plugin": "4.31.2",
         "@typescript-eslint/parser": "4.31.2",
         "eslint": "^7.32.0",
@@ -1847,6 +1848,93 @@
         "rlp": "^2.2.3"
       }
     },
+    "node_modules/@microsoft/api-extractor": {
+      "version": "7.34.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.4.tgz",
+      "integrity": "sha512-HOdcci2nT40ejhwPC3Xja9G+WSJmWhCUKKryRfQYsmE9cD+pxmBaKBKCbuS9jUcl6bLLb4Gz+h7xEN5r0QiXnQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.26.4",
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "3.55.2",
+        "@rushstack/rig-package": "0.3.18",
+        "@rushstack/ts-command-line": "4.13.2",
+        "colors": "~1.2.1",
+        "lodash": "~4.17.15",
+        "resolve": "~1.22.1",
+        "semver": "~7.3.0",
+        "source-map": "~0.6.1",
+        "typescript": "~4.8.4"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.26.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.4.tgz",
+      "integrity": "sha512-PDCgCzXDo+SLY5bsfl4bS7hxaeEtnXj7XtuzEE+BtALp7B5mK/NrS2kHWU69pohgsRmEALycQdaQPXoyT2i5MQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "3.55.2"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==",
+      "dev": true
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz",
+      "integrity": "sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.14.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@morgan-stanley/ts-mocking-bird": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/@morgan-stanley/ts-mocking-bird/-/ts-mocking-bird-0.6.4.tgz",
@@ -2705,6 +2793,101 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "3.55.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.55.2.tgz",
+      "integrity": "sha512-SaLe/x/Q/uBVdNFK5V1xXvsVps0y7h1sN7aSJllQyFbugyOaxhNRF25bwEDnicARNEjJw0pk0lYnJQ9Kr6ev0A==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.3.0",
+        "z-schema": "~5.0.2"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@rushstack/rig-package": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.18.tgz",
+      "integrity": "sha512-SGEwNTwNq9bI3pkdd01yCaH+gAsHqs0uxfGvtw9b0LJXH52qooWXnrFTRRLG1aL9pf+M2CARdrA9HLHJys3jiQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "~1.22.1",
+        "strip-json-comments": "~3.1.1"
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.13.2.tgz",
+      "integrity": "sha512-bCU8qoL9HyWiciltfzg7GqdfODUeda/JpI0602kbN5YH22rzTxyqYvv7aRLENCM7XCQ1VRs7nMkEqgJUOU8Sag==",
+      "dev": true,
+      "dependencies": {
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "colors": "~1.2.1",
+        "string-argv": "~0.3.1"
+      }
+    },
+    "node_modules/@rushstack/ts-command-line/node_modules/colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
@@ -3351,6 +3534,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true
     },
     "node_modules/@types/async-eventemitter": {
       "version": "0.2.1",
@@ -11268,6 +11457,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -12043,6 +12241,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
+    },
     "node_modules/js-graph-algorithms": {
       "version": "1.0.18",
       "resolved": "https://registry.npmjs.org/js-graph-algorithms/-/js-graph-algorithms-1.0.18.tgz",
@@ -12401,6 +12605,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -17086,6 +17296,15 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-format": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
@@ -18426,6 +18645,15 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/varint": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
@@ -19308,6 +19536,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dev": true,
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "packages/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "eslint-plugin-import": "2.24.2",
         "eslint-plugin-mocha": "^9.0.0",
         "eslint-plugin-prettier": "4.0.0",
+        "open-cli": "7.2.0",
         "prettier": "2.4.1",
+        "typedoc": "0.23.28",
         "typescript": "^4.7.4"
       },
       "workspaces": {
@@ -2937,6 +2939,12 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "dev": true
+    },
     "node_modules/@truffle/abi-utils": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@truffle/abi-utils/-/abi-utils-0.3.9.tgz",
@@ -3762,6 +3770,12 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -3789,6 +3803,12 @@
       "version": "18.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
       "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw=="
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
     },
     "node_modules/@types/object-hash": {
       "version": "2.2.1",
@@ -4485,6 +4505,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4653,6 +4679,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/asap": {
@@ -4956,6 +4991,27 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
+    "node_modules/bplist-parser/node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5106,6 +5162,21 @@
         "node": ">=6.14.2"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -5223,6 +5294,60 @@
       "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
+      "integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^7.0.0",
+        "map-obj": "^4.3.0",
+        "quick-lru": "^6.1.1",
+        "type-fest": "^2.13.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/quick-lru": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
+      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -6073,6 +6198,45 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cross-spawn-async": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha512-snteb3aVrxYYOX9e8BabYFK9WhCDhTlw1YQktfTthBogxri4/2r9U2nQc0ffY73ZAxezDc+U8gvHAeU1wy1ubQ==",
+      "deprecated": "cross-spawn no longer requires a build toolchain, use it instead",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^4.0.0",
+        "which": "^1.2.8"
+      }
+    },
+    "node_modules/cross-spawn-async/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/cross-spawn-async/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/cross-spawn-async/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "dev": true
+    },
     "node_modules/crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
@@ -6095,6 +6259,33 @@
         "ripemd160-min": "0.0.6",
         "safe-buffer": "^5.2.0",
         "sha3": "^2.1.1"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/css-select": {
@@ -6649,6 +6840,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -6713,6 +6929,40 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/default-browser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-3.1.0.tgz",
+      "integrity": "sha512-SOHecvSoairSAWxEHP/0qcsld/KtI3DargfEuELQDyHIYmS2EMgdGhHOTC1GxaYr+NLUV6kDroeiSBfnNHnn8w==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^5.0.0",
+        "xdg-default-browser": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/default-require-extensions": {
       "version": "3.0.1",
@@ -9100,6 +9350,29 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/express": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -9327,6 +9600,23 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
+      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
+      "dev": true,
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -9683,6 +9973,18 @@
       "peer": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -10062,6 +10364,15 @@
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10868,6 +11179,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -11357,6 +11677,39 @@
         "npm": ">=3"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-lower-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
@@ -11754,6 +12107,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -11786,6 +12145,12 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -11861,7 +12226,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11970,6 +12334,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -12118,6 +12488,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -12148,12 +12524,36 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "devOptional": true
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
       "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/mcl-wasm": {
       "version": "0.7.9",
@@ -12202,10 +12602,309 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/meow": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-11.0.0.tgz",
+      "integrity": "sha512-Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.2",
+        "camelcase-keys": "^8.0.2",
+        "decamelize": "^6.0.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^4.0.1",
+        "read-pkg-up": "^9.1.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.2",
+        "type-fest": "^3.1.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/decamelize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/hosted-git-info": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
+      "integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^7.5.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/meow/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/meow/node_modules/normalize-package-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
+      "integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/meow/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
+      "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.1",
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg-up": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
+      "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^6.3.0",
+        "read-pkg": "^7.1.0",
+        "type-fest": "^2.5.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.7.0.tgz",
+      "integrity": "sha512-A2qUJ/j8vkKIT+UorxayZjFJoEdNkIPZkjOJSWezoAbRQd7QEhnz2iJlfVy4Or0GuEnCXts5cNorQNUvdLkaSQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/meow/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -12324,6 +13023,15 @@
         "dom-walk": "^0.1.0"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -12351,6 +13059,29 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/minimist-options/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/minipass": {
@@ -12951,6 +13682,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -13339,6 +14082,58 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open-cli": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/open-cli/-/open-cli-7.2.0.tgz",
+      "integrity": "sha512-1ANJc8oJ92FiaNZ0o2Hw4WBvDJoXs1P74aFMtpAvlbkIPV4uPcQvDz7V6kMOrsZkmB4tglrHVMlLQaafuUuxXg==",
+      "dev": true,
+      "dependencies": {
+        "file-type": "^18.2.1",
+        "get-stdin": "^9.0.0",
+        "meow": "^11.0.0",
+        "open": "^9.0.0",
+        "tempy": "^3.0.0"
+      },
+      "bin": {
+        "open-cli": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-cli/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-cli/node_modules/open": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.0.0.tgz",
+      "integrity": "sha512-yerrN5WPzgwuE3T6rxAkT1UuMLDzs4Szpug7hy9s4gru3iOTnaU0yKc1AYOVYrBzvykce5gUdr9RPNB4R+Zc/A==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^3.1.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -13626,6 +14421,19 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -13873,6 +14681,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -14110,6 +14924,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -14145,6 +14975,49 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/redent/node_modules/strip-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reduce-flatten": {
@@ -14463,6 +15336,21 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
       "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==",
       "dev": true
+    },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -14926,6 +15814,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "node_modules/side-channel": {
@@ -16271,6 +17171,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-hex-prefix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
@@ -16300,6 +17218,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "dev": true,
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/stylis": {
@@ -16600,6 +17535,57 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.0.0.tgz",
+      "integrity": "sha512-B2I9X7+o2wOaW4r/CWMkpOO9mdiTRCxXNgob6iGvPmfPWgH/KyUD6Uy5crtWBxIBe3YrNZKR2lSzv1JJKWD4vA==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -16701,6 +17687,15 @@
         "upper-case": "^1.0.3"
       }
     },
+    "node_modules/titleize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-1.0.1.tgz",
+      "integrity": "sha512-rUwGDruKq1gX+FFHbTl5qjI7teVO7eOe+C8IcQ7QT+1BK3eEUXJqbZcBOeaRP4FwSC/C1A5jDoIVta0nIQ9yew==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -16746,6 +17741,23 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "dev": true,
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -16762,6 +17774,18 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/trim-newlines": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+      "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/ts-command-line-args": {
       "version": "2.4.2",
@@ -17099,6 +18123,51 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.28",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
+      "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -17172,6 +18241,21 @@
         "node": ">=12.18"
       }
     },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -17186,6 +18270,15 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -17358,6 +18451,18 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/web-worker": {
       "version": "1.2.0",
@@ -17991,6 +19096,56 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-default-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-default-browser/-/xdg-default-browser-2.1.0.tgz",
+      "integrity": "sha512-HY4G725+IDQr16N8XOjAms5qJGArdJaWIuC7Q7A8UXIwj2mifqnPXephazyL7sIkQPvmEoPX3E0v2yFv6hQUNg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^0.2.2",
+        "titleize": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/xdg-default-browser/node_modules/execa": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.2.2.tgz",
+      "integrity": "sha512-zmBGzLd3nhA/NB9P7VLoceAO6vyYPftvl809Vjwe5U2fYI9tYWbeKqP3wZlAw9WS+znnkogf/bhSU+Gcn2NbkQ==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn-async": "^2.1.1",
+        "npm-run-path": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "path-key": "^1.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/xdg-default-browser/node_modules/npm-run-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+      "integrity": "sha512-PrGAi1SLlqNvKN5uGBjIgnrTb8fl0Jz0a3JJmeMcGnIBh7UE9Gc4zsAMlwDajOMg2b1OgP6UPvoLUboTmMZPFA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xdg-default-browser/node_modules/path-key": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+      "integrity": "sha512-T3hWy7tyXlk3QvPFnT+o2tmXRzU4GkitkUWLp/WZ0S/FXd7XMx176tRurgTvHTNMJOQzTcesHNpBqetH86mQ9g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/xhr": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:examples": "npm run test -w examples --if-present",
     "watch": "tsc --build --watch packages/core packages/hardhat-plugin",
     "fullcheck": "npm run build && npm run lint && npm run test:coverage && npm run test:examples",
+    "typedocs": "typedoc --entryPointStrategy packages --out ./typedocs ./packages/core && open-cli ./typedocs/index.html",
     "clean": "npm run clean --workspaces --if-present"
   },
   "devDependencies": {
@@ -31,7 +32,9 @@
     "eslint-plugin-import": "2.24.2",
     "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-prettier": "4.0.0",
+    "open-cli": "7.2.0",
     "prettier": "2.4.1",
+    "typedoc": "0.23.28",
     "typescript": "^4.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clean": "npm run clean --workspaces --if-present"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "7.34.4",
     "@typescript-eslint/eslint-plugin": "4.31.2",
     "@typescript-eslint/parser": "4.31.2",
     "eslint": "^7.32.0",

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,1 +1,3 @@
 dist/
+etc/
+temp/

--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -2,3 +2,4 @@
 /dist
 /coverage
 /.nyc_output
+/temp

--- a/packages/core/api-extractor.json
+++ b/packages/core/api-extractor.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/src/index.d.ts",
+  "bundledPackages": [],
+  "compiler": {},
+
+  "apiReport": {
+    "enabled": false,
+    "reportFileName": "<unscopedPackageName>.api.md",
+    "reportFolder": "<projectFolder>/etc/",
+    "reportTempFolder": "<projectFolder>/temp/"
+  },
+
+  "docModel": {
+    "enabled": true
+  },
+
+  "dtsRollup": {
+    "enabled": true
+  },
+
+  "tsdocMetadata": {},
+
+  "messages": {
+    "compilerMessageReporting": {
+      "default": {
+        "logLevel": "error"
+      }
+    },
+    "extractorMessageReporting": {
+      "default": {
+        "logLevel": "error",
+        "addToApiReportFile": true
+      },
+      "ae-forgotten-export": {
+        "logLevel": "error",
+        "addToApiReportFile": true
+      },
+      "ae-incompatible-release-tags": {
+        "logLevel": "error",
+        "addToApiReportFile": true
+      },
+      "ae-internal-missing-underscore": {
+        "logLevel": "none",
+        "addToApiReportFile": false
+      },
+      "ae-internal-mixed-release-tag": {
+        "logLevel": "error",
+        "addToApiReportFile": true
+      },
+      "ae-unresolved-inheritdoc-reference": {
+        "logLevel": "error",
+        "addToApiReportFile": true
+      },
+      "ae-unresolved-inheritdoc-base": {
+        "logLevel": "error",
+        "addToApiReportFile": true
+      },
+      "ae-wrong-input-file-type": {
+        "logLevel": "error",
+        "addToApiReportFile": true
+      }
+    },
+    "tsdocMessageReporting": {
+      "default": {
+        "logLevel": "warning"
+      }
+    }
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,10 +37,12 @@
   },
   "scripts": {
     "build": "tsc --build",
-    "lint": "npm run prettier -- --check && npm run eslint",
+    "lint": "npm run prettier -- --check && npm run eslint && npm run api-extractor",
     "lint:fix": "npm run prettier -- --write && npm run eslint -- --fix",
     "eslint": "eslint \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\"",
     "prettier": "prettier \"**/*.{js,ts,md,json}\"",
+    "preapi-extractor": "npm run build",
+    "api-extractor": "api-extractor run --local --verbose",
     "test": "mocha --recursive \"test/**/*.ts\"",
     "test:debug": "DEBUG='ignition:*' npm run test",
     "test:build": "tsc --project ./test/",

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -32,24 +32,17 @@ import { addEdge, ensureVertex } from "../internal/graph/adjacencyList";
 import {
   ArtifactContractDeploymentVertex,
   ArtifactLibraryDeploymentVertex,
-  AwaitOptions,
   CallDeploymentVertex,
-  CallOptions,
   CallPoints,
-  ContractOptions,
   DeployedContractDeploymentVertex,
   DeploymentBuilderOptions,
   DeploymentGraphVertex,
   EventVertex,
   HardhatContractDeploymentVertex,
   HardhatLibraryDeploymentVertex,
-  IDeploymentBuilder,
   IDeploymentGraph,
-  InternalParamValue,
   ScopeData,
-  SendOptions,
   SendVertex,
-  UseModuleOptions,
   VirtualVertex,
 } from "../internal/types/deploymentGraph";
 import {
@@ -61,6 +54,15 @@ import {
   isParameter,
 } from "../internal/utils/guards";
 import { resolveProxyDependency } from "../internal/utils/proxy";
+import {
+  AwaitOptions,
+  CallOptions,
+  ContractOptions,
+  IDeploymentBuilder,
+  InternalParamValue,
+  SendOptions,
+  UseModuleOptions,
+} from "../types/dsl";
 
 import { DeploymentGraph } from "./DeploymentGraph";
 import { ScopeStack } from "./ScopeStack";
@@ -81,25 +83,19 @@ type DeploymentApiPublicFunctions =
 const DEFAULT_VALUE = ethers.utils.parseUnits("0");
 
 /**
- * A builder object for specifying the different parts and
- * dependencies of your deployment.
+ * A builder object for specifying the different parts  of your deployment
+ * and their interdependencies.
  */
 export class DeploymentBuilder implements IDeploymentBuilder {
-  /**
-   * The `chainId` of the network being deployed to.
-   */
+  /** {@inheritDoc IDeploymentBuilder.chainId} */
   public chainId: number;
 
-  /**
-   * The Hardhat accounts as defined in the `Hardhat.config.{js,ts}` file,
-   * deployment actions can leverage these accounts to specify which
-   * account the on-chain transaction that underlies the action will
-   * execute under.
-   */
+  /** {@inheritDoc IDeploymentBuilder.accounts} */
   public accounts: string[];
 
   /**
    * The deployment graph built from the configuration actions.
+   *
    * @internal
    */
   public graph: IDeploymentGraph;
@@ -109,6 +105,7 @@ export class DeploymentBuilder implements IDeploymentBuilder {
    * position of the DeploymentBuilder action that created
    * them. Used during validation to provide better error
    * messages.
+   *
    * @internal
    */
   public callPoints: CallPoints;
@@ -130,11 +127,6 @@ export class DeploymentBuilder implements IDeploymentBuilder {
     }
   }
 
-  /**
-   * Deploy a
-   * @param libraryName
-   * @param options
-   */
   public library(
     libraryName: string,
     options?: ContractOptions

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -1,28 +1,28 @@
 import type {
-  DeploymentGraphFuture,
-  HardhatContract,
-  ArtifactLibrary,
-  HardhatLibrary,
+  AddressResolvable,
   ArtifactContract,
-  DeployedContract,
+  ArtifactFuture,
+  ArtifactLibrary,
+  CallableFuture,
   ContractCall,
-  RequiredParameter,
+  ContractFuture,
+  DependableFuture,
+  DeployedContract,
+  DeploymentGraphFuture,
+  EventFuture,
+  EventParamFuture,
+  EventParams,
+  HardhatContract,
+  HardhatLibrary,
   OptionalParameter,
   ParameterValue,
-  CallableFuture,
-  Virtual,
-  DependableFuture,
   ProxyFuture,
-  EventFuture,
-  EventParams,
-  ArtifactFuture,
-  EventParamFuture,
+  RequiredParameter,
   SendFuture,
-  ContractFuture,
-  AddressResolvable,
+  Virtual,
 } from "../types/future";
 import type { Artifact } from "../types/hardhat";
-import type { ModuleCache, ModuleDict, Module } from "../types/module";
+import type { Module, ModuleCache, ModuleDict } from "../types/module";
 
 import { BigNumber, ethers } from "ethers";
 import hash from "object-hash";
@@ -30,26 +30,26 @@ import hash from "object-hash";
 import { IgnitionError, IgnitionValidationError } from "../errors";
 import { addEdge, ensureVertex } from "../internal/graph/adjacencyList";
 import {
+  ArtifactContractDeploymentVertex,
+  ArtifactLibraryDeploymentVertex,
+  AwaitOptions,
+  CallDeploymentVertex,
   CallOptions,
+  CallPoints,
   ContractOptions,
-  InternalParamValue,
-  IDeploymentGraph,
-  IDeploymentBuilder,
+  DeployedContractDeploymentVertex,
   DeploymentBuilderOptions,
   DeploymentGraphVertex,
-  UseModuleOptions,
-  ScopeData,
-  AwaitOptions,
-  SendOptions,
-  CallPoints,
-  HardhatContractDeploymentVertex,
-  ArtifactContractDeploymentVertex,
-  DeployedContractDeploymentVertex,
-  HardhatLibraryDeploymentVertex,
-  ArtifactLibraryDeploymentVertex,
-  CallDeploymentVertex,
   EventVertex,
+  HardhatContractDeploymentVertex,
+  HardhatLibraryDeploymentVertex,
+  IDeploymentBuilder,
+  IDeploymentGraph,
+  InternalParamValue,
+  ScopeData,
+  SendOptions,
   SendVertex,
+  UseModuleOptions,
   VirtualVertex,
 } from "../internal/types/deploymentGraph";
 import {
@@ -80,10 +80,37 @@ type DeploymentApiPublicFunctions =
 
 const DEFAULT_VALUE = ethers.utils.parseUnits("0");
 
+/**
+ * A builder object for specifying the different parts and
+ * dependencies of your deployment.
+ */
 export class DeploymentBuilder implements IDeploymentBuilder {
+  /**
+   * The `chainId` of the network being deployed to.
+   */
   public chainId: number;
+
+  /**
+   * The Hardhat accounts as defined in the `Hardhat.config.{js,ts}` file,
+   * deployment actions can leverage these accounts to specify which
+   * account the on-chain transaction that underlies the action will
+   * execute under.
+   */
   public accounts: string[];
+
+  /**
+   * The deployment graph built from the configuration actions.
+   * @internal
+   */
   public graph: IDeploymentGraph;
+
+  /**
+   * A mapping of deployment graph vertexes to the source code
+   * position of the DeploymentBuilder action that created
+   * them. Used during validation to provide better error
+   * messages.
+   * @internal
+   */
   public callPoints: CallPoints;
 
   private idCounter: number = 0;
@@ -103,6 +130,11 @@ export class DeploymentBuilder implements IDeploymentBuilder {
     }
   }
 
+  /**
+   * Deploy a
+   * @param libraryName
+   * @param options
+   */
   public library(
     libraryName: string,
     options?: ContractOptions

--- a/packages/core/src/dsl/buildModule.ts
+++ b/packages/core/src/dsl/buildModule.ts
@@ -16,7 +16,7 @@ import {
  * deployment.
  * @returns An Ignition module that can be deployed.
  *
- * @internal
+ * @alpha
  */
 export function buildModule<T extends ModuleDict>(
   moduleName: string,

--- a/packages/core/src/dsl/buildModule.ts
+++ b/packages/core/src/dsl/buildModule.ts
@@ -1,10 +1,10 @@
-import type { IDeploymentBuilder } from "../internal/types/deploymentGraph";
 import type { Module, ModuleDict } from "../types/module";
 
 import {
   assertFunctionParam,
   assertStringParam,
 } from "../internal/utils/paramAssertions";
+import { IDeploymentBuilder } from "../types/dsl";
 
 /**
  * A factory that builds a deployment module given configuration function that

--- a/packages/core/src/dsl/buildModule.ts
+++ b/packages/core/src/dsl/buildModule.ts
@@ -6,15 +6,27 @@ import {
   assertStringParam,
 } from "../internal/utils/paramAssertions";
 
+/**
+ * A factory that builds a deployment module given configuration function that
+ * manipulates an injected deployment builder.
+ *
+ * @param moduleName - The name that will be used for the module internally and in
+ * logging and the UI.
+ * @param moduleConfigurationAction - A non-async function that configures the
+ * deployment.
+ * @returns An Ignition module that can be deployed.
+ *
+ * @internal
+ */
 export function buildModule<T extends ModuleDict>(
   moduleName: string,
-  moduleAction: (m: IDeploymentBuilder) => T
+  moduleConfigurationAction: (m: IDeploymentBuilder) => T
 ): Module<T> {
   assertStringParam(moduleName, "moduleName");
-  assertFunctionParam(moduleAction, "moduleAction");
+  assertFunctionParam(moduleConfigurationAction, "moduleAction");
 
   return {
     name: moduleName,
-    action: moduleAction,
+    action: moduleConfigurationAction,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,24 +25,16 @@ export type {
 export type {
   ArtifactContractDeploymentVertex,
   ArtifactLibraryDeploymentVertex,
-  AwaitOptions,
   CallDeploymentVertex,
-  CallOptions,
-  ContractOptions,
   DeployedContractDeploymentVertex,
   DeploymentGraphVertex,
   EventVertex,
-  ExternalParamValue,
   HardhatContractDeploymentVertex,
   HardhatLibraryDeploymentVertex,
-  IDeploymentBuilder,
   IDeploymentGraph,
-  InternalParamValue,
   LibraryMap,
   ScopeData,
-  SendOptions,
   SendVertex,
-  UseModuleOptions,
   VirtualVertex,
 } from "./internal/types/deploymentGraph";
 export type {
@@ -87,6 +79,16 @@ export type {
   Services,
   TransactionOptions,
 } from "./internal/types/services";
+export {
+  AwaitOptions,
+  CallOptions,
+  ContractOptions,
+  ExternalParamValue,
+  IDeploymentBuilder,
+  InternalParamValue,
+  SendOptions,
+  UseModuleOptions,
+} from "./types/dsl";
 export type {
   AddressResolvable,
   ArtifactContract,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,34 +1,141 @@
-export { Ignition } from "./Ignition";
 export { buildModule } from "./dsl/buildModule";
-
-export type { SerializedDeploymentResult } from "./types/serialization";
+export { Ignition } from "./Ignition";
 export type {
-  Providers,
-  ConfigProvider,
-  HasParamResult,
-} from "./types/providers";
-export type {
-  DeployState,
-  DeployPhase,
   DeploymentResult,
-  UpdateUiAction,
+  DeployNetworkConfig,
+  DeployPhase,
+  DeployState,
+  DeployStateExecutionCommand,
+  ExecutionState,
   IgnitionDeployOptions,
+  UpdateUiAction,
+  ValidationState,
+  VertexExecutionState,
+  VertexExecutionStateCompleted,
+  VertexExecutionStateFailed,
+  VertexExecutionStateHold,
+  VertexExecutionStateRunning,
+  VertexExecutionStateUnstarted,
+  VertexExecutionStatusCompleted,
+  VertexExecutionStatusFailed,
+  VertexExecutionStatusHold,
+  VertexExecutionStatusRunning,
+  VertexExecutionStatusUnstarted,
 } from "./internal/types/deployment";
-export type { Module, ModuleDict, ModuleParams } from "./types/module";
 export type {
-  ExternalParamValue,
-  IDeploymentBuilder,
+  ArtifactContractDeploymentVertex,
+  ArtifactLibraryDeploymentVertex,
+  AwaitOptions,
+  CallDeploymentVertex,
+  CallOptions,
+  ContractOptions,
+  DeployedContractDeploymentVertex,
   DeploymentGraphVertex,
+  EventVertex,
+  ExternalParamValue,
+  HardhatContractDeploymentVertex,
+  HardhatLibraryDeploymentVertex,
+  IDeploymentBuilder,
+  IDeploymentGraph,
+  InternalParamValue,
+  LibraryMap,
+  ScopeData,
+  SendOptions,
+  SendVertex,
+  UseModuleOptions,
+  VirtualVertex,
 } from "./internal/types/deploymentGraph";
-export type { IgnitionPlan } from "./types/plan";
 export type {
-  VertexGraph,
-  VertexDescriptor,
-  VertexVisitResultFailure,
-} from "./internal/types/graph";
-export type {
+  ArgValue,
+  AwaitedEventExecutionVertex,
+  AwaitedEventSuccess,
+  ContractCallExecutionVertex,
+  ContractCallSuccess,
+  ContractDeployExecutionVertex,
+  ContractDeploySuccess,
+  DeployedContractExecutionVertex,
+  DeployedContractSuccess,
   ExecutionVertex,
   ExecutionVertexType,
+  ExecutionVertexVisitResult,
+  IExecutionGraph,
+  LibraryDeployExecutionVertex,
+  LibraryDeploySuccess,
+  SendETHSuccess,
+  SentETHExecutionVertex,
+  VertexVisitResultSuccessResult,
 } from "./internal/types/executionGraph";
+export type {
+  AdjacencyList,
+  IGraph,
+  VertexDescriptor,
+  VertexGraph,
+  VertexResultEnum,
+  VertexVisitResult,
+  VertexVisitResultFailure,
+  VertexVisitResultHold,
+  VertexVisitResultSuccess,
+} from "./internal/types/graph";
 export type { ICommandJournal } from "./internal/types/journal";
-export type { DeployStateExecutionCommand } from "./internal/types/deployment";
+export type {
+  IAccountsService,
+  IArtifactsService,
+  IConfigService,
+  IContractsService,
+  INetworkService,
+  ITransactionsService,
+  Services,
+  TransactionOptions,
+} from "./internal/types/services";
+export type {
+  AddressResolvable,
+  ArtifactContract,
+  ArtifactFuture,
+  ArtifactLibrary,
+  CallableFuture,
+  ContractCall,
+  ContractFuture,
+  DependableFuture,
+  DeployedContract,
+  DeploymentGraphFuture,
+  EventFuture,
+  EventParamFuture,
+  EventParams,
+  HardhatContract,
+  HardhatLibrary,
+  LibraryFuture,
+  OptionalParameter,
+  ParameterFuture,
+  ParameterValue,
+  ProxyFuture,
+  RequiredParameter,
+  SendFuture,
+  Virtual,
+} from "./types/future";
+export type { Artifact } from "./types/hardhat";
+export type {
+  IgnitionConstructorArgs,
+  IgnitionCreationArgs,
+} from "./types/ignition";
+export type {
+  Module,
+  ModuleDict,
+  ModuleParams,
+  ModuleReturnValue,
+} from "./types/module";
+export type { IgnitionPlan } from "./types/plan";
+export type {
+  AccountsProvider,
+  ArtifactsProvider,
+  ConfigProvider,
+  EIP1193Provider,
+  GasProvider,
+  HasParamErrorCode,
+  HasParamResult,
+  Providers,
+  TransactionsProvider,
+} from "./types/providers";
+export type {
+  ContractInfo,
+  SerializedDeploymentResult,
+} from "./types/serialization";

--- a/packages/core/src/internal/execution/dispatch/executeAwaitedEvent.ts
+++ b/packages/core/src/internal/execution/dispatch/executeAwaitedEvent.ts
@@ -1,6 +1,6 @@
 import type { ExecutionContext } from "../../types/deployment";
 import type {
-  AwaitedEvent,
+  AwaitedEventExecutionVertex,
   ExecutionVertexVisitResult,
 } from "../../types/executionGraph";
 
@@ -11,7 +11,7 @@ import { VertexResultEnum } from "../../types/graph";
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeAwaitedEvent(
-  { event, address, abi, args }: AwaitedEvent,
+  { event, address, abi, args }: AwaitedEventExecutionVertex,
   resultAccumulator: Map<number, ExecutionVertexVisitResult | undefined>,
   { services, options }: ExecutionContext
 ): Promise<ExecutionVertexVisitResult> {

--- a/packages/core/src/internal/execution/dispatch/executeContractCall.ts
+++ b/packages/core/src/internal/execution/dispatch/executeContractCall.ts
@@ -1,6 +1,6 @@
 import type { ExecutionContext } from "../../types/deployment";
 import type {
-  ContractCall,
+  ContractCallExecutionVertex,
   ExecutionVertexVisitResult,
 } from "../../types/executionGraph";
 
@@ -11,7 +11,7 @@ import { VertexResultEnum } from "../../types/graph";
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeContractCall(
-  { method, contract, args, value, signer }: ContractCall,
+  { method, contract, args, value, signer }: ContractCallExecutionVertex,
   resultAccumulator: Map<number, ExecutionVertexVisitResult | undefined>,
   { services, options }: ExecutionContext
 ): Promise<ExecutionVertexVisitResult> {

--- a/packages/core/src/internal/execution/dispatch/executeContractDeploy.ts
+++ b/packages/core/src/internal/execution/dispatch/executeContractDeploy.ts
@@ -1,6 +1,6 @@
 import type { ExecutionContext } from "../../types/deployment";
 import type {
-  ContractDeploy,
+  ContractDeployExecutionVertex,
   ExecutionResultsAccumulator,
   ExecutionVertexVisitResult,
 } from "../../types/executionGraph";
@@ -13,7 +13,7 @@ import { collectLibrariesAndLink } from "../../utils/collectLibrariesAndLink";
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeContractDeploy(
-  { artifact, args, libraries, value, signer }: ContractDeploy,
+  { artifact, args, libraries, value, signer }: ContractDeployExecutionVertex,
   resultAccumulator: ExecutionResultsAccumulator,
   { services, options }: ExecutionContext
 ): Promise<ExecutionVertexVisitResult> {

--- a/packages/core/src/internal/execution/dispatch/executeDeployedContract.ts
+++ b/packages/core/src/internal/execution/dispatch/executeDeployedContract.ts
@@ -1,5 +1,5 @@
 import type {
-  DeployedContract,
+  DeployedContractExecutionVertex,
   ExecutionResultsAccumulator,
   ExecutionVertexVisitResult,
 } from "../../types/executionGraph";
@@ -10,7 +10,7 @@ import { VertexResultEnum } from "../../types/graph";
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeDeployedContract(
-  { label, address, abi }: DeployedContract,
+  { label, address, abi }: DeployedContractExecutionVertex,
   _resultAccumulator: ExecutionResultsAccumulator,
   _: { services: Services }
 ): Promise<ExecutionVertexVisitResult> {

--- a/packages/core/src/internal/execution/dispatch/executeLibraryDeploy.ts
+++ b/packages/core/src/internal/execution/dispatch/executeLibraryDeploy.ts
@@ -2,7 +2,7 @@ import type { ExecutionContext } from "../../types/deployment";
 import type {
   ExecutionResultsAccumulator,
   ExecutionVertexVisitResult,
-  LibraryDeploy,
+  LibraryDeployExecutionVertex,
 } from "../../types/executionGraph";
 
 import { ContractFactory, ethers } from "ethers";
@@ -13,7 +13,7 @@ import { collectLibrariesAndLink } from "../../utils/collectLibrariesAndLink";
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeLibraryDeploy(
-  { artifact, args, signer }: LibraryDeploy,
+  { artifact, args, signer }: LibraryDeployExecutionVertex,
   resultAccumulator: ExecutionResultsAccumulator,
   { services, options }: ExecutionContext
 ): Promise<ExecutionVertexVisitResult> {

--- a/packages/core/src/internal/execution/dispatch/executeSendETH.ts
+++ b/packages/core/src/internal/execution/dispatch/executeSendETH.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext } from "../../types/deployment";
 import type {
   ExecutionVertexVisitResult,
-  SentETH,
+  SentETHExecutionVertex,
 } from "../../types/executionGraph";
 import type { PopulatedTransaction } from "ethers";
 
@@ -10,7 +10,7 @@ import { VertexResultEnum } from "../../types/graph";
 import { resolveFrom, toAddress } from "./utils";
 
 export async function executeSendETH(
-  { address, value, signer }: SentETH,
+  { address, value, signer }: SentETHExecutionVertex,
   resultAccumulator: Map<number, ExecutionVertexVisitResult | undefined>,
   { services, options }: ExecutionContext
 ): Promise<ExecutionVertexVisitResult> {

--- a/packages/core/src/internal/process/transform/convertDeploymentVertexToExecutionVertex.ts
+++ b/packages/core/src/internal/process/transform/convertDeploymentVertexToExecutionVertex.ts
@@ -17,13 +17,13 @@ import {
   SendVertex,
 } from "../../types/deploymentGraph";
 import {
-  AwaitedEvent,
-  ContractCall,
-  ContractDeploy,
-  DeployedContract,
+  AwaitedEventExecutionVertex,
+  ContractCallExecutionVertex,
+  ContractDeployExecutionVertex,
+  DeployedContractExecutionVertex,
   ExecutionVertex,
-  LibraryDeploy,
-  SentETH,
+  LibraryDeployExecutionVertex,
+  SentETHExecutionVertex,
 } from "../../types/executionGraph";
 import { Services } from "../../types/services";
 import { isFuture } from "../../utils/guards";
@@ -76,7 +76,7 @@ export function convertDeploymentVertexToExecutionVertex(
 async function convertHardhatContractToContractDeploy(
   vertex: HardhatContractDeploymentVertex,
   transformContext: TransformContext
-): Promise<ContractDeploy> {
+): Promise<ContractDeployExecutionVertex> {
   const artifact: Artifact =
     await transformContext.services.artifacts.getArtifact(vertex.contractName);
   const signer: ethers.Signer =
@@ -100,7 +100,7 @@ async function convertHardhatContractToContractDeploy(
 async function convertArtifactContractToContractDeploy(
   vertex: ArtifactContractDeploymentVertex,
   transformContext: TransformContext
-): Promise<ContractDeploy> {
+): Promise<ContractDeployExecutionVertex> {
   const signer: ethers.Signer =
     await transformContext.services.accounts.getSigner(vertex.from);
 
@@ -122,7 +122,7 @@ async function convertArtifactContractToContractDeploy(
 async function convertDeployedContractToDeployedDeploy(
   vertex: DeployedContractDeploymentVertex,
   _transformContext: TransformContext
-): Promise<DeployedContract> {
+): Promise<DeployedContractExecutionVertex> {
   return {
     type: "DeployedContract",
     id: vertex.id,
@@ -135,7 +135,7 @@ async function convertDeployedContractToDeployedDeploy(
 async function convertCallToContractCall(
   vertex: CallDeploymentVertex,
   transformContext: TransformContext
-): Promise<ContractCall> {
+): Promise<ContractCallExecutionVertex> {
   const signer: ethers.Signer =
     await transformContext.services.accounts.getSigner(vertex.from);
 
@@ -157,7 +157,7 @@ async function convertCallToContractCall(
 async function convertHardhatLibraryToLibraryDeploy(
   vertex: HardhatLibraryDeploymentVertex,
   transformContext: TransformContext
-): Promise<LibraryDeploy> {
+): Promise<LibraryDeployExecutionVertex> {
   const artifact: Artifact =
     await transformContext.services.artifacts.getArtifact(vertex.libraryName);
   const signer: ethers.Signer =
@@ -176,7 +176,7 @@ async function convertHardhatLibraryToLibraryDeploy(
 async function convertArtifactLibraryToLibraryDeploy(
   vertex: ArtifactLibraryDeploymentVertex,
   transformContext: TransformContext
-): Promise<LibraryDeploy> {
+): Promise<LibraryDeployExecutionVertex> {
   const signer: ethers.Signer =
     await transformContext.services.accounts.getSigner(vertex.from);
 
@@ -193,7 +193,7 @@ async function convertArtifactLibraryToLibraryDeploy(
 async function convertAwaitToAwaitedEvent(
   vertex: EventVertex,
   transformContext: TransformContext
-): Promise<AwaitedEvent> {
+): Promise<AwaitedEventExecutionVertex> {
   return {
     type: "AwaitedEvent",
     id: vertex.id,
@@ -208,7 +208,7 @@ async function convertAwaitToAwaitedEvent(
 async function convertSendToSentETH(
   vertex: SendVertex,
   transformContext: TransformContext
-): Promise<SentETH> {
+): Promise<SentETHExecutionVertex> {
   const signer: ethers.Signer =
     await transformContext.services.accounts.getSigner(vertex.from);
 

--- a/packages/core/src/internal/process/transform/convertDeploymentVertexToExecutionVertex.ts
+++ b/packages/core/src/internal/process/transform/convertDeploymentVertexToExecutionVertex.ts
@@ -1,6 +1,7 @@
 import { BigNumber, ethers } from "ethers";
 
 import { IgnitionError } from "../../../errors";
+import { ExternalParamValue } from "../../../types/dsl";
 import { DeploymentGraphFuture, EventParamFuture } from "../../../types/future";
 import { Artifact } from "../../../types/hardhat";
 import {
@@ -10,7 +11,6 @@ import {
   DeployedContractDeploymentVertex,
   DeploymentGraphVertex,
   EventVertex,
-  ExternalParamValue,
   HardhatContractDeploymentVertex,
   HardhatLibraryDeploymentVertex,
   IDeploymentGraph,

--- a/packages/core/src/internal/services/ConfigService.ts
+++ b/packages/core/src/internal/services/ConfigService.ts
@@ -1,6 +1,6 @@
 import type { HasParamResult, Providers } from "../../types/providers";
-import type { ExternalParamValue } from "../types/deploymentGraph";
 
+import { ExternalParamValue } from "../../types/dsl";
 import { IConfigService } from "../types/services";
 
 export class ConfigService implements IConfigService {

--- a/packages/core/src/internal/types/deploymentGraph.ts
+++ b/packages/core/src/internal/types/deploymentGraph.ts
@@ -63,14 +63,14 @@ export interface LibraryMap {
 /**
  * Allowed parameters that can be passed into a module.
  *
- * @internal
+ * @alpha
  */
 export type ExternalParamValue = boolean | string | number | BigNumber;
 
 /**
  * Allowed parameters across internal `useModule` boundaries.
  *
- * @internal
+ * @alpha
  */
 export type InternalParamValue =
   | ExternalParamValue
@@ -232,7 +232,7 @@ export interface SendVertex extends VertexDescriptor {
 /**
  * The options for a Contract deploy.
  *
- * @internal
+ * @alpha
  */
 export interface ContractOptions {
   args?: InternalParamValue[];
@@ -247,7 +247,7 @@ export interface ContractOptions {
 /**
  * The options for a smart contract method call.
  *
- * @internal
+ * @alpha
  */
 export interface CallOptions {
   args: InternalParamValue[];
@@ -259,7 +259,7 @@ export interface CallOptions {
 /**
  * The options for an await action.
  *
- * @internal
+ * @alpha
  */
 export interface AwaitOptions {
   args: InternalParamValue[];
@@ -269,7 +269,7 @@ export interface AwaitOptions {
 /**
  * The options for sending ETH to an address/contract.
  *
- * @internal
+ * @alpha
  */
 export interface SendOptions {
   value: BigNumber | ParameterFuture;
@@ -280,7 +280,7 @@ export interface SendOptions {
 /**
  * The options when using a module within another module.
  *
- * @internal
+ * @alpha
  */
 export interface UseModuleOptions {
   parameters?: { [key: string]: number | string | DeploymentGraphFuture };
@@ -291,12 +291,11 @@ export interface UseModuleOptions {
  * A builder object for specifying the different parts and
  * dependencies of your deployment.
  *
- * @internal
+ * @alpha
  */
 export interface IDeploymentBuilder {
   chainId: number;
   accounts: string[];
-  graph: IDeploymentGraph;
 
   contract(contractName: string, options?: ContractOptions): HardhatContract;
   contract(

--- a/packages/core/src/internal/types/deploymentGraph.ts
+++ b/packages/core/src/internal/types/deploymentGraph.ts
@@ -1,36 +1,46 @@
 import type { BigNumber } from "ethers";
 
 import {
+  AddressResolvable,
   ArtifactContract,
+  ArtifactFuture,
   ArtifactLibrary,
-  EventFuture,
+  CallableFuture,
   ContractCall,
   DeployedContract,
   DeploymentGraphFuture,
+  EventFuture,
+  EventParamFuture,
   HardhatContract,
   HardhatLibrary,
   OptionalParameter,
+  ParameterFuture,
   ParameterValue,
   RequiredParameter,
-  CallableFuture,
-  Virtual,
-  ParameterFuture,
-  ArtifactFuture,
-  EventParamFuture,
   SendFuture,
-  AddressResolvable,
+  Virtual,
 } from "../../types/future";
 import { Artifact } from "../../types/hardhat";
-import { ModuleDict, Module } from "../../types/module";
+import { Module, ModuleDict } from "../../types/module";
 
 import { AdjacencyList, VertexDescriptor } from "./graph";
 
+/**
+ * Scope data to manage internal nested calls to submodules.
+ *
+ * @internal
+ */
 export interface ScopeData {
   before: Virtual;
   after?: Virtual;
   parameters?: { [key: string]: string | number | DeploymentGraphFuture };
 }
 
+/**
+ * A dependency graph that matches the deployment decribed by a Module.
+ *
+ * @internal
+ */
 export interface IDeploymentGraph {
   vertexes: Map<number, DeploymentGraphVertex>;
   adjacencyList: AdjacencyList;
@@ -40,17 +50,38 @@ export interface IDeploymentGraph {
   getEdges(): Array<{ from: number; to: number }>;
 }
 
+/**
+ * A mapping of library names to the future address
+ * of the deployed library.
+ *
+ * @internal
+ */
 export interface LibraryMap {
   [key: string]: DeploymentGraphFuture;
 }
 
+/**
+ * Allowed parameters that can be passed into a module.
+ *
+ * @internal
+ */
 export type ExternalParamValue = boolean | string | number | BigNumber;
 
+/**
+ * Allowed parameters across internal `useModule` boundaries.
+ *
+ * @internal
+ */
 export type InternalParamValue =
   | ExternalParamValue
   | DeploymentGraphFuture
   | EventParamFuture;
 
+/**
+ * A vertex representing an action specified in the Deployment api.
+ *
+ * @internal
+ */
 export type DeploymentGraphVertex =
   | HardhatContractDeploymentVertex
   | ArtifactContractDeploymentVertex
@@ -62,6 +93,12 @@ export type DeploymentGraphVertex =
   | EventVertex
   | SendVertex;
 
+/**
+ * Deploy a contract, where the contract will be retrieved by name
+ * from Hardhat's Artifact store.
+ *
+ * @internal
+ */
 export interface HardhatContractDeploymentVertex extends VertexDescriptor {
   type: "HardhatContract";
   scopeAdded: string;
@@ -73,6 +110,11 @@ export interface HardhatContractDeploymentVertex extends VertexDescriptor {
   from: string;
 }
 
+/**
+ * Deploy a contract based on a given Artifact.
+ *
+ * @internal
+ */
 export interface ArtifactContractDeploymentVertex extends VertexDescriptor {
   type: "ArtifactContract";
   scopeAdded: string;
@@ -84,6 +126,11 @@ export interface ArtifactContractDeploymentVertex extends VertexDescriptor {
   from: string;
 }
 
+/**
+ * Refer to an existing deployed contract, for later use in the Module.
+ *
+ * @internal
+ */
 export interface DeployedContractDeploymentVertex extends VertexDescriptor {
   type: "DeployedContract";
   scopeAdded: string;
@@ -92,6 +139,12 @@ export interface DeployedContractDeploymentVertex extends VertexDescriptor {
   after: DeploymentGraphFuture[];
 }
 
+/**
+ * Deploy a library, where the library will be retrieved by name
+ * from Hardhat's Artifact store.
+ *
+ * @internal
+ */
 export interface HardhatLibraryDeploymentVertex extends VertexDescriptor {
   type: "HardhatLibrary";
   libraryName: string;
@@ -101,6 +154,11 @@ export interface HardhatLibraryDeploymentVertex extends VertexDescriptor {
   from: string;
 }
 
+/**
+ * Deploy a library based on a given artifact.
+ *
+ * @internal
+ */
 export interface ArtifactLibraryDeploymentVertex extends VertexDescriptor {
   type: "ArtifactLibrary";
   scopeAdded: string;
@@ -110,6 +168,11 @@ export interface ArtifactLibraryDeploymentVertex extends VertexDescriptor {
   from: string;
 }
 
+/**
+ * Invoke a smart contract method.
+ *
+ * @internal
+ */
 export interface CallDeploymentVertex extends VertexDescriptor {
   type: "Call";
   scopeAdded: string;
@@ -121,12 +184,27 @@ export interface CallDeploymentVertex extends VertexDescriptor {
   from: string;
 }
 
+/**
+ * A non-action vertex used to represent group relationships. The virtual
+ * vertex can depend on many other vertexes, so a dependency on the virtual
+ * vertex will mean depending on all its dependents.
+ *
+ * The virtual vertex is removed during translation to a simplified
+ * execution graph.
+ *
+ * @internal
+ */
 export interface VirtualVertex extends VertexDescriptor {
   type: "Virtual";
   scopeAdded: string;
   after: DeploymentGraphFuture[];
 }
 
+/**
+ * Await on an on-chain Ethereum event.
+ *
+ * @internal
+ */
 export interface EventVertex extends VertexDescriptor {
   type: "Event";
   scopeAdded: string;
@@ -137,6 +215,11 @@ export interface EventVertex extends VertexDescriptor {
   after: DeploymentGraphFuture[];
 }
 
+/**
+ * Send ETH to a contract/address.
+ *
+ * @internal
+ */
 export interface SendVertex extends VertexDescriptor {
   type: "SendETH";
   scopeAdded: string;
@@ -146,6 +229,11 @@ export interface SendVertex extends VertexDescriptor {
   from: string;
 }
 
+/**
+ * The options for a Contract deploy.
+ *
+ * @internal
+ */
 export interface ContractOptions {
   args?: InternalParamValue[];
   libraries?: {
@@ -156,6 +244,11 @@ export interface ContractOptions {
   from?: string;
 }
 
+/**
+ * The options for a smart contract method call.
+ *
+ * @internal
+ */
 export interface CallOptions {
   args: InternalParamValue[];
   after?: DeploymentGraphFuture[];
@@ -163,22 +256,43 @@ export interface CallOptions {
   from?: string;
 }
 
+/**
+ * The options for an await action.
+ *
+ * @internal
+ */
 export interface AwaitOptions {
   args: InternalParamValue[];
   after?: DeploymentGraphFuture[];
 }
 
+/**
+ * The options for sending ETH to an address/contract.
+ *
+ * @internal
+ */
 export interface SendOptions {
   value: BigNumber | ParameterFuture;
   after?: DeploymentGraphFuture[];
   from?: string;
 }
 
+/**
+ * The options when using a module within another module.
+ *
+ * @internal
+ */
 export interface UseModuleOptions {
   parameters?: { [key: string]: number | string | DeploymentGraphFuture };
   after?: DeploymentGraphFuture[];
 }
 
+/**
+ * A builder object for specifying the different parts and
+ * dependencies of your deployment.
+ *
+ * @internal
+ */
 export interface IDeploymentBuilder {
   chainId: number;
   accounts: string[];

--- a/packages/core/src/internal/types/deploymentGraph.ts
+++ b/packages/core/src/internal/types/deploymentGraph.ts
@@ -1,27 +1,16 @@
 import type { BigNumber } from "ethers";
 
+import { InternalParamValue } from "../../types/dsl";
 import {
   AddressResolvable,
   ArtifactContract,
-  ArtifactFuture,
-  ArtifactLibrary,
   CallableFuture,
-  ContractCall,
-  DeployedContract,
   DeploymentGraphFuture,
-  EventFuture,
   EventParamFuture,
-  HardhatContract,
-  HardhatLibrary,
-  OptionalParameter,
   ParameterFuture,
-  ParameterValue,
-  RequiredParameter,
-  SendFuture,
   Virtual,
 } from "../../types/future";
 import { Artifact } from "../../types/hardhat";
-import { Module, ModuleDict } from "../../types/module";
 
 import { AdjacencyList, VertexDescriptor } from "./graph";
 
@@ -59,23 +48,6 @@ export interface IDeploymentGraph {
 export interface LibraryMap {
   [key: string]: DeploymentGraphFuture;
 }
-
-/**
- * Allowed parameters that can be passed into a module.
- *
- * @alpha
- */
-export type ExternalParamValue = boolean | string | number | BigNumber;
-
-/**
- * Allowed parameters across internal `useModule` boundaries.
- *
- * @alpha
- */
-export type InternalParamValue =
-  | ExternalParamValue
-  | DeploymentGraphFuture
-  | EventParamFuture;
 
 /**
  * A vertex representing an action specified in the Deployment api.
@@ -227,124 +199,6 @@ export interface SendVertex extends VertexDescriptor {
   value: BigNumber | ParameterFuture;
   after: DeploymentGraphFuture[];
   from: string;
-}
-
-/**
- * The options for a Contract deploy.
- *
- * @alpha
- */
-export interface ContractOptions {
-  args?: InternalParamValue[];
-  libraries?: {
-    [key: string]: DeploymentGraphFuture;
-  };
-  after?: DeploymentGraphFuture[];
-  value?: BigNumber | ParameterFuture;
-  from?: string;
-}
-
-/**
- * The options for a smart contract method call.
- *
- * @alpha
- */
-export interface CallOptions {
-  args: InternalParamValue[];
-  after?: DeploymentGraphFuture[];
-  value?: BigNumber | ParameterFuture;
-  from?: string;
-}
-
-/**
- * The options for an await action.
- *
- * @alpha
- */
-export interface AwaitOptions {
-  args: InternalParamValue[];
-  after?: DeploymentGraphFuture[];
-}
-
-/**
- * The options for sending ETH to an address/contract.
- *
- * @alpha
- */
-export interface SendOptions {
-  value: BigNumber | ParameterFuture;
-  after?: DeploymentGraphFuture[];
-  from?: string;
-}
-
-/**
- * The options when using a module within another module.
- *
- * @alpha
- */
-export interface UseModuleOptions {
-  parameters?: { [key: string]: number | string | DeploymentGraphFuture };
-  after?: DeploymentGraphFuture[];
-}
-
-/**
- * A builder object for specifying the different parts and
- * dependencies of your deployment.
- *
- * @alpha
- */
-export interface IDeploymentBuilder {
-  chainId: number;
-  accounts: string[];
-
-  contract(contractName: string, options?: ContractOptions): HardhatContract;
-  contract(
-    contractName: string,
-    artifact: Artifact,
-    options?: ContractOptions
-  ): ArtifactContract;
-
-  contractAt(
-    contractName: string,
-    address: string | EventParamFuture,
-    abi: any[],
-    options?: { after?: DeploymentGraphFuture[] }
-  ): DeployedContract;
-
-  library(contractName: string, options?: ContractOptions): HardhatLibrary;
-  library(
-    contractName: string,
-    artifact: Artifact,
-    options?: ContractOptions
-  ): ArtifactLibrary;
-
-  call(
-    contractFuture: DeploymentGraphFuture,
-    functionName: string,
-    options: CallOptions
-  ): ContractCall;
-
-  event(
-    contractFuture: ArtifactFuture,
-    eventName: string,
-    options: AwaitOptions
-  ): EventFuture;
-
-  sendETH(sendTo: AddressResolvable, options: SendOptions): SendFuture;
-
-  getParam(paramName: string): RequiredParameter;
-
-  getOptionalParam(
-    paramName: string,
-    defaultValue: ParameterValue
-  ): OptionalParameter;
-
-  getArtifact(contractName: string): Artifact;
-
-  useModule<T extends ModuleDict>(
-    module: Module<T>,
-    options?: UseModuleOptions
-  ): Virtual & T;
 }
 
 export interface DeploymentBuilderOptions {

--- a/packages/core/src/internal/types/executionGraph.ts
+++ b/packages/core/src/internal/types/executionGraph.ts
@@ -17,12 +17,22 @@ import {
   VisitResult,
 } from "./graph";
 
+/**
+ * A dependency graph for on-chain execution.
+ *
+ * @internal
+ */
 export interface IExecutionGraph {
   adjacencyList: AdjacencyList;
   vertexes: Map<number, ExecutionVertex>;
   getEdges(): Array<{ from: number; to: number }>;
 }
 
+/**
+ * The allowed values when passing an argument to a smart contract method call.
+ *
+ * @internal
+ */
 export type ArgValue =
   | boolean
   | string
@@ -30,6 +40,11 @@ export type ArgValue =
   | BigNumber
   | DeploymentGraphFuture;
 
+/**
+ * The different types of the vertexes of the execution graph.
+ *
+ * @internal
+ */
 export type ExecutionVertexType =
   | "ContractDeploy"
   | "DeployedContract"
@@ -38,15 +53,25 @@ export type ExecutionVertexType =
   | "AwaitedEvent"
   | "SentETH";
 
+/**
+ * The vertexes of the execution graph.
+ *
+ * @internal
+ */
 export type ExecutionVertex =
-  | ContractDeploy
-  | DeployedContract
-  | LibraryDeploy
-  | ContractCall
-  | AwaitedEvent
-  | SentETH;
+  | ContractDeployExecutionVertex
+  | DeployedContractExecutionVertex
+  | LibraryDeployExecutionVertex
+  | ContractCallExecutionVertex
+  | AwaitedEventExecutionVertex
+  | SentETHExecutionVertex;
 
-export interface ContractDeploy extends VertexDescriptor {
+/**
+ * Deploy a contract based on the given artifact.
+ *
+ * @internal
+ */
+export interface ContractDeployExecutionVertex extends VertexDescriptor {
   type: "ContractDeploy";
   artifact: Artifact;
   args: ArgValue[];
@@ -55,20 +80,36 @@ export interface ContractDeploy extends VertexDescriptor {
   signer: ethers.Signer;
 }
 
-export interface DeployedContract extends VertexDescriptor {
+/**
+ * Make no on-chain action but substitute an already known
+ * address and abi.
+ *
+ * @internal
+ */
+export interface DeployedContractExecutionVertex extends VertexDescriptor {
   type: "DeployedContract";
   address: string | EventParamFuture;
   abi: any[];
 }
 
-export interface LibraryDeploy extends VertexDescriptor {
+/**
+ * Deploy a library based on the given artifact.
+ *
+ * @internal
+ */
+export interface LibraryDeployExecutionVertex extends VertexDescriptor {
   type: "LibraryDeploy";
   artifact: Artifact;
   args: ArgValue[];
   signer: ethers.Signer;
 }
 
-export interface ContractCall extends VertexDescriptor {
+/**
+ * Make a method call to a smart chain contract.
+ *
+ * @internal
+ */
+export interface ContractCallExecutionVertex extends VertexDescriptor {
   type: "ContractCall";
   contract: any;
   method: string;
@@ -77,7 +118,12 @@ export interface ContractCall extends VertexDescriptor {
   signer: ethers.Signer;
 }
 
-export interface AwaitedEvent extends VertexDescriptor {
+/**
+ * Wait for the an Ethereum event to execute.
+ *
+ * @internal
+ */
+export interface AwaitedEventExecutionVertex extends VertexDescriptor {
   type: "AwaitedEvent";
   abi: any[];
   address: string | ArtifactContract | EventParamFuture;
@@ -85,13 +131,23 @@ export interface AwaitedEvent extends VertexDescriptor {
   args: ArgValue[];
 }
 
-export interface SentETH extends VertexDescriptor {
+/**
+ * Transfer ETH to a contract/address.
+ *
+ * @internal
+ */
+export interface SentETHExecutionVertex extends VertexDescriptor {
   type: "SentETH";
   address: AddressResolvable;
   value: BigNumber;
   signer: ethers.Signer;
 }
 
+/**
+ * The result of a successful contract deployment.
+ *
+ * @internal
+ */
 export interface ContractDeploySuccess {
   name: string;
   abi: any[];
@@ -100,12 +156,22 @@ export interface ContractDeploySuccess {
   value: ethers.BigNumber;
 }
 
+/**
+ * The result of a successful existing contract.
+ *
+ * @internal
+ */
 export interface DeployedContractSuccess {
   name: string;
   abi: any[];
   address: string;
 }
 
+/**
+ * The result of a successful library deployment.
+ *
+ * @internal
+ */
 export interface LibraryDeploySuccess {
   name: string;
   abi: any[];
@@ -113,19 +179,39 @@ export interface LibraryDeploySuccess {
   address: string;
 }
 
+/**
+ * The result of a successful wait on an Ethereum event.
+ *
+ * @internal
+ */
 export interface AwaitedEventSuccess {
   topics: ethers.utils.Result;
 }
 
+/**
+ * The result of a successful smart contract method invocation.
+ *
+ * @internal
+ */
 export interface ContractCallSuccess {
   hash: string;
 }
 
+/**
+ * The result of a successful transfer of ETH to a contract/address.
+ *
+ * @internal
+ */
 export interface SendETHSuccess {
   hash: string;
   value: ethers.BigNumber;
 }
 
+/**
+ * The result of a successful vertex execution.
+ *
+ * @internal
+ */
 export type VertexVisitResultSuccessResult =
   | ContractDeploySuccess
   | DeployedContractSuccess
@@ -134,6 +220,11 @@ export type VertexVisitResultSuccessResult =
   | ContractCallSuccess
   | SendETHSuccess;
 
+/**
+ * The result of a processing a vertex of the execution graph.
+ *
+ * @internal
+ */
 export type ExecutionVertexVisitResult =
   VertexVisitResult<VertexVisitResultSuccessResult>;
 

--- a/packages/core/src/internal/types/graph.ts
+++ b/packages/core/src/internal/types/graph.ts
@@ -1,3 +1,28 @@
+/**
+ * An abstraction for representing the edges of a graph,
+ * where a from vertex id is matched to a set of linked
+ * to vertexes.
+ *
+ * @internal
+ */
+export type AdjacencyList = Map<number, Set<number>>;
+
+/**
+ * An adjacency list based graph.
+ *
+ * @internal
+ */
+export interface IGraph<T> {
+  adjacencyList: AdjacencyList;
+  vertexes: Map<number, T>;
+  getEdges(): Array<{ from: number; to: number }>;
+}
+
+/**
+ * An Ignition on-chain action as part of a depedency graph.
+ *
+ * @internal
+ */
 export interface VertexDescriptor {
   id: number;
   label: string;
@@ -5,36 +30,60 @@ export interface VertexDescriptor {
   args?: any[];
 }
 
-export type AdjacencyList = Map<number, Set<number>>;
-
-export interface IGraph<T> {
-  adjacencyList: AdjacencyList;
-  vertexes: Map<number, T>;
-  getEdges(): Array<{ from: number; to: number }>;
-}
-
+/**
+ * A graph of Ignition on-chain actions.
+ *
+ * @internal
+ */
 export type VertexGraph = IGraph<VertexDescriptor>;
 
+/**
+ * The different possibilities of processing a dependency graph vertex.
+ *
+ * @internal
+ */
 export enum VertexResultEnum {
   SUCCESS = "success",
   FAILURE = "failure",
   HOLD = "hold",
 }
 
+/**
+ * The result of performing the vertex actioni succeeded with the result.
+ *
+ * @internal
+ */
 export interface VertexVisitResultSuccess<T> {
   _kind: VertexResultEnum.SUCCESS;
   result: T;
 }
 
+/**
+ * The result of performing the vertex action failed with the given error.
+ *
+ * @internal
+ */
 export interface VertexVisitResultFailure {
   _kind: VertexResultEnum.FAILURE;
   failure: Error;
 }
 
+/**
+ * The result of performing the vertex action either timed out or did not
+ * meet the test condition.
+ *
+ * @internal
+ */
 export interface VertexVisitResultHold {
   _kind: VertexResultEnum.HOLD;
 }
 
+/**
+ * The result of processing a vertex in the dependency graph, either a
+ * success, failure or on hold.
+ *
+ * @internal
+ */
 export type VertexVisitResult<T> =
   | VertexVisitResultSuccess<T>
   | VertexVisitResultFailure

--- a/packages/core/src/internal/types/journal.ts
+++ b/packages/core/src/internal/types/journal.ts
@@ -30,8 +30,23 @@ export interface Journal {
   delete(moduleId: string): Promise<void>;
 }
 
+/**
+ * An adapter to record and retrieve a transaction log of deployment state
+ * changes.
+ *
+ * @internal
+ */
 export interface ICommandJournal {
+  /**
+   * Store a record of the given command
+   * @param command - The deployment update command to record
+   *
+   * @internal
+   */
   record(command: DeployStateExecutionCommand): Promise<void>;
 
+  /**
+   * Read out the stored deployment update commands.
+   */
   read(): AsyncGenerator<DeployStateExecutionCommand, void, unknown>;
 }

--- a/packages/core/src/internal/types/services.ts
+++ b/packages/core/src/internal/types/services.ts
@@ -8,23 +8,44 @@ import type { ExternalParamValue } from "./deploymentGraph";
 
 import { ethers } from "ethers";
 
+/**
+ * Access a set of predefined ethereum accounts and their equivalent signers.
+ *
+ * @internal
+ */
 export interface IAccountsService {
   getAccounts(): Promise<string[]>;
   getSigner(address: string): Promise<ethers.Signer>;
 }
 
+/**
+ * Provide access to contract artifacts (i.e. the container for a contract's
+ * abi, bytecode and other key metadata).
+ *
+ * @internal
+ */
 export interface IArtifactsService {
   getArtifact(name: string): Promise<Artifact>;
   hasArtifact(name: string): Promise<boolean>;
   getAllArtifacts(): Promise<Artifact[]>;
 }
 
+/**
+ * Provide access to underlying configuration options.
+ *
+ * @internal
+ */
 export interface IConfigService {
   getParam(paramName: string): Promise<ExternalParamValue>;
 
   hasParam(paramName: string): Promise<HasParamResult>;
 }
 
+/**
+ * Allow the sending of transactions to smart contracts on-chain.
+ *
+ * @internal
+ */
 export interface IContractsService {
   sendTx(
     deployTransaction: ethers.providers.TransactionRequest,
@@ -32,10 +53,21 @@ export interface IContractsService {
   ): Promise<string>;
 }
 
+/**
+ * Provide access to details of the chain being deployed against.
+ *
+ * @internal
+ */
 export interface INetworkService {
   getChainId(): Promise<number>;
 }
 
+/**
+ * Provide general access to the target chains transaction and event
+ * processing.
+ *
+ * @internal
+ */
 export interface ITransactionsService {
   wait(txHash: string): Promise<ethers.providers.TransactionReceipt>;
   waitForEvent(
@@ -44,6 +76,12 @@ export interface ITransactionsService {
   ): Promise<ethers.providers.Log | null>;
 }
 
+/**
+ * Configuration options to be sent to the target chain with the transaction
+ * to be processed.
+ *
+ * @internal
+ */
 export interface TransactionOptions {
   gasLimit?: ethers.BigNumberish;
   gasPrice?: ethers.BigNumberish;
@@ -59,6 +97,13 @@ export interface ContractsServiceProviders {
   gasProvider: GasProvider;
 }
 
+/**
+ * Adapter implementations for the underlying services that represent
+ * Ignitions interactions with external systems (i.e. the target blockchain,
+ * the filesystem etc).
+ *
+ * @internal
+ */
 export interface Services {
   network: INetworkService;
   contracts: IContractsService;

--- a/packages/core/src/internal/types/services.ts
+++ b/packages/core/src/internal/types/services.ts
@@ -4,7 +4,7 @@ import type {
   HasParamResult,
   TransactionsProvider,
 } from "../../types/providers";
-import type { ExternalParamValue } from "./deploymentGraph";
+import type { ExternalParamValue } from "./../../types/dsl";
 
 import { ethers } from "ethers";
 

--- a/packages/core/src/types/dsl.ts
+++ b/packages/core/src/types/dsl.ts
@@ -1,0 +1,284 @@
+import { BigNumber } from "ethers";
+
+import {
+  AddressResolvable,
+  ArtifactContract,
+  ArtifactFuture,
+  ArtifactLibrary,
+  ContractCall,
+  DeployedContract,
+  DeploymentGraphFuture,
+  EventFuture,
+  EventParamFuture,
+  HardhatContract,
+  HardhatLibrary,
+  OptionalParameter,
+  ParameterFuture,
+  ParameterValue,
+  RequiredParameter,
+  SendFuture,
+  Virtual,
+} from "./future";
+import { Artifact } from "./hardhat";
+import { Module, ModuleDict } from "./module";
+
+/**
+ * A builder object for specifying the different parts and
+ * dependencies of your deployment.
+ *
+ * @alpha
+ */
+
+export interface IDeploymentBuilder {
+  /**
+   * The `chainId` of the network being deployed to.
+   */
+  chainId: number;
+
+  /**
+   * The Hardhat accounts as defined in the `Hardhat.config.{js,ts}` file,
+   * deployment actions can leverage these accounts to specify which
+   * account the on-chain transaction that underlies the action will
+   * execute under.
+   */
+  accounts: string[];
+
+  /**
+   * Call a contract method.
+   *
+   * @param contractFuture - A contract future
+   * @param functionName - the name of the method to be invoked
+   * @param options - The options to control the method invocation.
+   *
+   * @alpha
+   */
+  call(
+    contractFuture: DeploymentGraphFuture,
+    functionName: string,
+    options: CallOptions
+  ): ContractCall;
+
+  /**
+   * Deploy a named contract from Hardhat's contracts folder.
+   *
+   * @param contractName - The name of the contract to deploy
+   * @param options - The options for controlling the deployment of the contract
+   *
+   * @alpha
+   */
+  contract(contractName: string, options?: ContractOptions): HardhatContract;
+
+  /**
+   * Deploy a contract based on an artifact.
+   *
+   * @param contractName - The label to use for the given contract in logs,
+   * errors and UI
+   * @param artifact - The artifact containing the contract data (i.e. bytecode,
+   *  abi etc)
+   * @param options - The options for controlling the deployment of the contract
+   *
+   * @alpha
+   */
+  contract(
+    contractName: string,
+    artifact: Artifact,
+    options?: ContractOptions
+  ): ArtifactContract;
+
+  /**
+   * Refer to an existing deployed smart contract, the reference can be passed
+   * to subsequent actions.
+   *
+   * @param contractName - The label to use for the given contract in logs,
+   * errors and UI
+   * @param address - the Ethereum address of the contract
+   * @param abi - The contract's Application Binary Interface (ABI)
+   * @param options - The options for controlling the use of the deployed
+   *  contract
+   *
+   * @alpha
+   */
+  contractAt(
+    contractName: string,
+    address: string | EventParamFuture,
+    abi: any[],
+    options?: { after?: DeploymentGraphFuture[] }
+  ): DeployedContract;
+
+  /**
+   * Wait for a contract to emit an event, then continue with the deployment
+   * passing any returned arguments onto subsequent actions.
+   *
+   * @param contractFuture - The contract future where the event will originate
+   * @param eventName - The name of the event to wait on
+   * @param options - The options to control the wait for the event
+   *
+   * @alpha
+   */
+  event(
+    contractFuture: ArtifactFuture,
+    eventName: string,
+    options: AwaitOptions
+  ): EventFuture;
+
+  /**
+   * Retreive an artifact for the named contract or library within Hardhat's
+   * contracts folder.
+   *
+   * @param contractName - The name of the contract or library to retrieve
+   * the artifact for
+   * @returns The artifact for the contract or library
+   */
+  getArtifact(contractName: string): Artifact;
+
+  /**
+   * Get the value of a named parameter that _can_ be passed into the currently
+   * scoped Module. If the Module does not receive the parameter then the
+   * default value will be used instead.
+   *
+   * @param paramName - The parameter name
+   * @param defaultValue - The default value to use if no parameter with the
+   * given name is provided to the module currently in scops.
+   *
+   * @alpha
+   */
+  getOptionalParam(
+    paramName: string,
+    defaultValue: ParameterValue
+  ): OptionalParameter;
+
+  /**
+   * Get the value of a named parameter that _must_ be passed into the currently
+   * scoped Module.
+   *
+   * @param paramName - The parameter name
+   *
+   * @alpha
+   */
+  getParam(paramName: string): RequiredParameter;
+
+  /**
+   * Deploy a named library from Hardhat's contracts folder.
+   *
+   * @param libraryName - The name of the library to deploy
+   * @param options - The options to control the deployment of the library
+   *
+   * @alpha
+   */
+  library(libraryName: string, options?: ContractOptions): HardhatLibrary;
+  /**
+   * Deploy a library based on an artifact.
+   *
+   * @param libraryName - The label to use for the given library in logs,
+   * errors and UI
+   * @param artifact - The artifact containing the library;s data (i.e.
+   * bytecode, abi etc)
+   * @param options - The options to control the deployment of the library
+   */
+  library(
+    libraryName: string,
+    artifact: Artifact,
+    options?: ContractOptions
+  ): ArtifactLibrary;
+
+  /**
+   * Transfer ETH to an externally owned account or contract based on address.
+   *
+   * @param sendTo - The Ethereum address to send the ETH to
+   * @param options - The options to control the send
+   *
+   * @alpha
+   */
+  sendETH(sendTo: AddressResolvable, options: SendOptions): SendFuture;
+
+  /**
+   * Deploy a module from within the current module.
+   *
+   * @param module - The Ignition module to be deployed
+   * @param options - The options that control the running of the submodule
+   * @returns A results object that is both a future that can be depended on,
+   * representing the completion of everything within the submodule,
+   * and contains the contract futures of any contracts or libraries deployed.
+   *
+   * @alpha
+   */
+  useModule<T extends ModuleDict>(
+    module: Module<T>,
+    options?: UseModuleOptions
+  ): Virtual & T;
+}
+
+/**
+ * The options for an await action.
+ *
+ * @alpha
+ */
+export interface AwaitOptions {
+  args: InternalParamValue[];
+  after?: DeploymentGraphFuture[];
+}
+
+/**
+ * The options for a smart contract method call.
+ *
+ * @alpha
+ */
+export interface CallOptions {
+  args: InternalParamValue[];
+  after?: DeploymentGraphFuture[];
+  value?: BigNumber | ParameterFuture;
+  from?: string;
+}
+
+/**
+ * The options for a Contract deploy.
+ *
+ * @alpha
+ */
+export interface ContractOptions {
+  args?: InternalParamValue[];
+  libraries?: {
+    [key: string]: DeploymentGraphFuture;
+  };
+  after?: DeploymentGraphFuture[];
+  value?: BigNumber | ParameterFuture;
+  from?: string;
+}
+
+/**
+ * The options for sending ETH to an address/contract.
+ *
+ * @alpha
+ */
+export interface SendOptions {
+  value: BigNumber | ParameterFuture;
+  after?: DeploymentGraphFuture[];
+  from?: string;
+}
+
+/**
+ * The options when using a module within another module.
+ *
+ * @alpha
+ */
+export interface UseModuleOptions {
+  parameters?: { [key: string]: number | string | DeploymentGraphFuture };
+  after?: DeploymentGraphFuture[];
+}
+
+/**
+ * Allowed parameters that can be passed into a module.
+ *
+ * @alpha
+ */
+export type ExternalParamValue = boolean | string | number | BigNumber;
+
+/**
+ * Allowed parameters across internal `useModule` boundaries.
+ *
+ * @alpha
+ */
+export type InternalParamValue =
+  | ExternalParamValue
+  | DeploymentGraphFuture
+  | EventParamFuture;

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -4,7 +4,7 @@ import type { Artifact } from "./hardhat";
  * A future representing the address of a contract deployed using the
  * Hardhat Artifact system.
  *
- * @internal
+ * @alpha
  */
 export interface HardhatContract {
   vertexId: number;
@@ -19,7 +19,7 @@ export interface HardhatContract {
  * A future representing the value of a contract deployed using a given
  * artifact.
  *
- * @internal
+ * @alpha
  */
 export interface ArtifactContract {
   vertexId: number;
@@ -33,7 +33,7 @@ export interface ArtifactContract {
 /**
  * A future representing the address of an already deployed contract.
  *
- * @internal
+ * @alpha
  */
 export interface DeployedContract {
   vertexId: number;
@@ -49,7 +49,7 @@ export interface DeployedContract {
  * A future representing the address of a library deployed using Hardhat's
  * artifact system.
  *
- * @internal
+ * @alpha
  */
 export interface HardhatLibrary {
   vertexId: number;
@@ -64,7 +64,7 @@ export interface HardhatLibrary {
  * A future representing the address of a library deployed using a given
  * artifact.
  *
- * @internal
+ * @alpha
  */
 export interface ArtifactLibrary {
   vertexId: number;
@@ -78,7 +78,7 @@ export interface ArtifactLibrary {
 /**
  * A future representing an on-chain smart contract method invocation.
  *
- * @internal
+ * @alpha
  */
 export interface ContractCall {
   vertexId: number;
@@ -90,7 +90,7 @@ export interface ContractCall {
 /**
  * A future representing an on-chain Ethereum event.
  *
- * @internal
+ * @alpha
  */
 export interface EventFuture {
   vertexId: number;
@@ -104,7 +104,7 @@ export interface EventFuture {
 /**
  * A future representing the sending of Eth to a contract/address.
  *
- * @internal
+ * @alpha
  */
 export interface SendFuture {
   vertexId: number;
@@ -117,7 +117,7 @@ export interface SendFuture {
 /**
  * A mapping of named parameter labels to future parameter values.
  *
- * @internal
+ * @alpha
  */
 export interface EventParams {
   [eventParam: string]: EventParamFuture;
@@ -126,7 +126,7 @@ export interface EventParams {
 /**
  * A future representing a parameter of an on-chain Ethereum event.
  *
- * @internal
+ * @alpha
  */
 export interface EventParamFuture {
   vertexId: number;
@@ -139,7 +139,7 @@ export interface EventParamFuture {
 /**
  * A value that can be used as a Module parameter.
  *
- * @internal
+ * @alpha
  */
 export type ParameterValue = string | number | DeploymentGraphFuture;
 
@@ -147,7 +147,7 @@ export type ParameterValue = string | number | DeploymentGraphFuture;
  * A future representing a parameter value that _must_ be provided to the module
  * for it to execute.
  *
- * @internal
+ * @alpha
  */
 export interface RequiredParameter {
   label: string;
@@ -161,7 +161,7 @@ export interface RequiredParameter {
  * A future representing a parameter value that _may_ be provided to the module
  * for it to execute. In its absence the `defaultValue` will be used.
  *
- * @internal
+ * @alpha
  */
 export interface OptionalParameter {
   label: string;
@@ -175,7 +175,7 @@ export interface OptionalParameter {
 /**
  * A future representing a virtual node used for grouping other actions.
  *
- * @internal
+ * @alpha
  */
 export interface Virtual {
   vertexId: number;
@@ -193,7 +193,7 @@ export interface Virtual {
  * dependency on it can be made to depend on the Virtual vertex that
  * represents the entire submodule.
  *
- * @internal
+ * @alpha
  */
 export interface ProxyFuture {
   label: string;
@@ -210,14 +210,14 @@ export interface ProxyFuture {
  * @privateRemarks
  * TODO: is this needed?
  *
- * @internal
+ * @alpha
  */
 export type ArtifactFuture = ArtifactContract | DeployedContract;
 
 /**
  * A future representing the address of a deployed Contract.
  *
- * @internal
+ * @alpha
  */
 export type ContractFuture =
   | HardhatContract
@@ -227,21 +227,21 @@ export type ContractFuture =
 /**
  * The future representing the address of a deployed library.
  *
- * @internal
+ * @alpha
  */
 export type LibraryFuture = HardhatLibrary | ArtifactLibrary;
 
 /**
  * The future representing the value of calling a smart contract method.
  *
- * @internal
+ * @alpha
  */
 export type CallableFuture = ContractFuture | LibraryFuture;
 
 /**
  * A future value from an on-chain action that.
  *
- * @internal
+ * @alpha
  */
 export type DependableFuture =
   | CallableFuture
@@ -254,7 +254,7 @@ export type DependableFuture =
 /**
  * A future value representing an Ethereum address.
  *
- * @internal
+ * @alpha
  */
 export type AddressResolvable =
   | string
@@ -265,14 +265,14 @@ export type AddressResolvable =
 /**
  * The future value of a passed parameter to a Module.
  *
- * @internal
+ * @alpha
  */
 export type ParameterFuture = RequiredParameter | OptionalParameter;
 
 /**
  * The future values usable within the Module api.
  *
- * @internal
+ * @alpha
  */
 export type DeploymentGraphFuture =
   | DependableFuture

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -1,5 +1,11 @@
 import type { Artifact } from "./hardhat";
 
+/**
+ * A future representing the address of a contract deployed using the
+ * Hardhat Artifact system.
+ *
+ * @internal
+ */
 export interface HardhatContract {
   vertexId: number;
   label: string;
@@ -9,6 +15,12 @@ export interface HardhatContract {
   _future: true;
 }
 
+/**
+ * A future representing the value of a contract deployed using a given
+ * artifact.
+ *
+ * @internal
+ */
 export interface ArtifactContract {
   vertexId: number;
   label: string;
@@ -18,6 +30,11 @@ export interface ArtifactContract {
   _future: true;
 }
 
+/**
+ * A future representing the address of an already deployed contract.
+ *
+ * @internal
+ */
 export interface DeployedContract {
   vertexId: number;
   label: string;
@@ -28,6 +45,12 @@ export interface DeployedContract {
   _future: true;
 }
 
+/**
+ * A future representing the address of a library deployed using Hardhat's
+ * artifact system.
+ *
+ * @internal
+ */
 export interface HardhatLibrary {
   vertexId: number;
   label: string;
@@ -37,6 +60,12 @@ export interface HardhatLibrary {
   _future: true;
 }
 
+/**
+ * A future representing the address of a library deployed using a given
+ * artifact.
+ *
+ * @internal
+ */
 export interface ArtifactLibrary {
   vertexId: number;
   label: string;
@@ -46,6 +75,11 @@ export interface ArtifactLibrary {
   _future: true;
 }
 
+/**
+ * A future representing an on-chain smart contract method invocation.
+ *
+ * @internal
+ */
 export interface ContractCall {
   vertexId: number;
   label: string;
@@ -53,6 +87,11 @@ export interface ContractCall {
   _future: true;
 }
 
+/**
+ * A future representing an on-chain Ethereum event.
+ *
+ * @internal
+ */
 export interface EventFuture {
   vertexId: number;
   label: string;
@@ -62,6 +101,11 @@ export interface EventFuture {
   params: EventParams;
 }
 
+/**
+ * A future representing the sending of Eth to a contract/address.
+ *
+ * @internal
+ */
 export interface SendFuture {
   vertexId: number;
   label: string;
@@ -70,10 +114,20 @@ export interface SendFuture {
   _future: true;
 }
 
+/**
+ * A mapping of named parameter labels to future parameter values.
+ *
+ * @internal
+ */
 export interface EventParams {
   [eventParam: string]: EventParamFuture;
 }
 
+/**
+ * A future representing a parameter of an on-chain Ethereum event.
+ *
+ * @internal
+ */
 export interface EventParamFuture {
   vertexId: number;
   label: string;
@@ -82,8 +136,19 @@ export interface EventParamFuture {
   _future: true;
 }
 
+/**
+ * A value that can be used as a Module parameter.
+ *
+ * @internal
+ */
 export type ParameterValue = string | number | DeploymentGraphFuture;
 
+/**
+ * A future representing a parameter value that _must_ be provided to the module
+ * for it to execute.
+ *
+ * @internal
+ */
 export interface RequiredParameter {
   label: string;
   type: "parameter";
@@ -92,6 +157,12 @@ export interface RequiredParameter {
   _future: true;
 }
 
+/**
+ * A future representing a parameter value that _may_ be provided to the module
+ * for it to execute. In its absence the `defaultValue` will be used.
+ *
+ * @internal
+ */
 export interface OptionalParameter {
   label: string;
   type: "parameter";
@@ -101,6 +172,11 @@ export interface OptionalParameter {
   _future: true;
 }
 
+/**
+ * A future representing a virtual node used for grouping other actions.
+ *
+ * @internal
+ */
 export interface Virtual {
   vertexId: number;
   label: string;
@@ -108,6 +184,17 @@ export interface Virtual {
   _future: true;
 }
 
+/**
+ * A future that allows the splitting of dependency from value resolution.
+ * A proxy can stand for the value of another future, but point its
+ * dependency (the proxy) on a different.
+ *
+ * This allows the wrapping of a returned Contract future so that a
+ * dependency on it can be made to depend on the Virtual vertex that
+ * represents the entire submodule.
+ *
+ * @internal
+ */
 export interface ProxyFuture {
   label: string;
   type: "proxy";
@@ -116,17 +203,46 @@ export interface ProxyFuture {
   _future: true;
 }
 
+/**
+ * A future representing an artifact deployment or an already existing deployed
+ * contract.
+ *
+ * @privateRemarks
+ * TODO: is this needed?
+ *
+ * @internal
+ */
 export type ArtifactFuture = ArtifactContract | DeployedContract;
 
+/**
+ * A future representing the address of a deployed Contract.
+ *
+ * @internal
+ */
 export type ContractFuture =
   | HardhatContract
   | ArtifactContract
   | DeployedContract;
 
+/**
+ * The future representing the address of a deployed library.
+ *
+ * @internal
+ */
 export type LibraryFuture = HardhatLibrary | ArtifactLibrary;
 
+/**
+ * The future representing the value of calling a smart contract method.
+ *
+ * @internal
+ */
 export type CallableFuture = ContractFuture | LibraryFuture;
 
+/**
+ * A future value from an on-chain action that.
+ *
+ * @internal
+ */
 export type DependableFuture =
   | CallableFuture
   | ContractCall
@@ -135,14 +251,29 @@ export type DependableFuture =
   | EventFuture
   | SendFuture;
 
+/**
+ * A future value representing an Ethereum address.
+ *
+ * @internal
+ */
 export type AddressResolvable =
   | string
   | ParameterFuture
   | EventParamFuture
   | ContractFuture;
 
+/**
+ * The future value of a passed parameter to a Module.
+ *
+ * @internal
+ */
 export type ParameterFuture = RequiredParameter | OptionalParameter;
 
+/**
+ * The future values usable within the Module api.
+ *
+ * @internal
+ */
 export type DeploymentGraphFuture =
   | DependableFuture
   | ParameterFuture

--- a/packages/core/src/types/hardhat.ts
+++ b/packages/core/src/types/hardhat.ts
@@ -1,7 +1,7 @@
 /**
  * The key data for interacting with an Ethereum smart contract on-chain.
  *
- * @internal
+ * @alpha
  */
 export interface Artifact {
   contractName: string;

--- a/packages/core/src/types/hardhat.ts
+++ b/packages/core/src/types/hardhat.ts
@@ -1,3 +1,8 @@
+/**
+ * The key data for interacting with an Ethereum smart contract on-chain.
+ *
+ * @internal
+ */
 export interface Artifact {
   contractName: string;
   bytecode: string;

--- a/packages/core/src/types/ignition.ts
+++ b/packages/core/src/types/ignition.ts
@@ -1,0 +1,55 @@
+import { UpdateUiAction } from "../internal/types/deployment";
+import { ICommandJournal } from "../internal/types/journal";
+import { Services } from "../internal/types/services";
+
+import { Providers } from "./providers";
+
+/**
+ * The setup options for the Ignition.
+ *
+ * @internal
+ */
+export interface IgnitionCreationArgs {
+  /**
+   * The adapters that allows Ignition to communicate with external systems
+   * like the target blockchain or local filesystem.
+   */
+  providers: Providers;
+
+  /**
+   * An optional UI update function that will be invoked with the current
+   * Ignition state on each major state change.
+   */
+  uiRenderer?: UpdateUiAction;
+
+  /**
+   * An optional journal that will be used to store a record of the current
+   * run and to access the history of previous runs.
+   */
+  journal?: ICommandJournal;
+}
+
+/**
+ * The setup options for Ignition
+ *
+ * @internal
+ */
+export interface IgnitionConstructorArgs {
+  /**
+   * An adapter that allows Ignition to communicate with external services
+   * like the target blockchain or local filesystem.
+   */
+  services: Services;
+
+  /**
+   * A UI update function that will be invoked with the current
+   * Ignition state on each major state change.
+   */
+  uiRenderer: UpdateUiAction;
+
+  /**
+   * A journal that will be used to store a record of the current
+   * run and to access the history of previous runs.
+   */
+  journal: ICommandJournal;
+}

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -1,13 +1,12 @@
-import type {
-  ExternalParamValue,
-  IDeploymentBuilder,
-} from "../internal/types/deploymentGraph";
+import type { ExternalParamValue } from "../types/dsl";
 import type {
   ContractFuture,
   LibraryFuture,
   ProxyFuture,
   Virtual,
 } from "./future";
+
+import { IDeploymentBuilder } from "./dsl";
 
 /**
  * The potential return results of deploying a module.

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -12,7 +12,7 @@ import type {
 /**
  * The potential return results of deploying a module.
  *
- * @internal
+ * @alpha
  */
 export type ModuleReturnValue =
   | ContractFuture
@@ -23,7 +23,7 @@ export type ModuleReturnValue =
 /**
  * The results of deploying a module.
  *
- * @internal
+ * @alpha
  */
 export interface ModuleDict {
   [key: string]: ModuleReturnValue;
@@ -32,7 +32,7 @@ export interface ModuleDict {
 /**
  * An Ignition module that can be deployed.
  *
- * @internal
+ * @alpha
  */
 export interface Module<T extends ModuleDict> {
   name: string;

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -9,16 +9,31 @@ import type {
   Virtual,
 } from "./future";
 
+/**
+ * The potential return results of deploying a module.
+ *
+ * @internal
+ */
 export type ModuleReturnValue =
   | ContractFuture
   | LibraryFuture
   | Virtual
   | ProxyFuture;
 
+/**
+ * The results of deploying a module.
+ *
+ * @internal
+ */
 export interface ModuleDict {
   [key: string]: ModuleReturnValue;
 }
 
+/**
+ * An Ignition module that can be deployed.
+ *
+ * @internal
+ */
 export interface Module<T extends ModuleDict> {
   name: string;
   action: (builder: IDeploymentBuilder) => T;
@@ -33,6 +48,11 @@ export interface ModuleCache {
   [label: string]: ModuleData;
 }
 
+/**
+ * A mapping of parameter labels to allowed values or futures.
+ *
+ * @internal
+ */
 export interface ModuleParams {
   [key: string]: ExternalParamValue;
 }

--- a/packages/core/src/types/plan.ts
+++ b/packages/core/src/types/plan.ts
@@ -1,6 +1,11 @@
 import { IDeploymentGraph } from "../internal/types/deploymentGraph";
 import { IExecutionGraph } from "../internal/types/executionGraph";
 
+/**
+ * The planned deployment.
+ *
+ * @internal
+ */
 export interface IgnitionPlan {
   deploymentGraph: IDeploymentGraph;
   executionGraph: IExecutionGraph;

--- a/packages/core/src/types/providers.ts
+++ b/packages/core/src/types/providers.ts
@@ -1,4 +1,4 @@
-import type { ExternalParamValue } from "../internal/types/deploymentGraph";
+import type { ExternalParamValue } from "../types/dsl";
 import type { Artifact } from "./hardhat";
 
 import { ethers } from "ethers";

--- a/packages/core/src/types/providers.ts
+++ b/packages/core/src/types/providers.ts
@@ -1,9 +1,16 @@
 import type { ExternalParamValue } from "../internal/types/deploymentGraph";
 import type { Artifact } from "./hardhat";
-import type { ethers } from "ethers";
+
+import { ethers } from "ethers";
 
 import { ModuleParams } from "./module";
 
+/**
+ * The low level adapters that allow Ignition to interact with external services
+ * like the target chain or the local filesystem.
+ *
+ * @internal
+ */
 export interface Providers {
   artifacts: ArtifactsProvider;
   ethereumProvider: EIP1193Provider;
@@ -13,16 +20,31 @@ export interface Providers {
   accounts: AccountsProvider;
 }
 
+/**
+ * Provide access to contract artifacts based on a label.
+ *
+ * @internal
+ */
 export interface ArtifactsProvider {
   getArtifact: (name: string) => Promise<Artifact>;
   hasArtifact: (name: string) => Promise<boolean>;
   getAllArtifacts: () => Promise<Artifact[]>;
 }
 
+/**
+ * Provide access to the target Ethereum chain via requests.
+ *
+ * @internal
+ */
 export interface EIP1193Provider {
   request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
 }
 
+/**
+ * Provide access to Ethereum gas information for the target chain.
+ *
+ * @internal
+ */
 export interface GasProvider {
   estimateGasLimit: (
     tx: ethers.providers.TransactionRequest
@@ -30,13 +52,28 @@ export interface GasProvider {
   estimateGasPrice: () => Promise<ethers.BigNumber>;
 }
 
+/**
+ * Provide access to transaction information for the target chain.
+ *
+ * @internal
+ */
 export interface TransactionsProvider {
   isConfirmed(txHash: string): Promise<boolean>;
   isMined(txHash: string): Promise<boolean>;
 }
 
+/**
+ * Allowed error codes for a parameter lookup.
+ *
+ * @internal
+ */
 export type HasParamErrorCode = "no-params" | "param-missing";
 
+/**
+ * The results of a parameter look up.
+ *
+ * @internal
+ */
 export type HasParamResult =
   | {
       found: false;
@@ -44,6 +81,11 @@ export type HasParamResult =
     }
   | { found: true };
 
+/**
+ * Provide access to configuration options for Ignition execution.
+ *
+ * @internal
+ */
 export interface ConfigProvider {
   parameters: ModuleParams | undefined;
 
@@ -54,6 +96,12 @@ export interface ConfigProvider {
   hasParam(paramName: string): Promise<HasParamResult>;
 }
 
+/**
+ * Provide a set of usable Ethereum accounts that can be made available within
+ * the Module api.
+ *
+ * @internal
+ */
 export interface AccountsProvider {
   getAccounts(): Promise<string[]>;
   getSigner(address: string): Promise<ethers.Signer>;

--- a/packages/core/src/types/serialization.ts
+++ b/packages/core/src/types/serialization.ts
@@ -1,11 +1,22 @@
 import type { ModuleDict } from "./module";
 
+/**
+ * The details of a deployed contract. The combination of address and abi
+ * should allow a consumer to call the contract.
+ *
+ * @internal
+ */
 export interface ContractInfo {
   name: string;
   address: string;
   abi: any[];
 }
 
+/**
+ * The contract details from a successful deployment.
+ *
+ * @internal
+ */
 export type SerializedDeploymentResult<T extends ModuleDict> = {
   [K in keyof T]: ContractInfo;
 };

--- a/packages/core/test/deploymentBuilder/accounts.ts
+++ b/packages/core/test/deploymentBuilder/accounts.ts
@@ -1,8 +1,5 @@
 /* eslint-disable import/no-unused-modules */
-import type {
-  IDeploymentGraph,
-  IDeploymentBuilder,
-} from "../../src/internal/types/deploymentGraph";
+import type { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 
 import { assert } from "chai";
 import { ethers } from "ethers";
@@ -10,6 +7,7 @@ import { ethers } from "ethers";
 import { buildModule } from "../../src/dsl/buildModule";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
 import { isCall, isHardhatContract } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 
 import { getDeploymentVertexByLabel } from "./helpers";
 

--- a/packages/core/test/deploymentBuilder/artifacts.ts
+++ b/packages/core/test/deploymentBuilder/artifacts.ts
@@ -1,14 +1,12 @@
 /* eslint-disable import/no-unused-modules */
-import type {
-  IDeploymentBuilder,
-  IDeploymentGraph,
-} from "../../src/internal/types/deploymentGraph";
+import type { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 
 import { assert } from "chai";
 
 import { buildModule } from "../../src/dsl/buildModule";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
 import { isArtifactContract } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 
 import { getDeploymentVertexByLabel } from "./helpers";
 

--- a/packages/core/test/deploymentBuilder/calls.ts
+++ b/packages/core/test/deploymentBuilder/calls.ts
@@ -3,11 +3,9 @@ import { assert } from "chai";
 
 import { buildModule } from "../../src/dsl/buildModule";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
-import {
-  IDeploymentBuilder,
-  IDeploymentGraph,
-} from "../../src/internal/types/deploymentGraph";
+import { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 import { isCall, isHardhatContract } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 
 import {
   getDependenciesForVertex,

--- a/packages/core/test/deploymentBuilder/deploy.ts
+++ b/packages/core/test/deploymentBuilder/deploy.ts
@@ -1,8 +1,5 @@
 /* eslint-disable import/no-unused-modules */
-import type {
-  IDeploymentGraph,
-  IDeploymentBuilder,
-} from "../../src/internal/types/deploymentGraph";
+import type { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 
 import { assert } from "chai";
 
@@ -13,6 +10,7 @@ import {
   isDeployedContract,
   isHardhatContract,
 } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 import { Artifact } from "../../src/types/hardhat";
 
 import {

--- a/packages/core/test/deploymentBuilder/event.ts
+++ b/packages/core/test/deploymentBuilder/event.ts
@@ -3,15 +3,13 @@ import { assert } from "chai";
 
 import { buildModule } from "../../src/dsl/buildModule";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
+import { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 import {
-  IDeploymentBuilder,
-  IDeploymentGraph,
-} from "../../src/internal/types/deploymentGraph";
-import {
+  isArtifactContract,
   isAwaitedEvent,
   isCall,
-  isArtifactContract,
 } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 import { ArtifactContract } from "../../src/types/future";
 
 import {

--- a/packages/core/test/deploymentBuilder/libraries.ts
+++ b/packages/core/test/deploymentBuilder/libraries.ts
@@ -1,8 +1,5 @@
 /* eslint-disable import/no-unused-modules */
-import type {
-  IDeploymentGraph,
-  IDeploymentBuilder,
-} from "../../src/internal/types/deploymentGraph";
+import type { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 
 import { assert } from "chai";
 
@@ -12,6 +9,7 @@ import {
   isHardhatContract,
   isHardhatLibrary,
 } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 
 import {
   getDependenciesForVertex,

--- a/packages/core/test/deploymentBuilder/metadata.ts
+++ b/packages/core/test/deploymentBuilder/metadata.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 
 import { buildModule } from "../../src/dsl/buildModule";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
-import { IDeploymentBuilder } from "../../src/internal/types/deploymentGraph";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 
 describe("deployment builder - metadata", () => {
   it("should inject the chainId via the builder", () => {

--- a/packages/core/test/deploymentBuilder/parameters.ts
+++ b/packages/core/test/deploymentBuilder/parameters.ts
@@ -1,8 +1,5 @@
 /* eslint-disable import/no-unused-modules */
-import type {
-  IDeploymentGraph,
-  IDeploymentBuilder,
-} from "../../src/internal/types/deploymentGraph";
+import type { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 
 import { assert } from "chai";
 
@@ -10,6 +7,7 @@ import { buildModule } from "../../src/dsl/buildModule";
 import { IgnitionError } from "../../src/errors";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
 import { isCallable } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 
 describe("deployment builder - parameters", function () {
   let deploymentGraph: IDeploymentGraph;

--- a/packages/core/test/deploymentBuilder/sendETH.ts
+++ b/packages/core/test/deploymentBuilder/sendETH.ts
@@ -4,11 +4,9 @@ import { ethers } from "ethers";
 
 import { buildModule } from "../../src/dsl/buildModule";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
-import {
-  IDeploymentBuilder,
-  IDeploymentGraph,
-} from "../../src/internal/types/deploymentGraph";
+import { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 import { isHardhatContract } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 
 import {
   getDependenciesForVertex,

--- a/packages/core/test/deploymentBuilder/useModule.ts
+++ b/packages/core/test/deploymentBuilder/useModule.ts
@@ -1,13 +1,11 @@
 /* eslint-disable import/no-unused-modules */
-import type {
-  IDeploymentGraph,
-  IDeploymentBuilder,
-} from "../../src/internal/types/deploymentGraph";
+import type { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 
 import { assert } from "chai";
 
 import { buildModule } from "../../src/dsl/buildModule";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 import {
   ArtifactContract,
   CallableFuture,

--- a/packages/core/test/deploymentBuilder/value.ts
+++ b/packages/core/test/deploymentBuilder/value.ts
@@ -1,8 +1,5 @@
 /* eslint-disable import/no-unused-modules */
-import type {
-  IDeploymentGraph,
-  IDeploymentBuilder,
-} from "../../src/internal/types/deploymentGraph";
+import type { IDeploymentGraph } from "../../src/internal/types/deploymentGraph";
 import type { Artifact } from "../../src/types/hardhat";
 
 import { assert } from "chai";
@@ -12,9 +9,10 @@ import { buildModule } from "../../src/dsl/buildModule";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
 import {
   isArtifactContract,
-  isHardhatContract,
   isCall,
+  isHardhatContract,
 } from "../../src/internal/utils/guards";
+import { IDeploymentBuilder } from "../../src/types/dsl";
 
 import { getDeploymentVertexByLabel } from "./helpers";
 

--- a/packages/core/test/execution/batching.ts
+++ b/packages/core/test/execution/batching.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unused-modules */
 import type {
-  ContractDeploy,
+  ContractDeployExecutionVertex,
   ExecutionVertex,
   ExecutionVertexVisitResult,
 } from "../../src/internal/types/executionGraph";
@@ -66,7 +66,7 @@ describe("Execution - batching", () => {
 function createFakeContractDeployVertex(
   vertexId: number,
   label: string
-): ContractDeploy {
+): ContractDeployExecutionVertex {
   return {
     type: "ContractDeploy",
     id: vertexId,

--- a/packages/core/test/helpers/getMockProviders.ts
+++ b/packages/core/test/helpers/getMockProviders.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 
 import { IgnitionError } from "../../src/errors";
-import { ExternalParamValue } from "../../src/internal/types/deploymentGraph";
+import { ExternalParamValue } from "../../src/types/dsl";
 import { Artifact } from "../../src/types/hardhat";
 import { ModuleParams } from "../../src/types/module";
 import {

--- a/packages/core/test/validation.ts
+++ b/packages/core/test/validation.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-unused-modules */
-import type { IDeploymentBuilder } from "../src/internal/types/deploymentGraph";
 
 import { assert } from "chai";
 import { ethers } from "ethers";
@@ -10,6 +9,7 @@ import { generateDeploymentGraphFrom } from "../src/internal/process/generateDep
 import { Services } from "../src/internal/types/services";
 import { ValidationVisitResult } from "../src/internal/types/validation";
 import { validateDeploymentGraph } from "../src/internal/validation/validateDeploymentGraph";
+import { IDeploymentBuilder } from "../src/types/dsl";
 import { ArtifactContract } from "../src/types/future";
 import { Artifact } from "../src/types/hardhat";
 import { Module, ModuleDict } from "../src/types/module";

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -27,6 +27,11 @@ export type IgnitionWrapperOptions = Omit<
   keyof { force?: boolean }
 >;
 
+/**
+ * Hardhat entry into Ignition.
+ *
+ * @alpha
+ */
 export class IgnitionWrapper {
   constructor(
     private _providers: Providers,
@@ -34,6 +39,13 @@ export class IgnitionWrapper {
     public options: IgnitionWrapperOptions
   ) {}
 
+  /**
+   * Run a deployment of the given Ignition module.
+   * @param ignitionModule - the Ignition module to deploy
+   * @param deployParams - the configuration parameters to control the
+   * deployment run.
+   * @returns the deployed contracts as Ethers contract objects
+   */
   public async deploy<T extends ModuleDict>(
     ignitionModule: Module<T>,
     deployParams?: {
@@ -105,6 +117,14 @@ export class IgnitionWrapper {
     return this._toDeploymentResult(deploymentResult.result);
   }
 
+  /**
+   * Construct a plan (or dry run) describing how a deployment will be executed
+   * for the given module.
+   *
+   * @param ignitionModule - the Ignition module to plan out
+   * @returns the a description of the modules deployment, including the
+   * execution dependency graph.
+   */
   public async plan<T extends ModuleDict>(ignitionModule: Module<T>) {
     const ignition = Ignition.create({
       providers: this._providers,


### PR DESCRIPTION
We are adding tsdocs to the methods and types of the public api to help with discoverability by intellisense.

## Preview

![image](https://user-images.githubusercontent.com/24030/228524635-3c77f473-035f-4bf9-a8d2-9a0f35d4c1c0.png)


## Details

To support this goal we are adding two tools:

* typedocs - to generate html documentation from the tsdocs (currently only for internal use)
* api-extractor - to enforce linting rules on tsdocs like making sure every type used in the public api is exported.

We are also exporting (and documenting) all types that users could encounter through our api. This rule is now enforced in linting via `api-extractor`.

All exported class/function/types are marked with either `@alpha` or `@internal`. Any exported typed that an end Ignition user can use, is marked with `@alpha`. Any exported typed meant only to be used by tool developers (so us) is marked with `@internal`.

Currently that breaks down as:

![image](https://user-images.githubusercontent.com/24030/228522986-633c6ee0-cdb9-48e0-978b-55cec97e8265.png)

A similar distinction is now present at the file-system level with an explicit `./internal` folder make it easy to see violations during Ignition development.

## Usage

### Typedocs

To see the documentation for the exported classes/functions/types, run from root:

```sh
npm run typedocs
```

This will auto-open your browser with the generated documentation.

### Api-extractor

The `api-extractor` is only enabled for core. Within core you can run it with:

```sh
npm run api-extractor
```

It runs as part of core's linting.

A task has been added to `./.vscode`, called `api-extractor` that will run npm script but also leverage a problem matcher to highlight any issues inline within vscode.

Part of #171
