### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ See our [Getting started guide](./docs/getting-started-guide.md) for a worked ex
 
 This repo contains example projects that show **Ignition** features in context (under `./examples`):
 
-- [Sample](./examples/sample/README.md) - the **Hardhat** starter project enhanced with Ignition
-- [ENS](./examples/ens/README.md) - deploy ENS and its registry for local testing
-- [Create2](./examples/create2/README.md) - deploy contracts using a `create2` factory
-- [Uniswap](./examples/uniswap/README.md) - deploy Uniswap and test swaps
+- [Sample](./examples/sample) - the **Hardhat** starter project enhanced with Ignition
+- [ENS](./examples/ens) - deploy ENS and its registry for local testing
+- [Create2](./examples/create2) - deploy contracts using a `create2` factory
+- [Uniswap](./examples/uniswap) - deploy Uniswap and test swaps
 
 ## Contributing
 


### PR DESCRIPTION
Hello there!

I recently came across this plugin repository and noticed that the links to the examples were directing me to the README file of the respective examples. I found this a bit odd and opened a PR. I believe that having hardhat repo links to the examples would greatly enhance the user experience and make it easier for individuals to explore and understand Ignition features in context