### PR TITLE
Add readEventArgument action

### DIFF
--- a/packages/core/src/new-api/internal/module-builder.ts
+++ b/packages/core/src/new-api/internal/module-builder.ts
@@ -599,7 +599,7 @@ export class IgnitionModuleBuilderImplementation<
   private _assertUniqueReadEventArgumentId(futureId: string) {
     return this._assertUniqueFutureId(
       futureId,
-      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.readEventArgument("MyContract", "0x123...", artifact, { id: "MyId"})\``,
+      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.readEventArgument(myContract, "MyEvent", "eventArg", { id: "MyId"})\``,
       this.contractAt
     );
   }

--- a/packages/core/src/new-api/internal/module-builder.ts
+++ b/packages/core/src/new-api/internal/module-builder.ts
@@ -446,12 +446,12 @@ export class IgnitionModuleBuilderImplementation<
   ): ReadEventArgumentFuture {
     const eventIndex = options.eventIndex ?? 0;
 
-    const futureToReadFromsContract =
+    const contractToReadFrom =
       "contract" in futureToReadFrom
         ? futureToReadFrom.contract
         : futureToReadFrom;
 
-    const emitter = options.emitter ?? futureToReadFromsContract;
+    const emitter = options.emitter ?? contractToReadFrom;
 
     const id =
       options.id ??

--- a/packages/core/src/new-api/internal/module.ts
+++ b/packages/core/src/new-api/internal/module.ts
@@ -13,6 +13,7 @@ import {
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
   NamedStaticCallFuture,
+  ReadEventArgumentFuture,
 } from "../types/module";
 
 const customInspectSymbol = Symbol.for("nodejs.util.inspect.custom");
@@ -186,6 +187,23 @@ export class ArtifactContractAtFutureImplementation
     public readonly artifact: ArtifactType
   ) {
     super(id, FutureType.ARTIFACT_CONTRACT_AT, module);
+  }
+}
+
+export class ReadEventArgumentFutureImplementation
+  extends BaseFuture<FutureType.READ_EVENT_ARGUMENT, any>
+  implements ReadEventArgumentFuture
+{
+  constructor(
+    public readonly id: string,
+    public readonly module: IgnitionModuleImplementation,
+    public readonly futureToReadFrom: Future<any>,
+    public readonly eventName: string,
+    public readonly argumentName: string,
+    public readonly emitter: ContractFuture<string>,
+    public readonly eventIndex: number
+  ) {
+    super(id, FutureType.READ_EVENT_ARGUMENT, module);
   }
 }
 

--- a/packages/core/src/new-api/types/execution-state.ts
+++ b/packages/core/src/new-api/types/execution-state.ts
@@ -139,11 +139,15 @@ type ContractAtExecutionState = BaseExecutionState<
   FutureType.NAMED_CONTRACT_AT | FutureType.ARTIFACT_CONTRACT_AT
 >;
 
+type ReadEventArgumentExecutionState =
+  BaseExecutionState<FutureType.READ_EVENT_ARGUMENT>;
+
 export type ExecutionState =
   | DeploymentExecutionState
   | CallExecutionState
   | StaticCallExecutionState
-  | ContractAtExecutionState;
+  | ContractAtExecutionState
+  | ReadEventArgumentExecutionState;
 
 export interface ExecutionStateMap {
   [key: string]: ExecutionState;

--- a/packages/core/src/new-api/types/module-builder.ts
+++ b/packages/core/src/new-api/types/module-builder.ts
@@ -12,6 +12,7 @@ import {
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
   NamedStaticCallFuture,
+  ReadEventArgumentFuture,
 } from "./module";
 
 /**
@@ -112,6 +113,30 @@ export interface ContractAtOptions {
 }
 
 /**
+ * The options for a `readEventArgument` call.
+ *
+ * @beta
+ */
+export interface ReadEventArgumentOptions {
+  /**
+   * The future id.
+   */
+  id?: string;
+
+  /**
+   * The contract that emitted the event. If omitted the contract associated with
+   * the future you are reading the event from will be used.
+   */
+  emitter?: ContractFuture<string>;
+
+  /**
+   * If multiple events with the same name were emitted by the contract, you can
+   * choose which of those to read from by specifying its index (0-indexed).
+   */
+  eventIndex?: number;
+}
+
+/**
  * The build api for configuring a deployment within a module.
  *
  * @beta
@@ -175,6 +200,16 @@ export interface IgnitionModuleBuilder {
     parameterName: string,
     defaultValue?: ParamType
   ): ParamType;
+
+  readEventArgument(
+    futureToReadFrom:
+      | NamedContractDeploymentFuture<string>
+      | ArtifactContractDeploymentFuture
+      | NamedContractCallFuture<string, string>,
+    eventName: string,
+    argumentName: string,
+    options?: ReadEventArgumentOptions
+  ): ReadEventArgumentFuture;
 
   useModule<
     ModuleIdT extends string,

--- a/packages/core/src/new-api/types/module.ts
+++ b/packages/core/src/new-api/types/module.ts
@@ -14,6 +14,7 @@ export enum FutureType {
   NAMED_STATIC_CALL,
   NAMED_CONTRACT_AT,
   ARTIFACT_CONTRACT_AT,
+  READ_EVENT_ARGUMENT,
 }
 
 /**
@@ -165,6 +166,21 @@ export interface ArtifactContractAtFuture extends ContractFuture<string> {
   type: FutureType.ARTIFACT_CONTRACT_AT;
   address: string | NamedStaticCallFuture<string, string>;
   artifact: ArtifactType;
+}
+
+/**
+ * A future that represents reading an argument of an event emitted by the
+ * transaction that executed another future.
+ *
+ * @beta
+ */
+export interface ReadEventArgumentFuture extends Future<any> {
+  type: FutureType.READ_EVENT_ARGUMENT;
+  futureToReadFrom: Future<any>;
+  eventName: string;
+  argumentName: string;
+  emitter: ContractFuture<string>;
+  eventIndex: number;
 }
 
 /**

--- a/packages/core/src/new-api/types/serialized-deployment.ts
+++ b/packages/core/src/new-api/types/serialized-deployment.ts
@@ -160,6 +160,20 @@ export interface SerializedArtifactContractAtFuture
 }
 
 /**
+ * The serialized version of ReadEventArgumentFuture.
+ *
+ * @beta
+ */
+export interface SerializedReadEventAgument extends BaseSerializedFuture {
+  type: FutureType.READ_EVENT_ARGUMENT;
+  futureToReadFrom: FutureToken;
+  eventName: string;
+  argumentName: string;
+  emitter: FutureToken;
+  eventIndex: number;
+}
+
+/**
  * The details of a deployment that will be used in the UI.
  *
  * @beta
@@ -253,4 +267,5 @@ export type SerializedFuture =
   | SerializedNamedContractCallFuture
   | SerializedNamedStaticCallFuture
   | SerializedNamedContractAtFuture
-  | SerializedArtifactContractAtFuture;
+  | SerializedArtifactContractAtFuture
+  | SerializedReadEventAgument;

--- a/packages/core/test/new-api/readEventArgument.ts
+++ b/packages/core/test/new-api/readEventArgument.ts
@@ -1,0 +1,211 @@
+import { assert } from "chai";
+
+import { FutureType, ReadEventArgumentFuture } from "../../src";
+import { defineModule } from "../../src/new-api/define-module";
+import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
+
+describe("Read event argument", () => {
+  describe("creating modules with it", () => {
+    it("Should support reading arguments from all the futures that can emit them", () => {
+      const fakeArtifact = {} as any;
+
+      const defintion = defineModule("Module1", (m) => {
+        const contract = m.contract("Contract");
+        const contractFromArtifact = m.contractFromArtifact(
+          "ContractFromArtifact",
+          fakeArtifact
+        );
+        const call = m.call(contract, "fuc");
+
+        m.readEventArgument(contract, "EventName1", "arg1");
+        m.readEventArgument(contractFromArtifact, "EventName2", "arg2");
+        m.readEventArgument(call, "EventName3", "arg3");
+
+        return { contract, contractFromArtifact };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const mod = constructor.construct(defintion);
+
+      const callFuture = Array.from(mod.futures).find(
+        (f) => f.type === FutureType.NAMED_CONTRACT_CALL
+      );
+
+      const [read1, read2, read3] = Array.from(mod.futures).filter(
+        (f) => f.type === FutureType.READ_EVENT_ARGUMENT
+      ) as ReadEventArgumentFuture[];
+
+      assert.equal(read1.futureToReadFrom, mod.results.contract);
+      assert.equal(read2.futureToReadFrom, mod.results.contractFromArtifact);
+      assert.equal(read3.futureToReadFrom, callFuture);
+    });
+
+    it("Should infer the emitter from the future correctly", () => {
+      const defintion = defineModule("Module1", (m) => {
+        const contract = m.contract("Contract");
+        const call = m.call(contract, "fuc");
+
+        m.readEventArgument(contract, "EventName1", "arg1");
+        m.readEventArgument(call, "EventName2", "arg2");
+
+        return { contract };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const mod = constructor.construct(defintion);
+
+      const [read1, read2] = Array.from(mod.futures).filter(
+        (f) => f.type === FutureType.READ_EVENT_ARGUMENT
+      ) as ReadEventArgumentFuture[];
+
+      assert.equal(read1.emitter, mod.results.contract);
+      assert.equal(read2.emitter, mod.results.contract);
+    });
+
+    it("Should accept an explicit emitter", () => {
+      const defintion = defineModule("Module1", (m) => {
+        const contract = m.contract("Contract");
+        const call = m.call(contract, "fuc");
+
+        const contract2 = m.contract("Contract2");
+
+        m.readEventArgument(contract, "EventName1", "arg1");
+        m.readEventArgument(call, "EventName2", "arg2", { emitter: contract2 });
+
+        return { contract, contract2 };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const mod = constructor.construct(defintion);
+
+      const [read1, read2] = Array.from(mod.futures).filter(
+        (f) => f.type === FutureType.READ_EVENT_ARGUMENT
+      ) as ReadEventArgumentFuture[];
+
+      assert.equal(read1.emitter, mod.results.contract);
+      assert.equal(read2.emitter, mod.results.contract2);
+    });
+
+    it("Should set the right eventName and argumentName", () => {
+      const defintion = defineModule("Module1", (m) => {
+        const contract = m.contract("Contract");
+        const call = m.call(contract, "fuc");
+
+        m.readEventArgument(contract, "EventName1", "arg1");
+        m.readEventArgument(call, "EventName2", "arg2");
+
+        return { contract };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const mod = constructor.construct(defintion);
+
+      const [read1, read2] = Array.from(mod.futures).filter(
+        (f) => f.type === FutureType.READ_EVENT_ARGUMENT
+      ) as ReadEventArgumentFuture[];
+
+      assert.equal(read1.eventName, "EventName1");
+      assert.equal(read1.argumentName, "arg1");
+
+      assert.equal(read2.eventName, "EventName2");
+      assert.equal(read2.argumentName, "arg2");
+    });
+
+    it("Should default the eventIndex to 0", () => {
+      const defintion = defineModule("Module1", (m) => {
+        const contract = m.contract("Contract");
+
+        m.readEventArgument(contract, "EventName1", "arg1");
+
+        return { contract };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const mod = constructor.construct(defintion);
+
+      const [read1] = Array.from(mod.futures).filter(
+        (f) => f.type === FutureType.READ_EVENT_ARGUMENT
+      ) as ReadEventArgumentFuture[];
+
+      assert.equal(read1.eventIndex, 0);
+    });
+
+    it("Should accept an explicit eventIndex", () => {
+      const defintion = defineModule("Module1", (m) => {
+        const contract = m.contract("Contract");
+
+        m.readEventArgument(contract, "EventName1", "arg1", { eventIndex: 1 });
+
+        return { contract };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const mod = constructor.construct(defintion);
+
+      const [read1] = Array.from(mod.futures).filter(
+        (f) => f.type === FutureType.READ_EVENT_ARGUMENT
+      ) as ReadEventArgumentFuture[];
+
+      assert.equal(read1.eventIndex, 1);
+    });
+  });
+
+  describe("using the values", () => {
+    // TODO
+  });
+
+  describe("passing ids", () => {
+    it("Should have a default id based on the emitter's contract name, the event name, argument and index", () => {
+      const defintion = defineModule("Module1", (m) => {
+        const main = m.contract("Main");
+        const emitter = m.contract("Emitter");
+
+        m.readEventArgument(main, "EventName", "arg1");
+        m.readEventArgument(main, "EventName2", "arg2", {
+          emitter,
+          eventIndex: 1,
+        });
+
+        return { main, emitter };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const mod = constructor.construct(defintion);
+
+      assert.equal(mod.id, "Module1");
+      const futuresIds = Array.from(mod.futures).map((f) => f.id);
+
+      assert.include(futuresIds, "Module1:Main#EventName#arg1#0");
+      assert.include(futuresIds, "Module1:Emitter#EventName2#arg2#1");
+    });
+
+    it("Should be able to read the same argument twice by passing a explicit id", () => {
+      const moduleWithSameReadEventArgumentTwiceDefinition = defineModule(
+        "Module1",
+        (m) => {
+          const example = m.contract("Example");
+
+          m.readEventArgument(example, "EventName", "arg1");
+          m.readEventArgument(example, "EventName", "arg1", {
+            id: "second",
+          });
+
+          return { example };
+        }
+      );
+
+      const constructor = new ModuleConstructor(0, []);
+      const moduleWithSameReadEventArgumentTwice = constructor.construct(
+        moduleWithSameReadEventArgumentTwiceDefinition
+      );
+
+      assert.equal(moduleWithSameReadEventArgumentTwice.id, "Module1");
+      const futuresIds = Array.from(
+        moduleWithSameReadEventArgumentTwice.futures
+      ).map((f) => f.id);
+
+      assert.include(futuresIds, "Module1:Example#EventName#arg1#0");
+      assert.include(futuresIds, "Module1:second");
+    });
+  });
+});

--- a/packages/core/test/new-api/readEventArgument.ts
+++ b/packages/core/test/new-api/readEventArgument.ts
@@ -6,7 +6,7 @@ import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 
 describe("Read event argument", () => {
   describe("creating modules with it", () => {
-    it("Should support reading arguments from all the futures that can emit them", () => {
+    it("should support reading arguments from all the futures that can emit them", () => {
       const fakeArtifact = {} as any;
 
       const defintion = defineModule("Module1", (m) => {
@@ -40,7 +40,7 @@ describe("Read event argument", () => {
       assert.equal(read3.futureToReadFrom, callFuture);
     });
 
-    it("Should infer the emitter from the future correctly", () => {
+    it("should infer the emitter from the future correctly", () => {
       const defintion = defineModule("Module1", (m) => {
         const contract = m.contract("Contract");
         const call = m.call(contract, "fuc");
@@ -62,7 +62,7 @@ describe("Read event argument", () => {
       assert.equal(read2.emitter, mod.results.contract);
     });
 
-    it("Should accept an explicit emitter", () => {
+    it("should accept an explicit emitter", () => {
       const defintion = defineModule("Module1", (m) => {
         const contract = m.contract("Contract");
         const call = m.call(contract, "fuc");
@@ -86,7 +86,7 @@ describe("Read event argument", () => {
       assert.equal(read2.emitter, mod.results.contract2);
     });
 
-    it("Should set the right eventName and argumentName", () => {
+    it("should set the right eventName and argumentName", () => {
       const defintion = defineModule("Module1", (m) => {
         const contract = m.contract("Contract");
         const call = m.call(contract, "fuc");
@@ -111,7 +111,7 @@ describe("Read event argument", () => {
       assert.equal(read2.argumentName, "arg2");
     });
 
-    it("Should default the eventIndex to 0", () => {
+    it("should default the eventIndex to 0", () => {
       const defintion = defineModule("Module1", (m) => {
         const contract = m.contract("Contract");
 
@@ -130,7 +130,7 @@ describe("Read event argument", () => {
       assert.equal(read1.eventIndex, 0);
     });
 
-    it("Should accept an explicit eventIndex", () => {
+    it("should accept an explicit eventIndex", () => {
       const defintion = defineModule("Module1", (m) => {
         const contract = m.contract("Contract");
 
@@ -155,7 +155,7 @@ describe("Read event argument", () => {
   });
 
   describe("passing ids", () => {
-    it("Should have a default id based on the emitter's contract name, the event name, argument and index", () => {
+    it("should have a default id based on the emitter's contract name, the event name, argument and index", () => {
       const defintion = defineModule("Module1", (m) => {
         const main = m.contract("Main");
         const emitter = m.contract("Emitter");
@@ -179,7 +179,7 @@ describe("Read event argument", () => {
       assert.include(futuresIds, "Module1:Emitter#EventName2#arg2#1");
     });
 
-    it("Should be able to read the same argument twice by passing a explicit id", () => {
+    it("should be able to read the same argument twice by passing a explicit id", () => {
       const moduleWithSameReadEventArgumentTwiceDefinition = defineModule(
         "Module1",
         (m) => {

--- a/packages/core/test/new-api/readEventArgument.ts
+++ b/packages/core/test/new-api/readEventArgument.ts
@@ -64,15 +64,14 @@ describe("Read event argument", () => {
 
     it("should accept an explicit emitter", () => {
       const defintion = defineModule("Module1", (m) => {
-        const contract = m.contract("Contract");
-        const call = m.call(contract, "fuc");
+        const contract = m.contract("ContractThatCallsEmitter");
+        const emitter = m.contract("ContractThatEmittsEvent2");
+        const call = m.call(contract, "doSomethingAndCallThEmitter", [emitter]);
 
-        const contract2 = m.contract("Contract2");
+        m.readEventArgument(contract, "EventEmittedDuringConstruction", "arg1");
+        m.readEventArgument(call, "Event2", "arg2", { emitter });
 
-        m.readEventArgument(contract, "EventName1", "arg1");
-        m.readEventArgument(call, "EventName2", "arg2", { emitter: contract2 });
-
-        return { contract, contract2 };
+        return { contract, emitter };
       });
 
       const constructor = new ModuleConstructor(0, []);
@@ -83,7 +82,7 @@ describe("Read event argument", () => {
       ) as ReadEventArgumentFuture[];
 
       assert.equal(read1.emitter, mod.results.contract);
-      assert.equal(read2.emitter, mod.results.contract2);
+      assert.equal(read2.emitter, mod.results.emitter);
     });
 
     it("should set the right eventName and argumentName", () => {

--- a/packages/core/test/new-api/stored-deployment-serializer.ts
+++ b/packages/core/test/new-api/stored-deployment-serializer.ts
@@ -442,6 +442,29 @@ describe("stored deployment serializer", () => {
         module,
       });
     });
+
+    it("Should serialize readEventArgument", () => {
+      const moduleDefinition = defineModule("Module1", (m) => {
+        const contract1 = m.contract("Contract1");
+        const emitter = m.contract("Emitter");
+
+        m.readEventArgument(contract1, "EventName", "argumentName", {
+          id: "customId",
+          emitter,
+          eventIndex: 123,
+        });
+
+        return { contract1 };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const module = constructor.construct(moduleDefinition);
+
+      assertSerializableModuleIn({
+        details,
+        module,
+      });
+    });
   });
 
   describe("useModule", () => {

--- a/packages/ui/src/pages/future-details/components/future-summary.tsx
+++ b/packages/ui/src/pages/future-details/components/future-summary.tsx
@@ -54,6 +54,8 @@ function resolveTitleFor(future: UiFuture): string {
       return `Existing contract from Artifact - ${future.contractName} (${
         typeof future.address === "string" ? future.address : future.address.id
       })`;
+    case FutureType.READ_EVENT_ARGUMENT:
+      return `Read event argument from future - ${future.id}`;
   }
 }
 
@@ -148,6 +150,18 @@ const FutureDetailsSection: React.FC<{ future: UiFuture }> = ({ future }) => {
               ? future.address
               : future.address.id}
           </p>
+        </div>
+      );
+    case FutureType.READ_EVENT_ARGUMENT:
+      return (
+        <div>
+          <p>Future - {future.futureToReadFrom.id}</p>
+          {future.futureToReadFrom !== future.emitter ? (
+            <p>Emitter - {future.emitter.id}</p>
+          ) : null}
+          <p>Event - {future.eventName}</p>
+          <p>Event index - {future.eventIndex}</p>
+          <p>Argument - {future.argumentName}</p>
         </div>
       );
   }

--- a/packages/ui/src/pages/plan-overview/components/action.tsx
+++ b/packages/ui/src/pages/plan-overview/components/action.tsx
@@ -44,8 +44,6 @@ function toDisplayText(future: UiFuture): string {
       return `Existing contract ${future.contractName} from artifact (${
         typeof future.address === "string" ? future.address : future.address.id
       })`;
-    case FutureType.CONTRACT_AT:
-      return `Existing contract ${future.contractName} (${future.address})`;
     case FutureType.READ_EVENT_ARGUMENT:
       return `Read event from future ${future.futureToReadFrom.id} (event ${future.eventName} argument ${future.argumentName})`;
   }

--- a/packages/ui/src/pages/plan-overview/components/action.tsx
+++ b/packages/ui/src/pages/plan-overview/components/action.tsx
@@ -44,6 +44,10 @@ function toDisplayText(future: UiFuture): string {
       return `Existing contract ${future.contractName} from artifact (${
         typeof future.address === "string" ? future.address : future.address.id
       })`;
+    case FutureType.CONTRACT_AT:
+      return `Existing contract ${future.contractName} (${future.address})`;
+    case FutureType.READ_EVENT_ARGUMENT:
+      return `Read event from future ${future.futureToReadFrom.id} (event ${future.eventName} argument ${future.argumentName})`;
   }
 }
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -7,6 +7,7 @@ import {
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
   NamedStaticCallFuture,
+  ReadEventArgumentFuture,
 } from "@ignored/ignition-core/ui-helpers";
 
 export type UiContractFuture =
@@ -23,4 +24,8 @@ export type UiContractAtFuture =
   | NamedContractAtFuture<string>
   | ArtifactContractAtFuture;
 
-export type UiFuture = UiContractFuture | UiCallFuture | UiContractAtFuture;
+export type UiFuture =
+  | UiContractFuture
+  | UiCallFuture
+  | UiContractAtFuture
+  | ReadEventArgumentFuture;

--- a/packages/ui/src/utils/to-mermaid.ts
+++ b/packages/ui/src/utils/to-mermaid.ts
@@ -76,5 +76,7 @@ function toLabel(f: UiFuture): string {
       return `Existing contract from artifact ${f.contractName} (${
         typeof f.address === "string" ? f.address : f.address.id
       })`;
+    case FutureType.READ_EVENT_ARGUMENT:
+      return `Read event from future ${f.futureToReadFrom.id} (event ${f.eventName} argument ${f.argumentName})`;
   }
 }


### PR DESCRIPTION
This PR adds ModuleBuilder#readEventArgument.

It also fixes an error message that I believe got outdated due to a merging order issue.

I intentionally left out of this PR using the values read by these futures, as I think that requires some work across the whole module api.