### PR TITLE
Library Refactor

### DIFF
--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -325,7 +325,7 @@ module.exports = buildModule("`TEST` registrar", (m) => {
 
 Calls to `useModule` memoize the results object, assuming the same parameters are passed. Multiple calls to the same module with different parameters are banned.
 
-Only `CallableFuture` types can be returned when building a module, so contracts or libraries (not calls).
+Only contract or library types can be returned when building a module.
 
 ## Module parameters
 

--- a/packages/core/src/internal/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/internal/dsl/DeploymentBuilder.ts
@@ -2,7 +2,6 @@ import type {
   AddressResolvable,
   ArtifactContract,
   ArtifactLibrary,
-  CallableFuture,
   ContractCall,
   ContractFuture,
   DependableFuture,
@@ -48,7 +47,6 @@ import {
 import {
   assertModuleReturnTypes,
   isArtifact,
-  isCallable,
   isContract,
   isDependable,
   isFuture,
@@ -327,7 +325,7 @@ export class DeploymentBuilder implements IDeploymentBuilder {
       _future: true,
     };
 
-    let contract: CallableFuture;
+    let contract: ContractFuture;
     if (isParameter(contractFuture)) {
       const parameter = contractFuture;
       const scope = parameter.scope;
@@ -346,11 +344,11 @@ export class DeploymentBuilder implements IDeploymentBuilder {
         | HardhatContract
         | ArtifactContract
         | DeployedContract;
-    } else if (isCallable(contractFuture)) {
+    } else if (isContract(contractFuture)) {
       contract = contractFuture;
     } else {
       throw new IgnitionError(
-        `Not a callable future ${contractFuture.label} (${contractFuture.type})`
+        `Not a contract future ${contractFuture.label} (${contractFuture.type})`
       );
     }
 
@@ -382,7 +380,7 @@ export class DeploymentBuilder implements IDeploymentBuilder {
       _future: true,
     };
 
-    let contract: CallableFuture;
+    let contract: ContractFuture;
     if (isParameter(contractFuture)) {
       const parameter = contractFuture;
       const scope = parameter.scope;
@@ -401,11 +399,11 @@ export class DeploymentBuilder implements IDeploymentBuilder {
         | HardhatContract
         | ArtifactContract
         | DeployedContract;
-    } else if (isCallable(contractFuture)) {
+    } else if (isContract(contractFuture)) {
       contract = contractFuture;
     } else {
       throw new IgnitionError(
-        `Not a callable future ${contractFuture.label} (${contractFuture.type})`
+        `Not a contract future ${contractFuture.label} (${contractFuture.type})`
       );
     }
 
@@ -440,7 +438,7 @@ export class DeploymentBuilder implements IDeploymentBuilder {
       params: {},
     };
 
-    let contract: CallableFuture;
+    let contract: ContractFuture;
     if (isParameter(contractFuture)) {
       const parameter = contractFuture;
       const scope = parameter.scope;
@@ -460,13 +458,13 @@ export class DeploymentBuilder implements IDeploymentBuilder {
         | ArtifactContract
         | DeployedContract;
     } else if (
-      isCallable(contractFuture) &&
+      isContract(contractFuture) &&
       contractFuture.type === "contract"
     ) {
       contract = contractFuture;
     } else {
       throw new IgnitionError(
-        `Not a callable future ${contractFuture.label} (${contractFuture.type})`
+        `Not a contract future ${contractFuture.label} (${contractFuture.type})`
       );
     }
 

--- a/packages/core/src/internal/types/deploymentGraph.ts
+++ b/packages/core/src/internal/types/deploymentGraph.ts
@@ -4,7 +4,7 @@ import { InternalParamValue } from "../../types/dsl";
 import {
   AddressResolvable,
   ArtifactContract,
-  CallableFuture,
+  ContractFuture,
   DeploymentGraphFuture,
   EventParamFuture,
   HardhatContract,
@@ -150,7 +150,7 @@ export interface ArtifactLibraryDeploymentVertex extends VertexDescriptor {
 export interface CallDeploymentVertex extends VertexDescriptor {
   type: "Call";
   scopeAdded: string;
-  contract: CallableFuture;
+  contract: ContractFuture;
   method: string;
   args: InternalParamValue[];
   after: DeploymentGraphFuture[];
@@ -166,7 +166,7 @@ export interface CallDeploymentVertex extends VertexDescriptor {
 export interface StaticCallDeploymentVertex extends VertexDescriptor {
   type: "StaticCall";
   scopeAdded: string;
-  contract: CallableFuture;
+  contract: ContractFuture;
   method: string;
   args: InternalParamValue[];
   after: DeploymentGraphFuture[];

--- a/packages/core/src/internal/utils/guards.ts
+++ b/packages/core/src/internal/utils/guards.ts
@@ -1,5 +1,4 @@
 import type {
-  CallableFuture,
   ContractFuture,
   DependableFuture,
   DeploymentGraphFuture,
@@ -128,16 +127,6 @@ export function isParameter(
   future: DeploymentGraphFuture
 ): future is RequiredParameter | OptionalParameter {
   return future.type === "parameter";
-}
-
-export function isCallable(
-  future: DeploymentGraphFuture
-): future is CallableFuture {
-  if (isProxy(future)) {
-    return isCallable(future.value);
-  }
-
-  return future.type === "contract" || future.type === "library";
 }
 
 export function isContract(

--- a/packages/core/src/internal/validation/dispatch/helpers.ts
+++ b/packages/core/src/internal/validation/dispatch/helpers.ts
@@ -1,4 +1,4 @@
-import type { CallableFuture } from "../../../types/future";
+import type { ContractFuture } from "../../../types/future";
 import type { Services } from "../../types/services";
 
 import { IgnitionError } from "../../../errors";
@@ -6,8 +6,8 @@ import { CallPoints, DeploymentGraphVertex } from "../../types/deploymentGraph";
 import { VertexResultEnum, VertexVisitResultFailure } from "../../types/graph";
 import { resolveProxyValue } from "../../utils/proxy";
 
-export async function resolveArtifactForCallableFuture(
-  givenFuture: CallableFuture,
+export async function resolveArtifactForContractFuture(
+  givenFuture: ContractFuture,
   { services }: { services: Services }
 ): Promise<any[] | undefined> {
   const future = resolveProxyValue(givenFuture);

--- a/packages/core/src/internal/validation/dispatch/validateArtifactLibrary.ts
+++ b/packages/core/src/internal/validation/dispatch/validateArtifactLibrary.ts
@@ -34,19 +34,6 @@ export async function validateArtifactLibrary(
     );
   }
 
-  const argsLength = vertex.args.length;
-
-  const iface = new ethers.utils.Interface(vertex.artifact.abi);
-  const expectedArgsLength = iface.deploy.inputs.length;
-
-  if (argsLength !== expectedArgsLength) {
-    return buildValidationError(
-      vertex,
-      `The constructor of the library '${vertex.label}' expects ${expectedArgsLength} arguments but ${argsLength} were given`,
-      context.callPoints
-    );
-  }
-
   return {
     _kind: VertexResultEnum.SUCCESS,
     result: undefined,

--- a/packages/core/src/internal/validation/dispatch/validateCall.ts
+++ b/packages/core/src/internal/validation/dispatch/validateCall.ts
@@ -11,7 +11,7 @@ import { isParameter } from "../../utils/guards";
 
 import {
   buildValidationError,
-  resolveArtifactForCallableFuture,
+  resolveArtifactForContractFuture,
 } from "./helpers";
 
 export async function validateCall(
@@ -37,7 +37,7 @@ export async function validateCall(
 
   const contractName = vertex.contract.label;
 
-  const artifactAbi = await resolveArtifactForCallableFuture(
+  const artifactAbi = await resolveArtifactForContractFuture(
     vertex.contract,
     context
   );

--- a/packages/core/src/internal/validation/dispatch/validateEvent.ts
+++ b/packages/core/src/internal/validation/dispatch/validateEvent.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   buildValidationError,
-  resolveArtifactForCallableFuture,
+  resolveArtifactForContractFuture,
 } from "./helpers";
 
 export async function validateEvent(
@@ -30,7 +30,7 @@ export async function validateEvent(
 
     artifactAbi = vertex.abi;
   } else if (vertex.address.type === "contract") {
-    artifactAbi = await resolveArtifactForCallableFuture(vertex.address, {
+    artifactAbi = await resolveArtifactForContractFuture(vertex.address, {
       services,
     });
 

--- a/packages/core/src/internal/validation/dispatch/validateHardhatLibrary.ts
+++ b/packages/core/src/internal/validation/dispatch/validateHardhatLibrary.ts
@@ -35,20 +35,6 @@ export async function validateHardhatLibrary(
     );
   }
 
-  const artifact = await services.artifacts.getArtifact(vertex.libraryName);
-  const argsLength = vertex.args.length;
-
-  const iface = new ethers.utils.Interface(artifact.abi);
-  const expectedArgsLength = iface.deploy.inputs.length;
-
-  if (argsLength !== expectedArgsLength) {
-    return buildValidationError(
-      vertex,
-      `The constructor of the library '${vertex.libraryName}' expects ${expectedArgsLength} arguments but ${argsLength} were given`,
-      callPoints
-    );
-  }
-
   return {
     _kind: VertexResultEnum.SUCCESS,
     result: undefined,

--- a/packages/core/src/internal/validation/dispatch/validateStaticCall.ts
+++ b/packages/core/src/internal/validation/dispatch/validateStaticCall.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   buildValidationError,
-  resolveArtifactForCallableFuture,
+  resolveArtifactForContractFuture,
 } from "./helpers";
 
 export async function validateStaticCall(
@@ -28,7 +28,7 @@ export async function validateStaticCall(
 
   const contractName = vertex.contract.label;
 
-  const artifactAbi = await resolveArtifactForCallableFuture(
+  const artifactAbi = await resolveArtifactForContractFuture(
     vertex.contract,
     context
   );

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -233,19 +233,13 @@ export type ContractFuture =
 export type LibraryFuture = HardhatLibrary | ArtifactLibrary;
 
 /**
- * The future representing the value of calling a smart contract method.
- *
- * @alpha
- */
-export type CallableFuture = ContractFuture | LibraryFuture;
-
-/**
  * A future value from an on-chain action that.
  *
  * @alpha
  */
 export type DependableFuture =
-  | CallableFuture
+  | ContractFuture
+  | LibraryFuture
   | ContractCall
   | StaticContractCall
   | Virtual

--- a/packages/core/test/deploymentBuilder/parameters.ts
+++ b/packages/core/test/deploymentBuilder/parameters.ts
@@ -6,7 +6,7 @@ import { assert } from "chai";
 import { buildModule } from "../../src/buildModule";
 import { IgnitionError } from "../../src/errors";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
-import { isCallable } from "../../src/internal/utils/guards";
+import { isContract } from "../../src/internal/utils/guards";
 import { isFailure } from "../../src/internal/utils/process-results";
 import { IDeploymentBuilder } from "../../src/types/dsl";
 
@@ -32,8 +32,8 @@ describe("deployment builder - parameters", function () {
         parameters: { tokenSymbol: "EXAMPLE", tokenName: "Example" },
       });
 
-      if (!isCallable(token)) {
-        throw new IgnitionError("Not callable");
+      if (!isContract(token)) {
+        throw new IgnitionError("Not contract");
       }
 
       return { token };

--- a/packages/core/test/deploymentBuilder/useModule.ts
+++ b/packages/core/test/deploymentBuilder/useModule.ts
@@ -10,9 +10,10 @@ import { isFailure } from "../../src/internal/utils/process-results";
 import { IDeploymentBuilder } from "../../src/types/dsl";
 import {
   ArtifactContract,
-  CallableFuture,
+  ContractFuture,
   EventFuture,
   HardhatContract,
+  LibraryFuture,
   ProxyFuture,
   Virtual,
 } from "../../src/types/future";
@@ -537,7 +538,12 @@ describe("deployment builder - useModule", () => {
   describe("returning non contract futures from within a module", () => {
     // @ts-ignore
     let returnsWrongFutureTypeModule: Module<{
-      token: CallableFuture | Virtual | ProxyFuture | EventFuture;
+      token:
+        | ContractFuture
+        | LibraryFuture
+        | Virtual
+        | ProxyFuture
+        | EventFuture;
     }>;
 
     before(() => {

--- a/packages/core/test/validation.ts
+++ b/packages/core/test/validation.ts
@@ -107,23 +107,6 @@ describe("Validation", () => {
       assert.equal(validationResult._kind, ProcessResultKind.SUCCESS);
     });
 
-    it("should not validate a artifact library deploy with the wrong number of args", async () => {
-      const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.library("Example", exampleArtifact, {
-          args: [1, 2, 3],
-        });
-
-        return { example };
-      });
-
-      const validationResult = await runValidation(singleModule);
-
-      assertValidationError(
-        validationResult,
-        "The constructor of the library 'Example' expects 0 arguments but 3 were given"
-      );
-    });
-
     it("should not validate a artifact library deploy with a non-address `from`", async () => {
       const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
         const example = m.library("Example", exampleArtifact, {
@@ -1014,29 +997,6 @@ describe("Validation", () => {
       assertValidationError(
         validationResult,
         "Library with name 'Nonexistant' doesn't exist"
-      );
-    });
-
-    it("should not validate a library deployed with the wrong number of args", async () => {
-      const singleModule = buildModule("single", (m: IDeploymentBuilder) => {
-        const example = m.library("Example", { args: [1, 2] });
-
-        return { example };
-      });
-
-      const mockServices = {
-        ...getMockServices(),
-        artifacts: {
-          hasArtifact: () => true,
-          getArtifact: () => exampleArtifact,
-        },
-      } as any;
-
-      const validationResult = await runValidation(singleModule, mockServices);
-
-      assertValidationError(
-        validationResult,
-        "The constructor of the library 'Example' expects 0 arguments but 2 were given"
       );
     });
 


### PR DESCRIPTION
There are currently some incorrect assumptions made about libraries that aren't harming anything, per se, but we should refactor them for clarity regardless.

- [x] inclusion in CallableFuture type (you can't call functions on a library)
- [x] unnecessary arg length validation (you can't give constructor args for a library)

fixes #177 