### PR TITLE
add getParameter to new API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,11 @@ export { defineModule } from "./new-api/define-module";
 export { ModuleConstructor } from "./new-api/internal/module-builder";
 export { StoredDeploymentSerializer } from "./new-api/stored-deployment-serializer";
 /* TODO: move out and concretize these stubs */
-export { ArtifactType, SolidityParamsType } from "./new-api/stubs";
+export {
+  ArtifactType,
+  SolidityParamsType,
+  SolidityParamType,
+} from "./new-api/stubs";
 export * from "./new-api/types/module";
 export * from "./new-api/types/module-builder";
 export * from "./new-api/types/serialized-deployment";

--- a/packages/core/src/new-api/internal/module-builder.ts
+++ b/packages/core/src/new-api/internal/module-builder.ts
@@ -62,7 +62,7 @@ export class ModuleConstructor {
   constructor(
     public readonly chainId: number,
     public readonly accounts: string[],
-    public readonly parameters: ModuleParameters = {}
+    public readonly parameters: { [moduleId: string]: ModuleParameters } = {}
   ) {}
 
   public construct<
@@ -96,7 +96,7 @@ export class ModuleConstructor {
         mod,
         this.chainId,
         this.accounts,
-        this.parameters
+        this.parameters[moduleDefintion.id]
       )
     );
 

--- a/packages/core/src/new-api/internal/module-builder.ts
+++ b/packages/core/src/new-api/internal/module-builder.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { inspect } from "util";
 
 import { IgnitionValidationError } from "../../errors";
-import { ArtifactType, SolidityParamsType } from "../stubs";
+import { ArtifactType, SolidityParamType, SolidityParamsType } from "../stubs";
 import {
   ArtifactContractDeploymentFuture,
   ArtifactLibraryDeploymentFuture,
@@ -10,6 +10,7 @@ import {
   ContractFuture,
   IgnitionModule,
   IgnitionModuleResult,
+  ModuleParameters,
   NamedContractCallFuture,
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
@@ -60,7 +61,8 @@ export class ModuleConstructor {
 
   constructor(
     public readonly chainId: number,
-    public readonly accounts: string[]
+    public readonly accounts: string[],
+    public readonly parameters: ModuleParameters = {}
   ) {}
 
   public construct<
@@ -93,7 +95,8 @@ export class ModuleConstructor {
         this,
         mod,
         this.chainId,
-        this.accounts
+        this.accounts,
+        this.parameters
       )
     );
 
@@ -119,7 +122,8 @@ export class IgnitionModuleBuilderImplementation<
       IgnitionModuleResultsT
     >,
     public readonly chainId: number,
-    public readonly accounts: string[]
+    public readonly accounts: string[],
+    public readonly parameters: ModuleParameters = {}
   ) {
     this._futureIds = new Set<string>();
   }
@@ -364,6 +368,22 @@ export class IgnitionModuleBuilderImplementation<
     return future;
   }
 
+  public getParameter<ParamType extends SolidityParamType>(
+    parameterName: string,
+    defaultValue?: ParamType
+  ): ParamType {
+    const param = this.parameters[parameterName] ?? defaultValue;
+
+    if (param === undefined) {
+      this._throwErrorWithStackTrace(
+        `Module parameter '${parameterName}' is required, but none was given`,
+        this.getParameter
+      );
+    }
+
+    return param as ParamType;
+  }
+
   public useModule<
     SubmoduleModuleIdT extends string,
     SubmoduleContractNameT extends string,
@@ -391,18 +411,25 @@ export class IgnitionModuleBuilderImplementation<
     return submodule.results;
   }
 
+  private _throwErrorWithStackTrace(
+    message: string,
+    func: (...[]: any[]) => any
+  ): never {
+    const validationError = new IgnitionValidationError(message);
+
+    // Improve the stack trace to stop on module api level
+    Error.captureStackTrace(validationError, func);
+
+    throw validationError;
+  }
+
   private _assertUniqueFutureId(
     futureId: string,
     message: string,
     func: (...[]: any[]) => any
   ) {
     if (this._futureIds.has(futureId)) {
-      const validationError = new IgnitionValidationError(message);
-
-      // Improve the stack trace to stop on module api level
-      Error.captureStackTrace(validationError, func);
-
-      throw validationError;
+      this._throwErrorWithStackTrace(message, func);
     }
 
     this._futureIds.add(futureId);

--- a/packages/core/src/new-api/internal/module-builder.ts
+++ b/packages/core/src/new-api/internal/module-builder.ts
@@ -368,7 +368,7 @@ export class IgnitionModuleBuilderImplementation<
     return future;
   }
 
-  public getParameter<ParamType extends SolidityParamType>(
+  public getParameter<ParamType extends SolidityParamType = any>(
     parameterName: string,
     defaultValue?: ParamType
   ): ParamType {

--- a/packages/core/src/new-api/stubs.ts
+++ b/packages/core/src/new-api/stubs.ts
@@ -1,9 +1,16 @@
 /**
+ * The type representing all valid types for solidity parameters.
+ *
+ * @beta
+ */
+export type SolidityParamType = any;
+
+/**
  * The composite type of a solidity methods parameters.
  *
  * @beta
  */
-export type SolidityParamsType = any[];
+export type SolidityParamsType = SolidityParamType[];
 
 /**
  * The artifact of a contract compilation.

--- a/packages/core/src/new-api/types/module-builder.ts
+++ b/packages/core/src/new-api/types/module-builder.ts
@@ -1,4 +1,4 @@
-import { ArtifactType, SolidityParamsType } from "../stubs";
+import { ArtifactType, SolidityParamType, SolidityParamsType } from "../stubs";
 
 import {
   ArtifactContractDeploymentFuture,
@@ -154,6 +154,11 @@ export interface IgnitionModuleBuilder {
     artifact: ArtifactType,
     options?: ContractAtOptions
   ): ContractAtFuture;
+
+  getParameter<ParamType extends SolidityParamType>(
+    parameterName: string,
+    defaultValue?: ParamType
+  ): ParamType;
 
   useModule<
     ModuleIdT extends string,

--- a/packages/core/src/new-api/types/module.ts
+++ b/packages/core/src/new-api/types/module.ts
@@ -1,4 +1,4 @@
-import { ArtifactType, SolidityParamsType } from "../stubs";
+import { ArtifactType, SolidityParamType, SolidityParamsType } from "../stubs";
 
 /**
  * The different future types supported by Ignition.
@@ -144,6 +144,15 @@ export interface ContractAtFuture extends ContractFuture<string> {
   type: FutureType.CONTRACT_AT;
   address: string;
   artifact: ArtifactType;
+}
+
+/**
+ * An object containing the parameters passed into the module.
+ *
+ * @beta
+ */
+export interface ModuleParameters {
+  [parameterName: string]: SolidityParamType;
 }
 
 /**

--- a/packages/core/test/new-api/getParameter.ts
+++ b/packages/core/test/new-api/getParameter.ts
@@ -1,0 +1,87 @@
+import { assert } from "chai";
+
+import { defineModule } from "../../src/new-api/define-module";
+import { NamedContractDeploymentFutureImplementation } from "../../src/new-api/internal/module";
+import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
+
+describe("getParameter", () => {
+  it("should record given parameters", () => {
+    const constructor = new ModuleConstructor(0, [], { param1: 42 });
+
+    assert.equal(constructor.parameters.param1, 42);
+  });
+
+  it("should allow a parameter to be passed as an arg", () => {
+    const moduleWithParamsDefinition = defineModule("Module1", (m) => {
+      const arg1 = m.getParameter<string>("param1");
+      const contract1 = m.contract("Contract1", [arg1]);
+
+      return { contract1 };
+    });
+
+    const constructor = new ModuleConstructor(0, [], { param1: "arg1" });
+    const moduleWithParams = constructor.construct(moduleWithParamsDefinition);
+
+    assert.isDefined(moduleWithParams);
+
+    const contractFuture = [...moduleWithParams.futures].find(
+      ({ id }) => id === "Module1:Contract1"
+    );
+
+    if (
+      !(contractFuture instanceof NamedContractDeploymentFutureImplementation)
+    ) {
+      assert.fail("Not a named contract deployment");
+    }
+
+    assert.equal(contractFuture.constructorArgs.length, 1);
+    assert.equal(contractFuture.constructorArgs[0], "arg1");
+  });
+
+  it("should allow a parameter to have a default value", () => {
+    const moduleWithParamsDefinition = defineModule("Module1", (m) => {
+      const arg1 = m.getParameter<string>("param1", "arg1");
+      const arg2 = m.getParameter<number>("param2", 42);
+      const contract1 = m.contract("Contract1", [arg1, arg2]);
+
+      return { contract1 };
+    });
+
+    const constructor = new ModuleConstructor(0, [], {
+      param1: "overriddenParam",
+    });
+    const moduleWithParams = constructor.construct(moduleWithParamsDefinition);
+
+    assert.isDefined(moduleWithParams);
+
+    const contractFuture = [...moduleWithParams.futures].find(
+      ({ id }) => id === "Module1:Contract1"
+    );
+
+    if (
+      !(contractFuture instanceof NamedContractDeploymentFutureImplementation)
+    ) {
+      assert.fail("Not a named contract deployment");
+    }
+
+    assert.equal(contractFuture.constructorArgs.length, 2);
+    assert.equal(contractFuture.constructorArgs[0], "overriddenParam");
+    assert.equal(contractFuture.constructorArgs[1], 42);
+  });
+
+  it("should throw if a parameter has no value", () => {
+    const moduleWithParamsDefinition = defineModule("Module1", (m) => {
+      const arg1 = m.getParameter<string>("param1");
+      const contract1 = m.contract("Contract1", [arg1]);
+
+      return { contract1 };
+    });
+
+    const constructor = new ModuleConstructor(0, []);
+
+    assert.throws(
+      () => constructor.construct(moduleWithParamsDefinition),
+      /Module parameter 'param1' is required, but none was given/
+    );
+  });
+});

--- a/packages/core/test/new-api/getParameter.ts
+++ b/packages/core/test/new-api/getParameter.ts
@@ -6,20 +6,24 @@ import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 
 describe("getParameter", () => {
   it("should record given parameters", () => {
-    const constructor = new ModuleConstructor(0, [], { param1: 42 });
+    const constructor = new ModuleConstructor(0, [], {
+      TestModule: { param1: 42 },
+    });
 
-    assert.equal(constructor.parameters.param1, 42);
+    assert.equal(constructor.parameters.TestModule.param1, 42);
   });
 
   it("should allow a parameter to be passed as an arg", () => {
     const moduleWithParamsDefinition = defineModule("Module1", (m) => {
-      const arg1 = m.getParameter<string>("param1");
+      const arg1 = m.getParameter("param1");
       const contract1 = m.contract("Contract1", [arg1]);
 
       return { contract1 };
     });
 
-    const constructor = new ModuleConstructor(0, [], { param1: "arg1" });
+    const constructor = new ModuleConstructor(0, [], {
+      Module1: { param1: "arg1" },
+    });
     const moduleWithParams = constructor.construct(moduleWithParamsDefinition);
 
     assert.isDefined(moduleWithParams);
@@ -40,15 +44,17 @@ describe("getParameter", () => {
 
   it("should allow a parameter to have a default value", () => {
     const moduleWithParamsDefinition = defineModule("Module1", (m) => {
-      const arg1 = m.getParameter<string>("param1", "arg1");
-      const arg2 = m.getParameter<number>("param2", 42);
+      const arg1 = m.getParameter("param1", "arg1");
+      const arg2 = m.getParameter("param2", 42);
       const contract1 = m.contract("Contract1", [arg1, arg2]);
 
       return { contract1 };
     });
 
     const constructor = new ModuleConstructor(0, [], {
-      param1: "overriddenParam",
+      Module1: {
+        param1: "overriddenParam",
+      },
     });
     const moduleWithParams = constructor.construct(moduleWithParamsDefinition);
 


### PR DESCRIPTION
Included both required and optional parameters in the same implementation because it seemed like a clean and simple solution to me. Happy to refactor back to just the `getOptioinalParam` version if we prefer separate implementations like in the old API. 

fixes #226 