### PR TITLE
chore: bump version to v0.0.11

### DIFF
--- a/examples/create2/package.json
+++ b/examples/create2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-create2-example",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.0.10",
+    "@ignored/hardhat-ignition": "^0.0.11",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "2.13.0"
   },

--- a/examples/ens/package.json
+++ b/examples/ens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-ens-example",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.0.10",
+    "@ignored/hardhat-ignition": "^0.0.11",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "2.13.0"
   },

--- a/examples/multisig/package.json
+++ b/examples/multisig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-example-multisig",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.0.10",
+    "@ignored/hardhat-ignition": "^0.0.11",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "2.13.0"
   },

--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-sample-example",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.0.10",
+    "@ignored/hardhat-ignition": "^0.0.11",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "2.13.0"
   }

--- a/examples/ts-sample/package.json
+++ b/examples/ts-sample/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-ts-sample-example",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,ts,md,json}\" \"ignition/*.{js,ts,md,json}\" \"test/*.{js,ts,md,json}\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.0.10",
+    "@ignored/hardhat-ignition": "^0.0.11",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "2.13.0"
   }

--- a/examples/uniswap/package.json
+++ b/examples/uniswap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-uniswap-example",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.0.10",
+    "@ignored/hardhat-ignition": "^0.0.11",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "2.13.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,12 @@
     },
     "examples/create2": {
       "name": "@nomicfoundation/ignition-create2-example",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@openzeppelin/contracts": "4.7.3"
       },
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.0.10",
+        "@ignored/hardhat-ignition": "^0.0.11",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "2.13.0"
       }
@@ -43,49 +43,49 @@
     },
     "examples/ens": {
       "name": "@nomicfoundation/ignition-ens-example",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@ensdomains/ens-contracts": "0.0.11"
       },
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.0.10",
+        "@ignored/hardhat-ignition": "^0.0.11",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "2.13.0"
       }
     },
     "examples/multisig": {
       "name": "@nomicfoundation/ignition-example-multisig",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@openzeppelin/contracts": "^4.3.2"
       },
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.0.10",
+        "@ignored/hardhat-ignition": "^0.0.11",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "2.13.0"
       }
     },
     "examples/sample": {
       "name": "@nomicfoundation/ignition-sample-example",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.0.10",
+        "@ignored/hardhat-ignition": "^0.0.11",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "2.13.0"
       }
     },
     "examples/ts-sample": {
       "name": "@nomicfoundation/ignition-ts-sample-example",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.0.10",
+        "@ignored/hardhat-ignition": "^0.0.11",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "2.13.0"
       }
     },
     "examples/uniswap": {
       "name": "@nomicfoundation/ignition-uniswap-example",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@openzeppelin/contracts": "npm:@openzeppelin/contracts@3.4.2-solc-0.7",
         "@uniswap/swap-router-contracts": "1.1.0",
@@ -97,7 +97,7 @@
         "v3-periphery-1_3_0": "npm:@uniswap/v3-periphery@1.3.0"
       },
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.0.10",
+        "@ignored/hardhat-ignition": "^0.0.11",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "2.13.0"
       }
@@ -18157,7 +18157,7 @@
     },
     "packages/core": {
       "name": "@ignored/ignition-core",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "5.6.1",
@@ -18220,7 +18220,7 @@
     },
     "packages/hardhat-plugin": {
       "name": "@ignored/hardhat-ignition",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.2",
@@ -18234,7 +18234,7 @@
         "serialize-error": "8.1.0"
       },
       "devDependencies": {
-        "@ignored/ignition-core": "^0.0.10",
+        "@ignored/ignition-core": "^0.0.11",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@types/chai": "^4.2.22",
@@ -18275,7 +18275,7 @@
         "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
       },
       "peerDependencies": {
-        "@ignored/ignition-core": "^0.0.10",
+        "@ignored/ignition-core": "^0.0.11",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "hardhat": "^2.12.0"
       }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.0.10 - 2023-04-14
+## 0.0.11 - 2023-03-29
+
+### Changed
+
+- Replace `m.getBytesForArtifact("Foo")` with `m.getArtifact("Foo")` in the module api ([#155](https://github.com/NomicFoundation/ignition/issues/155))
+
+### Fixed
+
+- Fix libraries in plan ([#131](https://github.com/NomicFoundation/ignition/issues/131))
+
+## 0.0.10 - 2023-03-14
 
 ### Added
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/ignition-core",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.0.10 - 2023-04-14
+## 0.0.11 - 2023-03-29
+
+### Changed
+
+- Replace `m.getBytesForArtifact("Foo")` with `m.getArtifact("Foo")` in the module api ([#155](https://github.com/NomicFoundation/ignition/issues/155))
+
+### Fixed
+
+- Fix libraries in plan ([#131](https://github.com/NomicFoundation/ignition/issues/131))
+
+## 0.0.10 - 2023-03-14
 
 ### Added
 

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/hardhat-ignition",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",
@@ -33,7 +33,7 @@
     "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {
-    "@ignored/ignition-core": "^0.0.10",
+    "@ignored/ignition-core": "^0.0.11",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@types/chai": "^4.2.22",
@@ -71,7 +71,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@ignored/ignition-core": "^0.0.10",
+    "@ignored/ignition-core": "^0.0.11",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "hardhat": "^2.12.0"
   },


### PR DESCRIPTION
## 0.0.11 - 2023-03-29

### Changed

- Replace `m.getBytesForArtifact("Foo")` with `m.getArtifact("Foo")` in the module api ([#155](https://github.com/NomicFoundation/ignition/issues/155))

### Fixed

- Fix libraries in plan ([#131](https://github.com/NomicFoundation/ignition/issues/131))
