### PR TITLE
refactor/rename build module define module (new api PR 8)

### DIFF
--- a/packages/core/src/new-api/define-module.ts
+++ b/packages/core/src/new-api/define-module.ts
@@ -1,10 +1,10 @@
 import { IgnitionModuleResult } from "./types/module";
 import {
-  IgnitionModuleDefinition,
   IgnitionModuleBuilder,
+  IgnitionModuleDefinition,
 } from "./types/module-builder";
 
-export function buildModule<
+export function defineModule<
   ModuleIdT extends string,
   ContractNameT extends string,
   IgnitionModuleResultsT extends IgnitionModuleResult<ContractNameT>

--- a/packages/core/src/new-api/examples.ts
+++ b/packages/core/src/new-api/examples.ts
@@ -2,17 +2,17 @@
 //  Future: representation of a future value, which may require on-chain interaction (e.g. deploy a contract, an already existing contract)
 //  FutureFactory: Methods exposed by IgnitionModuleBuidler which create factories
 
-import { buildModule } from "./build-module";
+import { defineModule } from "./define-module";
 
 // Examples
 
-const moduleWithASingleContract = buildModule("Module1", (m) => {
+const moduleWithASingleContract = defineModule("Module1", (m) => {
   const contract1 = m.contract("Contract1", []);
 
   return { contract1 };
 });
 
-const moduleWithUnexportedContract = buildModule("Module2", (m) => {
+const moduleWithUnexportedContract = defineModule("Module2", (m) => {
   const contract1 = m.contract("Contract1", [1, 2, 3]);
 
   // We don't export this, but we still need to run every future,
@@ -22,7 +22,7 @@ const moduleWithUnexportedContract = buildModule("Module2", (m) => {
   return { contract1 };
 });
 
-const moduleWithSubmodule = buildModule("Module3", (m) => {
+const moduleWithSubmodule = defineModule("Module3", (m) => {
   const { contract1 } = m.useModule(moduleWithASingleContract);
   // ^ This is typed 😎
 

--- a/packages/core/test/new-api/call.ts
+++ b/packages/core/test/new-api/call.ts
@@ -1,13 +1,13 @@
 import { assert } from "chai";
 
-import { buildModule } from "../../src/new-api/build-module";
+import { defineModule } from "../../src/new-api/define-module";
 import { NamedContractCallFutureImplementation } from "../../src/new-api/internal/module";
 import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 import { FutureType } from "../../src/new-api/types/module";
 
 describe("call", () => {
   it("should be able to setup a contract call", () => {
-    const moduleWithASingleContractDefinition = buildModule("Module1", (m) => {
+    const moduleWithASingleContractDefinition = defineModule("Module1", (m) => {
       const contract1 = m.contract("Contract1");
 
       m.call(contract1, "test");
@@ -45,7 +45,7 @@ describe("call", () => {
   });
 
   it("should be able to pass one contract as an arg dependency to a call", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -86,7 +86,7 @@ describe("call", () => {
   });
 
   it("should be able to pass one contract as an after dependency of a call", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -128,7 +128,7 @@ describe("call", () => {
 
   describe("passing id", () => {
     it("should be able to call the same function twice by passing an id", () => {
-      const moduleWithSameCallTwiceDefinition = buildModule("Module1", (m) => {
+      const moduleWithSameCallTwiceDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contract("Example");
 
         m.call(sameContract1, "test", [], { id: "first" });
@@ -157,7 +157,7 @@ describe("call", () => {
     });
 
     it("should throw if the same function is called twice without differentiating ids", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contract("SameContract");
         m.call(sameContract1, "test");
         m.call(sameContract1, "test");
@@ -174,7 +174,7 @@ describe("call", () => {
     });
 
     it("should throw if a call tries to pass the same id twice", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contract("SameContract");
         m.call(sameContract1, "test", [], { id: "first" });
         m.call(sameContract1, "test", [], { id: "first" });

--- a/packages/core/test/new-api/contract.ts
+++ b/packages/core/test/new-api/contract.ts
@@ -1,13 +1,13 @@
 import { assert } from "chai";
 
-import { buildModule } from "../../src/new-api/build-module";
+import { defineModule } from "../../src/new-api/define-module";
 import { NamedContractDeploymentFutureImplementation } from "../../src/new-api/internal/module";
 import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 import { FutureType } from "../../src/new-api/types/module";
 
 describe("contract", () => {
   it("should be able to setup a deploy contract call", () => {
-    const moduleWithASingleContractDefinition = buildModule("Module1", (m) => {
+    const moduleWithASingleContractDefinition = defineModule("Module1", (m) => {
       const contract1 = m.contract("Contract1");
 
       return { contract1 };
@@ -39,7 +39,7 @@ describe("contract", () => {
   });
 
   it("should be able to pass one contract as an arg dependency to another", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -75,7 +75,7 @@ describe("contract", () => {
   });
 
   it("should be able to pass one contract as an after dependency of another", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -111,7 +111,7 @@ describe("contract", () => {
   });
 
   it("should be able to pass a library as a dependency of a contract", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.library("Example");
@@ -151,7 +151,7 @@ describe("contract", () => {
 
   describe("passing id", () => {
     it("should be able to deploy the same contract twice by passing an id", () => {
-      const moduleWithSameContractTwiceDefinition = buildModule(
+      const moduleWithSameContractTwiceDefinition = defineModule(
         "Module1",
         (m) => {
           const sameContract1 = m.contract("SameContract", [], { id: "first" });
@@ -180,7 +180,7 @@ describe("contract", () => {
     });
 
     it("should throw if the same contract is deployed twice without differentiating ids", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contract("SameContract");
         const sameContract2 = m.contract("SameContract");
 
@@ -196,7 +196,7 @@ describe("contract", () => {
     });
 
     it("should throw if a contract tries to pass the same id twice", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contract("SameContract", [], {
           id: "same",
         });

--- a/packages/core/test/new-api/contractAt.ts
+++ b/packages/core/test/new-api/contractAt.ts
@@ -1,13 +1,13 @@
 import { assert } from "chai";
 
-import { buildModule } from "../../src/new-api/build-module";
+import { defineModule } from "../../src/new-api/define-module";
 import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 
 describe("contractAt", () => {
   const fakeArtifact: any = {};
 
   it("should be able to setup a contract at a given address", () => {
-    const moduleWithContractFromArtifactDefinition = buildModule(
+    const moduleWithContractFromArtifactDefinition = defineModule(
       "Module1",
       (m) => {
         const contract1 = m.contractAt("Contract1", "0xtest", fakeArtifact);
@@ -44,7 +44,7 @@ describe("contractAt", () => {
   });
 
   it("should be able to pass an after dependency", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -72,7 +72,7 @@ describe("contractAt", () => {
 
   describe("passing id", () => {
     it("should use contract at twice by passing an id", () => {
-      const moduleWithSameContractTwiceDefinition = buildModule(
+      const moduleWithSameContractTwiceDefinition = defineModule(
         "Module1",
         (m) => {
           const sameContract1 = m.contractAt(
@@ -114,7 +114,7 @@ describe("contractAt", () => {
     });
 
     it("should throw if the same contract is deployed twice without differentiating ids", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contractAt(
           "SameContract",
           "0xtest",
@@ -138,7 +138,7 @@ describe("contractAt", () => {
     });
 
     it("should throw if a contract tries to pass the same id twice", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contractAt(
           "SameContract",
           "0xtest",

--- a/packages/core/test/new-api/contractFromArtifact.ts
+++ b/packages/core/test/new-api/contractFromArtifact.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import { buildModule } from "../../src/new-api/build-module";
+import { defineModule } from "../../src/new-api/define-module";
 import { ArtifactContractDeploymentFutureImplementation } from "../../src/new-api/internal/module";
 import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 
@@ -8,7 +8,7 @@ describe("contractFromArtifact", () => {
   const fakeArtifact: any = {};
 
   it("should be able to deploy with a contract based on an artifact", () => {
-    const moduleWithContractFromArtifactDefinition = buildModule(
+    const moduleWithContractFromArtifactDefinition = defineModule(
       "Module1",
       (m) => {
         const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
@@ -49,7 +49,7 @@ describe("contractFromArtifact", () => {
   });
 
   it("should be able to pass an arg dependency", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -76,7 +76,7 @@ describe("contractFromArtifact", () => {
   });
 
   it("should be able to pass an after dependency", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -103,7 +103,7 @@ describe("contractFromArtifact", () => {
   });
 
   it("should be able to pass a library as a dependency of a contract", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.library("Example");
@@ -143,7 +143,7 @@ describe("contractFromArtifact", () => {
 
   describe("passing id", () => {
     it("should use contract from artifact twice by passing an id", () => {
-      const moduleWithSameContractTwiceDefinition = buildModule(
+      const moduleWithSameContractTwiceDefinition = defineModule(
         "Module1",
         (m) => {
           const sameContract1 = m.contractFromArtifact(
@@ -183,7 +183,7 @@ describe("contractFromArtifact", () => {
     });
 
     it("should throw if the same contract is deployed twice without differentiating ids", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contractFromArtifact(
           "SameContract",
           fakeArtifact
@@ -204,7 +204,7 @@ describe("contractFromArtifact", () => {
     });
 
     it("should throw if a contract tries to pass the same id twice", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contractFromArtifact(
           "SameContract",
           fakeArtifact,

--- a/packages/core/test/new-api/library.ts
+++ b/packages/core/test/new-api/library.ts
@@ -1,13 +1,13 @@
 import { assert } from "chai";
 
-import { buildModule } from "../../src/new-api/build-module";
+import { defineModule } from "../../src/new-api/define-module";
 import { NamedLibraryDeploymentFutureImplementation } from "../../src/new-api/internal/module";
 import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 import { FutureType } from "../../src/new-api/types/module";
 
 describe("library", () => {
   it("should be able to setup a deploy library call", () => {
-    const moduleWithASingleContractDefinition = buildModule("Module1", (m) => {
+    const moduleWithASingleContractDefinition = defineModule("Module1", (m) => {
       const library1 = m.library("Library1");
 
       return { library1 };
@@ -39,7 +39,7 @@ describe("library", () => {
   });
 
   it("should be able to pass one library as an after dependency of another", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.library("Example");
@@ -75,7 +75,7 @@ describe("library", () => {
   });
 
   it("should be able to pass a library as a dependency of a library", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.library("Example");
@@ -115,7 +115,7 @@ describe("library", () => {
 
   describe("passing id", () => {
     it("should be able to deploy the same library twice by passing an id", () => {
-      const moduleWithSameContractTwiceDefinition = buildModule(
+      const moduleWithSameContractTwiceDefinition = defineModule(
         "Module1",
         (m) => {
           const sameContract1 = m.library("SameContract", { id: "first" });
@@ -144,7 +144,7 @@ describe("library", () => {
     });
 
     it("should throw if the same library is deployed twice without differentiating ids", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.library("SameContract");
         const sameContract2 = m.library("SameContract");
 
@@ -159,7 +159,7 @@ describe("library", () => {
     });
 
     it("should throw if a library tries to pass the same id twice", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.library("SameContract", {
           id: "same",
         });

--- a/packages/core/test/new-api/libraryFromArtifact.ts
+++ b/packages/core/test/new-api/libraryFromArtifact.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import { buildModule } from "../../src/new-api/build-module";
+import { defineModule } from "../../src/new-api/define-module";
 import { ArtifactLibraryDeploymentFutureImplementation } from "../../src/new-api/internal/module";
 import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 
@@ -8,7 +8,7 @@ describe("libraryFromArtifact", () => {
   const fakeArtifact: any = {};
 
   it("should be able to deploy with a library based on an artifact", () => {
-    const moduleWithContractFromArtifactDefinition = buildModule(
+    const moduleWithContractFromArtifactDefinition = defineModule(
       "Module1",
       (m) => {
         const library1 = m.libraryFromArtifact("Library1", fakeArtifact);
@@ -39,7 +39,7 @@ describe("libraryFromArtifact", () => {
   });
 
   it("should be able to pass an after dependency", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.library("Example");
@@ -66,7 +66,7 @@ describe("libraryFromArtifact", () => {
   });
 
   it("should be able to pass a library as a dependency of a library", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.library("Example");
@@ -106,7 +106,7 @@ describe("libraryFromArtifact", () => {
 
   describe("passing id", () => {
     it("should use library from artifact twice by passing an id", () => {
-      const moduleWithSameContractTwiceDefinition = buildModule(
+      const moduleWithSameContractTwiceDefinition = defineModule(
         "Module1",
         (m) => {
           const sameContract1 = m.libraryFromArtifact(
@@ -144,7 +144,7 @@ describe("libraryFromArtifact", () => {
     });
 
     it("should throw if the same library is deployed twice without differentiating ids", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.libraryFromArtifact(
           "SameContract",
           fakeArtifact
@@ -165,7 +165,7 @@ describe("libraryFromArtifact", () => {
     });
 
     it("should throw if a library tries to pass the same id twice", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.libraryFromArtifact(
           "SameContract",
           fakeArtifact,

--- a/packages/core/test/new-api/staticCall.ts
+++ b/packages/core/test/new-api/staticCall.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import { buildModule } from "../../src/new-api/build-module";
+import { defineModule } from "../../src/new-api/define-module";
 import {
   NamedContractCallFutureImplementation,
   NamedStaticCallFutureImplementation,
@@ -10,7 +10,7 @@ import { FutureType } from "../../src/new-api/types/module";
 
 describe("static call", () => {
   it("should be able to setup a static call", () => {
-    const moduleWithASingleContractDefinition = buildModule("Module1", (m) => {
+    const moduleWithASingleContractDefinition = defineModule("Module1", (m) => {
       const contract1 = m.contract("Contract1");
 
       m.staticCall(contract1, "test");
@@ -48,7 +48,7 @@ describe("static call", () => {
   });
 
   it("should be able to pass one contract as an arg dependency to a static call", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -89,7 +89,7 @@ describe("static call", () => {
   });
 
   it("should be able to pass one contract as an after dependency of a static call", () => {
-    const moduleWithDependentContractsDefinition = buildModule(
+    const moduleWithDependentContractsDefinition = defineModule(
       "Module1",
       (m) => {
         const example = m.contract("Example");
@@ -130,7 +130,7 @@ describe("static call", () => {
   });
 
   it("should be able to pass its result into another call", () => {
-    const moduleWithASingleContractDefinition = buildModule("Module1", (m) => {
+    const moduleWithASingleContractDefinition = defineModule("Module1", (m) => {
       const contract1 = m.contract("Contract1");
 
       const data = m.staticCall(contract1, "test");
@@ -165,7 +165,7 @@ describe("static call", () => {
 
   describe("passing id", () => {
     it("should be able to statically call the same function twice by passing an id", () => {
-      const moduleWithSameCallTwiceDefinition = buildModule("Module1", (m) => {
+      const moduleWithSameCallTwiceDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contract("Example");
 
         m.staticCall(sameContract1, "test", [], { id: "first" });
@@ -194,7 +194,7 @@ describe("static call", () => {
     });
 
     it("should throw if the same function is statically called twice without differentiating ids", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contract("SameContract");
         m.staticCall(sameContract1, "test");
         m.staticCall(sameContract1, "test");
@@ -211,7 +211,7 @@ describe("static call", () => {
     });
 
     it("should throw if a static call tries to pass the same id twice", () => {
-      const moduleDefinition = buildModule("Module1", (m) => {
+      const moduleDefinition = defineModule("Module1", (m) => {
         const sameContract1 = m.contract("SameContract");
         m.staticCall(sameContract1, "test", [], { id: "first" });
         m.staticCall(sameContract1, "test", [], { id: "first" });

--- a/packages/core/test/new-api/useModule.ts
+++ b/packages/core/test/new-api/useModule.ts
@@ -1,17 +1,17 @@
 import { assert } from "chai";
 
-import { buildModule } from "../../src/new-api/build-module";
+import { defineModule } from "../../src/new-api/define-module";
 import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 
 describe("useModule", () => {
   it("should be able to use a submodule", () => {
-    const submoduleDefinition = buildModule("Submodule1", (m) => {
+    const submoduleDefinition = defineModule("Submodule1", (m) => {
       const contract1 = m.contract("Contract1");
 
       return { contract1 };
     });
 
-    const moduleWithSubmoduleDefinition = buildModule("Module1", (m) => {
+    const moduleWithSubmoduleDefinition = defineModule("Module1", (m) => {
       const { contract1 } = m.useModule(submoduleDefinition);
 
       return { contract1 };
@@ -29,13 +29,13 @@ describe("useModule", () => {
   });
 
   it("returns the same result set (object equal) for each usage", () => {
-    const submoduleDefinition = buildModule("Submodule1", (m) => {
+    const submoduleDefinition = defineModule("Submodule1", (m) => {
       const contract1 = m.contract("Contract1");
 
       return { contract1 };
     });
 
-    const moduleWithSubmoduleDefinition = buildModule("Module1", (m) => {
+    const moduleWithSubmoduleDefinition = defineModule("Module1", (m) => {
       const { contract1: first } = m.useModule(submoduleDefinition);
       const { contract1: second } = m.useModule(submoduleDefinition);
 
@@ -58,13 +58,13 @@ describe("useModule", () => {
   });
 
   it("supports dependending on returned results", () => {
-    const submoduleDefinition = buildModule("Submodule1", (m) => {
+    const submoduleDefinition = defineModule("Submodule1", (m) => {
       const contract1 = m.contract("Contract1");
 
       return { contract1 };
     });
 
-    const moduleWithSubmoduleDefinition = buildModule("Module1", (m) => {
+    const moduleWithSubmoduleDefinition = defineModule("Module1", (m) => {
       const { contract1 } = m.useModule(submoduleDefinition);
 
       const contract2 = m.contract("Contract2", [contract1]);

--- a/packages/hardhat-plugin/src/ui/components/execution/ModuleParameters.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/ModuleParameters.tsx
@@ -1,6 +1,6 @@
 import type { ModuleParams } from "@ignored/ignition-core";
 
-import { Text, Newline } from "ink";
+import { Newline, Text } from "ink";
 
 export const ModuleParameters = ({
   moduleParams,
@@ -20,7 +20,7 @@ export const ModuleParameters = ({
   const params = entries.map(([key, value]) => (
     <Text>
       <Text>
-        {key}: {value}
+        {key}: {value.toString()}
       </Text>
       <Newline />
     </Text>


### PR DESCRIPTION
Rename `buildModule` to `defineModule` to help clarify the mental steps.