### PR TITLE
fix: support arrays as arg option on call

### DIFF
--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -51,6 +51,7 @@ import {
   isCallable,
   isContract,
   isDependable,
+  isFuture,
   isParameter,
 } from "../internal/utils/guards";
 import { resolveProxyDependency } from "../internal/utils/proxy";
@@ -765,7 +766,8 @@ export class DeploymentBuilder implements IDeploymentBuilder {
       typeof arg === "string" ||
       typeof arg === "number" ||
       typeof arg === "boolean" ||
-      BigNumber.isBigNumber(arg)
+      BigNumber.isBigNumber(arg) ||
+      !isFuture(arg)
     ) {
       return;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,8 @@ export type {
   SendETHSuccess,
   SentETHExecutionVertex,
   VertexVisitResultSuccessResult,
+  BaseArgValue,
+  StructuredArgValue,
 } from "./internal/types/executionGraph";
 export type {
   AdjacencyList,
@@ -81,6 +83,7 @@ export type {
 } from "./internal/types/services";
 export {
   AwaitOptions,
+  BaseArgumentType,
   CallOptions,
   ContractOptions,
   ExternalParamValue,

--- a/packages/core/src/internal/process/transform/convertDeploymentVertexToExecutionVertex.ts
+++ b/packages/core/src/internal/process/transform/convertDeploymentVertexToExecutionVertex.ts
@@ -1,8 +1,8 @@
 import { BigNumber, ethers } from "ethers";
 
 import { IgnitionError } from "../../../errors";
-import { ExternalParamValue } from "../../../types/dsl";
-import { DeploymentGraphFuture, EventParamFuture } from "../../../types/future";
+import { ExternalParamValue, InternalParamValue } from "../../../types/dsl";
+import { DeploymentGraphFuture } from "../../../types/future";
 import { Artifact } from "../../../types/hardhat";
 import {
   ArtifactContractDeploymentVertex,
@@ -17,6 +17,7 @@ import {
   SendVertex,
 } from "../../types/deploymentGraph";
 import {
+  ArgValue,
   AwaitedEventExecutionVertex,
   ContractCallExecutionVertex,
   ContractDeployExecutionVertex,
@@ -226,18 +227,9 @@ async function convertSendToSentETH(
 }
 
 async function convertArgs(
-  args: Array<
-    | boolean
-    | string
-    | number
-    | BigNumber
-    | DeploymentGraphFuture
-    | EventParamFuture
-  >,
+  args: InternalParamValue[],
   transformContext: TransformContext
-): Promise<
-  Array<boolean | string | number | BigNumber | DeploymentGraphFuture>
-> {
+): Promise<ArgValue[]> {
   const resolvedArgs = [];
 
   for (const arg of args) {
@@ -252,7 +244,7 @@ async function convertArgs(
 async function resolveParameter<T extends DeploymentGraphFuture>(
   arg: ExternalParamValue | T,
   { services, graph }: TransformContext
-): Promise<ExternalParamValue | T> {
+): Promise<ArgValue> {
   if (!isFuture(arg)) {
     return arg;
   }

--- a/packages/core/src/internal/types/executionGraph.ts
+++ b/packages/core/src/internal/types/executionGraph.ts
@@ -29,15 +29,31 @@ export interface IExecutionGraph {
 }
 
 /**
+ * The base value that Ethereum ABIs accept.
+ *
+ * @internal
+ */
+export type BaseArgValue = number | BigNumber | string | boolean;
+
+/**
+ * A composite (i.e. arrays and nested objects) of base value that Ethereum
+ * ABIs accept.
+ *
+ * @internal
+ */
+export type StructuredArgValue =
+  | BaseArgValue
+  | StructuredArgValue[]
+  | { [field: string]: StructuredArgValue };
+
+/**
  * The allowed values when passing an argument to a smart contract method call.
  *
  * @internal
  */
 export type ArgValue =
-  | boolean
-  | string
-  | number
-  | BigNumber
+  | BaseArgValue
+  | StructuredArgValue
   | DeploymentGraphFuture;
 
 /**

--- a/packages/core/src/types/dsl.ts
+++ b/packages/core/src/types/dsl.ts
@@ -267,11 +267,21 @@ export interface UseModuleOptions {
 }
 
 /**
+ * Paramater value types
+ *
+ * @alpha
+ */
+export type BaseArgumentType = number | BigNumber | string | boolean;
+
+/**
  * Allowed parameters that can be passed into a module.
  *
  * @alpha
  */
-export type ExternalParamValue = boolean | string | number | BigNumber;
+export type ExternalParamValue =
+  | BaseArgumentType
+  | ExternalParamValue[]
+  | { [field: string]: ExternalParamValue };
 
 /**
  * Allowed parameters across internal `useModule` boundaries.

--- a/packages/core/test/deploymentBuilder/calls.ts
+++ b/packages/core/test/deploymentBuilder/calls.ts
@@ -12,191 +12,349 @@ import {
   getDeploymentVertexByLabel,
 } from "./helpers";
 
-describe("deployment builder - chainId", () => {
-  let deploymentGraph: IDeploymentGraph;
+describe("deployment builder - calls", () => {
+  describe("with basic value args", () => {
+    let deploymentGraph: IDeploymentGraph;
 
-  before(() => {
-    const callModule = buildModule("call", (m: IDeploymentBuilder) => {
-      const token = m.contract("Token");
-      const exchange = m.contract("Exchange");
-      const another = m.contract("Another");
+    before(() => {
+      const callModule = buildModule("call", (m: IDeploymentBuilder) => {
+        const token = m.contract("Token");
+        const exchange = m.contract("Exchange");
+        const another = m.contract("Another");
 
-      m.call(exchange, "addToken", {
-        args: [token],
-        after: [another],
-        from: m.accounts[0],
+        m.call(exchange, "addToken", {
+          args: [token],
+          after: [another],
+          from: m.accounts[0],
+        });
+
+        return {};
       });
 
-      return {};
+      const { graph } = generateDeploymentGraphFrom(callModule, {
+        chainId: 31337,
+        accounts: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
+        artifacts: [],
+      });
+
+      deploymentGraph = graph;
     });
 
-    const { graph } = generateDeploymentGraphFrom(callModule, {
-      chainId: 31337,
-      accounts: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
-      artifacts: [],
+    it("should create a graph", () => {
+      assert.isDefined(deploymentGraph);
     });
 
-    deploymentGraph = graph;
+    it("should have four nodes", () => {
+      assert.equal(deploymentGraph.vertexes.size, 4);
+    });
+
+    it("should have the contract node Token", () => {
+      const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+      assert.equal(depNode?.label, "Token");
+      assert(isHardhatContract(depNode));
+    });
+
+    it("should have the contract node Exchange", () => {
+      const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      assert.equal(depNode?.label, "Exchange");
+      assert(isHardhatContract(depNode));
+    });
+
+    it("should have the call node Exchange/addToken", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "Exchange/addToken"
+      );
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      assert.equal(depNode?.label, "Exchange/addToken");
+      assert(isCall(depNode));
+    });
+
+    it("should show no dependencies for the contract node Token", () => {
+      const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      const deps = getDependenciesForVertex(deploymentGraph, depNode);
+
+      assert.deepStrictEqual(deps, []);
+    });
+
+    it("should show no dependencies for the contract node Exchange", () => {
+      const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      const deps = getDependenciesForVertex(deploymentGraph, depNode);
+
+      assert.deepStrictEqual(deps, []);
+    });
+
+    it("should show three dependencies for the call node Exchange/addToken", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "Exchange/addToken"
+      );
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      const deps = getDependenciesForVertex(deploymentGraph, depNode);
+
+      assert.deepStrictEqual(deps, [
+        {
+          id: 0,
+          label: "Token",
+          type: "",
+        },
+        { id: 1, label: "Exchange", type: "" },
+        { id: 2, label: "Another", type: "" },
+      ]);
+    });
+
+    it("should record the argument list for the contract node Token as empty", () => {
+      const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      if (!isHardhatContract(depNode)) {
+        return assert.fail("Not a hardhat contract dependency node");
+      }
+
+      assert.deepStrictEqual(depNode.args, []);
+    });
+
+    it("should record the argument list for the contract node Exchange as empty", () => {
+      const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      if (!isHardhatContract(depNode)) {
+        return assert.fail("Not a hardhat contract dependency node");
+      }
+
+      assert.deepStrictEqual(depNode.args, []);
+    });
+
+    it("should record the argument list for the call node Exchange at Exchange/addToken", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "Exchange/addToken"
+      );
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      if (!isCall(depNode)) {
+        return assert.fail("Not a call dependency node");
+      }
+
+      assert.deepStrictEqual(depNode.args, [
+        {
+          vertexId: 0,
+          label: "Token",
+          type: "contract",
+          subtype: "hardhat",
+          contractName: "Token",
+          _future: true,
+        },
+      ]);
+    });
+
+    it("should record the address to send from for the call node Exchange at Exchange/addToken", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "Exchange/addToken"
+      );
+
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
+
+      if (!isCall(depNode)) {
+        return assert.fail("Not a call dependency node");
+      }
+
+      assert.equal(depNode.from, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    });
   });
 
-  it("should create a graph", () => {
-    assert.isDefined(deploymentGraph);
-  });
+  describe("with array args", () => {
+    let deploymentGraph: IDeploymentGraph;
 
-  it("should have four nodes", () => {
-    assert.equal(deploymentGraph.vertexes.size, 4);
-  });
+    before(() => {
+      const callModule = buildModule("call", (m: IDeploymentBuilder) => {
+        const captureArraysContracts = m.contract("CaptureArraysContract");
 
-  it("should have the contract node Token", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+        m.call(captureArraysContracts, "recordArrays", {
+          args: [
+            [1, 2, 3],
+            ["a", "b", "c"],
+            [true, false, true],
+          ],
+          from: m.accounts[0],
+        });
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
-    assert.equal(depNode?.label, "Token");
-    assert(isHardhatContract(depNode));
-  });
+        return {};
+      });
 
-  it("should have the contract node Exchange", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
+      const { graph } = generateDeploymentGraphFrom(callModule, {
+        chainId: 31337,
+        accounts: ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"],
+        artifacts: [],
+      });
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
+      deploymentGraph = graph;
+    });
 
-    assert.equal(depNode?.label, "Exchange");
-    assert(isHardhatContract(depNode));
-  });
+    it("should create a graph", () => {
+      assert.isDefined(deploymentGraph);
+    });
 
-  it("should have the call node Exchange/addToken", () => {
-    const depNode = getDeploymentVertexByLabel(
-      deploymentGraph,
-      "Exchange/addToken"
-    );
+    it("should have four nodes", () => {
+      assert.equal(deploymentGraph.vertexes.size, 2);
+    });
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
+    it("should have the contract node CaptureArraysContract", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "CaptureArraysContract"
+      );
 
-    assert.equal(depNode?.label, "Exchange/addToken");
-    assert(isCall(depNode));
-  });
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
 
-  it("should show no dependencies for the contract node Token", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+      assert.equal(depNode?.label, "CaptureArraysContract");
+      assert(isHardhatContract(depNode));
+    });
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
+    it("should have the call node CaptureArraysContract/recordArrays", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "CaptureArraysContract/recordArrays"
+      );
 
-    const deps = getDependenciesForVertex(deploymentGraph, depNode);
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
 
-    assert.deepStrictEqual(deps, []);
-  });
+      assert.equal(depNode?.label, "CaptureArraysContract/recordArrays");
+      assert(isCall(depNode));
+    });
 
-  it("should show no dependencies for the contract node Exchange", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
+    it("should show no dependencies for the contract node Token", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "CaptureArraysContract"
+      );
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
 
-    const deps = getDependenciesForVertex(deploymentGraph, depNode);
+      const deps = getDependenciesForVertex(deploymentGraph, depNode);
 
-    assert.deepStrictEqual(deps, []);
-  });
+      assert.deepStrictEqual(deps, []);
+    });
 
-  it("should show three dependencies for the call node Exchange/addToken", () => {
-    const depNode = getDeploymentVertexByLabel(
-      deploymentGraph,
-      "Exchange/addToken"
-    );
+    it("should show one dependencies for the call node CaptureArraysContract/recordArrays", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "CaptureArraysContract/recordArrays"
+      );
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
 
-    const deps = getDependenciesForVertex(deploymentGraph, depNode);
+      const deps = getDependenciesForVertex(deploymentGraph, depNode);
 
-    assert.deepStrictEqual(deps, [
-      {
-        id: 0,
-        label: "Token",
-        type: "",
-      },
-      { id: 1, label: "Exchange", type: "" },
-      { id: 2, label: "Another", type: "" },
-    ]);
-  });
+      assert.deepStrictEqual(deps, [
+        {
+          id: 0,
+          label: "CaptureArraysContract",
+          type: "",
+        },
+      ]);
+    });
 
-  it("should record the argument list for the contract node Token as empty", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Token");
+    it("should record the argument list for the contract node CaptureArraysContract as empty", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "CaptureArraysContract"
+      );
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
 
-    if (!isHardhatContract(depNode)) {
-      return assert.fail("Not a hardhat contract dependency node");
-    }
+      if (!isHardhatContract(depNode)) {
+        return assert.fail("Not a hardhat contract dependency node");
+      }
 
-    assert.deepStrictEqual(depNode.args, []);
-  });
+      assert.deepStrictEqual(depNode.args, []);
+    });
 
-  it("should record the argument list for the contract node Exchange as empty", () => {
-    const depNode = getDeploymentVertexByLabel(deploymentGraph, "Exchange");
+    it("should record the argument list for the call node CaptureArraysContract at CaptureArraysContract/recordArrays", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "CaptureArraysContract/recordArrays"
+      );
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
 
-    if (!isHardhatContract(depNode)) {
-      return assert.fail("Not a hardhat contract dependency node");
-    }
+      if (!isCall(depNode)) {
+        return assert.fail("Not a call dependency node");
+      }
 
-    assert.deepStrictEqual(depNode.args, []);
-  });
+      assert.deepStrictEqual(depNode.args, [
+        [1, 2, 3],
+        ["a", "b", "c"],
+        [true, false, true],
+      ]);
+    });
 
-  it("should record the argument list for the call node Exchange at Exchange/addToken", () => {
-    const depNode = getDeploymentVertexByLabel(
-      deploymentGraph,
-      "Exchange/addToken"
-    );
+    it("should record the address to send from for the call node CaptureArraysContract at CaptureArraysContract/recordArrays", () => {
+      const depNode = getDeploymentVertexByLabel(
+        deploymentGraph,
+        "CaptureArraysContract/recordArrays"
+      );
 
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
+      if (depNode === undefined) {
+        return assert.isDefined(depNode);
+      }
 
-    if (!isCall(depNode)) {
-      return assert.fail("Not a call dependency node");
-    }
+      if (!isCall(depNode)) {
+        return assert.fail("Not a call dependency node");
+      }
 
-    assert.deepStrictEqual(depNode.args, [
-      {
-        vertexId: 0,
-        label: "Token",
-        type: "contract",
-        subtype: "hardhat",
-        contractName: "Token",
-        _future: true,
-      },
-    ]);
-  });
-
-  it("should record the address to send from for the call node Exchange at Exchange/addToken", () => {
-    const depNode = getDeploymentVertexByLabel(
-      deploymentGraph,
-      "Exchange/addToken"
-    );
-
-    if (depNode === undefined) {
-      return assert.isDefined(depNode);
-    }
-
-    if (!isCall(depNode)) {
-      return assert.fail("Not a call dependency node");
-    }
-
-    assert.equal(depNode.from, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+      assert.equal(depNode.from, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    });
   });
 });

--- a/packages/hardhat-plugin/test/calls.ts
+++ b/packages/hardhat-plugin/test/calls.ts
@@ -30,6 +30,55 @@ describe("calls", () => {
     assert.equal(usedAddress, result.bar.address);
   });
 
+  it("should be able to call contracts with array args", async function () {
+    const result = await deployModule(this.hre, (m) => {
+      const captureArraysContract = m.contract("CaptureArraysContract");
+
+      m.call(captureArraysContract, "recordArrays", {
+        args: [
+          [1, 2, 3],
+          ["a", "b", "c"],
+          [true, false, true],
+        ],
+      });
+
+      return { captureArraysContract };
+    });
+
+    assert.isDefined(result.captureArraysContract);
+
+    const captureSuceeded = await result.captureArraysContract.arraysCaptured();
+
+    assert(captureSuceeded);
+  });
+
+  it("should be able to call contracts with arrays nested in objects args", async function () {
+    const result = await deployModule(this.hre, (m) => {
+      const captureComplexObjectContract = m.contract(
+        "CaptureComplexObjectContract"
+      );
+
+      m.call(captureComplexObjectContract, "testComplexObject", {
+        args: [
+          {
+            firstBool: true,
+            secondArray: [1, 2, 3],
+            thirdSubcomplex: { sub: "sub" },
+          },
+        ],
+      });
+
+      return { captureComplexObjectContract };
+    });
+
+    assert.isDefined(result.captureComplexObjectContract);
+
+    const captureSuceeded =
+      await result.captureComplexObjectContract.complexArgCaptured();
+
+    assert(captureSuceeded);
+  });
+
   it("should be able to make calls in order", async function () {
     const result = await deployModule(this.hre, (m) => {
       const trace = m.contract("Trace", {

--- a/packages/hardhat-plugin/test/fixture-projects/minimal/contracts/Contracts.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/minimal/contracts/Contracts.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.7.0 <0.9.0;
+pragma experimental ABIEncoderV2;
 
 contract Foo {
     bool public isFoo = true;
@@ -52,4 +53,88 @@ contract PassingValue {
     constructor() payable {}
 
     function deposit() public payable {}
+}
+
+contract CaptureArraysContract {
+    bool public arraysCaptured;
+
+    constructor() {
+        arraysCaptured = false;
+    }
+
+    function recordArrays(
+        uint256[] memory first,
+        string[] memory second,
+        bool[] memory third
+    ) public returns (uint256 output) {
+        arraysCaptured = true;
+
+        require(first.length == 3, "Wrong number of args on first arg");
+        require(first[0] == 1, "First value is wrong");
+        require(first[1] == 2, "Second value is wrong");
+        require(first[2] == 3, "Third value is wrong");
+
+        require(second.length == 3, "Wrong number of args on second arg");
+        require(
+            keccak256(abi.encodePacked(second[0])) ==
+                keccak256(abi.encodePacked("a")),
+            "First value is wrong"
+        );
+        require(
+            keccak256(abi.encodePacked(second[1])) ==
+                keccak256(abi.encodePacked("b")),
+            "Second value is wrong"
+        );
+        require(
+            keccak256(abi.encodePacked(second[2])) ==
+                keccak256(abi.encodePacked("c")),
+            "Third value is wrong"
+        );
+
+        require(third.length == 3, "Wrong number of args on third arg");
+        require(third[0] == true, "First value is wrong");
+        require(third[1] == false, "Second value is wrong");
+        require(third[2] == true, "Third value is wrong");
+
+        return 1;
+    }
+}
+
+contract CaptureComplexObjectContract {
+    bool public complexArgCaptured;
+
+    constructor() {
+        complexArgCaptured = false;
+    }
+
+    struct SubComplex {
+        string sub;
+    }
+
+    struct Complex {
+        bool firstBool;
+        uint256[] secondArray;
+        SubComplex thirdSubcomplex;
+    }
+
+    function testComplexObject(
+        Complex memory complexArg
+    ) public returns (uint256 output) {
+        complexArgCaptured = true;
+
+        require(complexArg.firstBool, "bad first bool");
+
+        require(complexArg.secondArray.length == 3, "bad second array");
+        require(complexArg.secondArray[0] == 1, "First value is wrong");
+        require(complexArg.secondArray[1] == 2, "Second value is wrong");
+        require(complexArg.secondArray[2] == 3, "Third value is wrong");
+
+        require(
+            keccak256(abi.encodePacked(complexArg.thirdSubcomplex.sub)) ==
+                keccak256(abi.encodePacked("sub")),
+            "The complex sub object property is wrong"
+        );
+
+        return 1;
+    }
 }


### PR DESCRIPTION
Support arrays of bools, numbers and strings as args in `m.call`.

Fixes #186.