### PR TITLE
Support passing futures as addresses in contractAt

### DIFF
--- a/packages/core/src/new-api/internal/module-builder.ts
+++ b/packages/core/src/new-api/internal/module-builder.ts
@@ -354,12 +354,12 @@ export class IgnitionModuleBuilderImplementation<
 
   public contractAt(
     contractName: string,
-    address: string,
+    address: string | NamedStaticCallFuture<string, string>,
     artifact: ArtifactType,
     options: ContractAtOptions = {}
   ): ContractAtFuture {
-    const id = options.id ?? address;
-    const futureId = `${this._module.id}:${contractName}:${id}`;
+    const id = options.id ?? contractName;
+    const futureId = `${this._module.id}:${id}`;
 
     this._assertUniqueContractAtId(futureId);
 
@@ -373,6 +373,10 @@ export class IgnitionModuleBuilderImplementation<
 
     for (const afterFuture of (options.after ?? []).filter(isFuture)) {
       future.dependencies.add(afterFuture);
+    }
+
+    if (typeof address !== "string") {
+      future.dependencies.add(address);
     }
 
     this._module.futures.add(future);
@@ -498,7 +502,7 @@ export class IgnitionModuleBuilderImplementation<
   private _assertUniqueContractAtId(futureId: string) {
     return this._assertUniqueFutureId(
       futureId,
-      `Contracts must have unique ids, ${futureId} has already been used, ensure the id passed is unique \`m.contractAt("MyContract", "0x123...", artifact, { id: "MyId"})\``,
+      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contractAt("MyContract", "0x123...", artifact, { id: "MyId"})\``,
       this.contractAt
     );
   }

--- a/packages/core/src/new-api/internal/module-builder.ts
+++ b/packages/core/src/new-api/internal/module-builder.ts
@@ -4,13 +4,14 @@ import { inspect } from "util";
 import { IgnitionValidationError } from "../../errors";
 import { ArtifactType, SolidityParamType, SolidityParamsType } from "../stubs";
 import {
+  ArtifactContractAtFuture,
   ArtifactContractDeploymentFuture,
   ArtifactLibraryDeploymentFuture,
-  ContractAtFuture,
   ContractFuture,
   IgnitionModule,
   IgnitionModuleResult,
   ModuleParameters,
+  NamedContractAtFuture,
   NamedContractCallFuture,
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
@@ -28,10 +29,11 @@ import {
 } from "../types/module-builder";
 
 import {
+  ArtifactContractAtFutureImplementation,
   ArtifactContractDeploymentFutureImplementation,
   ArtifactLibraryDeploymentFutureImplementation,
-  ContractAtFutureImplementation,
   IgnitionModuleImplementation,
+  NamedContractAtFutureImplementation,
   NamedContractCallFutureImplementation,
   NamedContractDeploymentFutureImplementation,
   NamedLibraryDeploymentFutureImplementation,
@@ -352,18 +354,48 @@ export class IgnitionModuleBuilderImplementation<
     return future;
   }
 
-  public contractAt(
-    contractName: string,
+  public contractAt<ContractNameT extends string>(
+    contractName: ContractNameT,
     address: string | NamedStaticCallFuture<string, string>,
-    artifact: ArtifactType,
     options: ContractAtOptions = {}
-  ): ContractAtFuture {
+  ): NamedContractAtFuture<ContractNameT> {
     const id = options.id ?? contractName;
     const futureId = `${this._module.id}:${id}`;
 
     this._assertUniqueContractAtId(futureId);
 
-    const future = new ContractAtFutureImplementation(
+    const future = new NamedContractAtFutureImplementation(
+      futureId,
+      this._module,
+      contractName,
+      address
+    );
+
+    for (const afterFuture of (options.after ?? []).filter(isFuture)) {
+      future.dependencies.add(afterFuture);
+    }
+
+    if (typeof address !== "string") {
+      future.dependencies.add(address);
+    }
+
+    this._module.futures.add(future);
+
+    return future;
+  }
+
+  public contractAtFromArtifact(
+    contractName: string,
+    address: string | NamedStaticCallFuture<string, string>,
+    artifact: ArtifactType,
+    options: ContractAtOptions = {}
+  ): ArtifactContractAtFuture {
+    const id = options.id ?? contractName;
+    const futureId = `${this._module.id}:${id}`;
+
+    this._assertUniqueContractAtFromArtifactId(futureId);
+
+    const future = new ArtifactContractAtFutureImplementation(
       futureId,
       this._module,
       contractName,
@@ -504,6 +536,14 @@ export class IgnitionModuleBuilderImplementation<
       futureId,
       `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contractAt("MyContract", "0x123...", artifact, { id: "MyId"})\``,
       this.contractAt
+    );
+  }
+
+  private _assertUniqueContractAtFromArtifactId(futureId: string) {
+    return this._assertUniqueFutureId(
+      futureId,
+      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contractAtFromArtifact("MyContract", "0x123...", { id: "MyId"})\``,
+      this.contractAtFromArtifact
     );
   }
 }

--- a/packages/core/src/new-api/internal/module.ts
+++ b/packages/core/src/new-api/internal/module.ts
@@ -167,7 +167,7 @@ export class ContractAtFutureImplementation<ContractNameT extends string>
     public readonly id: string,
     public readonly module: IgnitionModuleImplementation,
     public readonly contractName: ContractNameT,
-    public readonly address: string,
+    public readonly address: string | NamedStaticCallFuture<string, string>,
     public readonly artifact: ArtifactType
   ) {
     super(id, FutureType.CONTRACT_AT, module);

--- a/packages/core/src/new-api/internal/module.ts
+++ b/packages/core/src/new-api/internal/module.ts
@@ -1,13 +1,14 @@
 import { ArtifactType, SolidityParamsType } from "../stubs";
 import {
+  ArtifactContractAtFuture,
   ArtifactContractDeploymentFuture,
   ArtifactLibraryDeploymentFuture,
-  ContractAtFuture,
   ContractFuture,
   Future,
   FutureType,
   IgnitionModule,
   IgnitionModuleResult,
+  NamedContractAtFuture,
   NamedContractCallFuture,
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
@@ -159,18 +160,32 @@ export class NamedStaticCallFutureImplementation<
   }
 }
 
-export class ContractAtFutureImplementation<ContractNameT extends string>
-  extends BaseFuture<FutureType.CONTRACT_AT, string>
-  implements ContractAtFuture
+export class NamedContractAtFutureImplementation<ContractNameT extends string>
+  extends BaseFuture<FutureType.NAMED_CONTRACT_AT, string>
+  implements NamedContractAtFuture<ContractNameT>
 {
   constructor(
     public readonly id: string,
     public readonly module: IgnitionModuleImplementation,
     public readonly contractName: ContractNameT,
+    public readonly address: string | NamedStaticCallFuture<string, string>
+  ) {
+    super(id, FutureType.NAMED_CONTRACT_AT, module);
+  }
+}
+
+export class ArtifactContractAtFutureImplementation
+  extends BaseFuture<FutureType.ARTIFACT_CONTRACT_AT, string>
+  implements ArtifactContractAtFuture
+{
+  constructor(
+    public readonly id: string,
+    public readonly module: IgnitionModuleImplementation,
+    public readonly contractName: string,
     public readonly address: string | NamedStaticCallFuture<string, string>,
     public readonly artifact: ArtifactType
   ) {
-    super(id, FutureType.CONTRACT_AT, module);
+    super(id, FutureType.ARTIFACT_CONTRACT_AT, module);
   }
 }
 

--- a/packages/core/src/new-api/stored-deployment-serializer.ts
+++ b/packages/core/src/new-api/stored-deployment-serializer.ts
@@ -273,8 +273,8 @@ export class StoredDeploymentSerializer {
             partialFutureLookup[
               (
                 (serializedFuture as SerializedNamedContractAtFuture)
-                  .address as unknown as NamedStaticCallFuture<string, string>
-              ).id
+                  .address as unknown as FutureToken
+              ).futureId
             ] as NamedStaticCallFuture<string, string>
           );
         }
@@ -286,8 +286,8 @@ export class StoredDeploymentSerializer {
             partialFutureLookup[
               (
                 (serializedFuture as SerializedArtifactContractAtFuture)
-                  .address as unknown as NamedStaticCallFuture<string, string>
-              ).id
+                  .address as unknown as FutureToken
+              ).futureId
             ] as NamedStaticCallFuture<string, string>
           );
         }

--- a/packages/core/src/new-api/types/execution-state.ts
+++ b/packages/core/src/new-api/types/execution-state.ts
@@ -135,7 +135,9 @@ type CallExecutionState = BaseExecutionState<FutureType.NAMED_CONTRACT_CALL>;
 type StaticCallExecutionState =
   BaseExecutionState<FutureType.NAMED_STATIC_CALL>;
 
-type ContractAtExecutionState = BaseExecutionState<FutureType.CONTRACT_AT>;
+type ContractAtExecutionState = BaseExecutionState<
+  FutureType.NAMED_CONTRACT_AT | FutureType.ARTIFACT_CONTRACT_AT
+>;
 
 export type ExecutionState =
   | DeploymentExecutionState

--- a/packages/core/src/new-api/types/module-builder.ts
+++ b/packages/core/src/new-api/types/module-builder.ts
@@ -159,7 +159,7 @@ export interface IgnitionModuleBuilder {
 
   contractAt(
     contractName: string,
-    address: string,
+    address: string | NamedStaticCallFuture<string, string>,
     artifact: ArtifactType,
     options?: ContractAtOptions
   ): ContractAtFuture;

--- a/packages/core/src/new-api/types/module-builder.ts
+++ b/packages/core/src/new-api/types/module-builder.ts
@@ -1,12 +1,13 @@
 import { ArtifactType, SolidityParamType, SolidityParamsType } from "../stubs";
 
 import {
+  ArtifactContractAtFuture,
   ArtifactContractDeploymentFuture,
   ArtifactLibraryDeploymentFuture,
-  ContractAtFuture,
   ContractFuture,
   Future,
   IgnitionModuleResult,
+  NamedContractAtFuture,
   NamedContractCallFuture,
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
@@ -157,12 +158,18 @@ export interface IgnitionModuleBuilder {
     options?: StaticCallOptions
   ): NamedStaticCallFuture<ContractNameT, FunctionNameT>;
 
-  contractAt(
+  contractAt<ContractNameT extends string>(
+    contractName: ContractNameT,
+    address: string | NamedStaticCallFuture<string, string>,
+    options?: ContractAtOptions
+  ): NamedContractAtFuture<ContractNameT>;
+
+  contractAtFromArtifact(
     contractName: string,
     address: string | NamedStaticCallFuture<string, string>,
     artifact: ArtifactType,
     options?: ContractAtOptions
-  ): ContractAtFuture;
+  ): ArtifactContractAtFuture;
 
   getParameter<ParamType extends SolidityParamType>(
     parameterName: string,

--- a/packages/core/src/new-api/types/module.ts
+++ b/packages/core/src/new-api/types/module.ts
@@ -12,7 +12,8 @@ export enum FutureType {
   ARTIFACT_LIBRARY_DEPLOYMENT,
   NAMED_CONTRACT_CALL,
   NAMED_STATIC_CALL,
-  CONTRACT_AT,
+  NAMED_CONTRACT_AT,
+  ARTIFACT_CONTRACT_AT,
 }
 
 /**
@@ -144,13 +145,24 @@ export interface NamedStaticCallFuture<
 }
 
 /**
- * A future representing a previously deployed contract at a known address.
+ * A future representing a previously deployed contract at a known address that belongs to this project.
+ *
+ * @beta
+ */
+export interface NamedContractAtFuture<ContractNameT extends string>
+  extends ContractFuture<ContractNameT> {
+  type: FutureType.NAMED_CONTRACT_AT;
+  address: string | NamedStaticCallFuture<string, string>;
+}
+
+/**
+ * A future representing a previously deployed contract at a known address with a given artifact.
  * It may not belong to this project, and we may struggle to type.
  *
  * @beta
  */
-export interface ContractAtFuture extends ContractFuture<string> {
-  type: FutureType.CONTRACT_AT;
+export interface ArtifactContractAtFuture extends ContractFuture<string> {
+  type: FutureType.ARTIFACT_CONTRACT_AT;
   address: string | NamedStaticCallFuture<string, string>;
   artifact: ArtifactType;
 }

--- a/packages/core/src/new-api/types/module.ts
+++ b/packages/core/src/new-api/types/module.ts
@@ -151,7 +151,7 @@ export interface NamedStaticCallFuture<
  */
 export interface ContractAtFuture extends ContractFuture<string> {
   type: FutureType.CONTRACT_AT;
-  address: string;
+  address: string | NamedStaticCallFuture<string, string>;
   artifact: ArtifactType;
 }
 

--- a/packages/core/src/new-api/types/serialized-deployment.ts
+++ b/packages/core/src/new-api/types/serialized-deployment.ts
@@ -136,14 +136,26 @@ export interface SerializedNamedStaticCallFuture extends BaseSerializedFuture {
 }
 
 /**
- * The serialized version of ContractAtFuture.
+ * The serialized version of NamedContractAtFuture.
  *
  * @beta
  */
-export interface SerializedContractAtFuture extends BaseSerializedFuture {
-  type: FutureType.CONTRACT_AT;
+export interface SerializedNamedContractAtFuture extends BaseSerializedFuture {
+  type: FutureType.NAMED_CONTRACT_AT;
   contractName: string;
-  address: string;
+  address: string | FutureToken;
+}
+
+/**
+ * The serialized version of ArtifactContractAtFuture.
+ *
+ * @beta
+ */
+export interface SerializedArtifactContractAtFuture
+  extends BaseSerializedFuture {
+  type: FutureType.ARTIFACT_CONTRACT_AT;
+  contractName: string;
+  address: string | FutureToken;
   artifact: ArtifactType;
 }
 
@@ -240,4 +252,5 @@ export type SerializedFuture =
   | SerializedArtifactLibraryDeploymentFuture
   | SerializedNamedContractCallFuture
   | SerializedNamedStaticCallFuture
-  | SerializedContractAtFuture;
+  | SerializedNamedContractAtFuture
+  | SerializedArtifactContractAtFuture;

--- a/packages/core/test/new-api/contractAtFromArtifact.ts
+++ b/packages/core/test/new-api/contractAtFromArtifact.ts
@@ -3,14 +3,18 @@ import { assert } from "chai";
 import { defineModule } from "../../src/new-api/define-module";
 import { ModuleConstructor } from "../../src/new-api/internal/module-builder";
 
-describe("contractAt", () => {
+describe("contractAtFromArtifactFromArtifact", () => {
   const fakeArtifact: any = {};
 
   it("should be able to setup a contract at a given address", () => {
     const moduleWithContractFromArtifactDefinition = defineModule(
       "Module1",
       (m) => {
-        const contract1 = m.contractAt("Contract1", "0xtest");
+        const contract1 = m.contractAtFromArtifact(
+          "Contract1",
+          "0xtest",
+          fakeArtifact
+        );
 
         return { contract1 };
       }
@@ -48,9 +52,14 @@ describe("contractAt", () => {
       "Module1",
       (m) => {
         const example = m.contract("Example");
-        const another = m.contractAt("Another", "0xtest", {
-          after: [example],
-        });
+        const another = m.contractAtFromArtifact(
+          "Another",
+          "0xtest",
+          fakeArtifact,
+          {
+            after: [example],
+          }
+        );
 
         return { example, another };
       }
@@ -77,7 +86,7 @@ describe("contractAt", () => {
         const example = m.contract("Example");
         const call = m.staticCall(example, "getAddress");
 
-        const another = m.contractAt("Another", call);
+        const another = m.contractAtFromArtifact("Another", call, fakeArtifact);
 
         return { example, another };
       }
@@ -105,16 +114,16 @@ describe("contractAt", () => {
       const moduleWithSameContractTwiceDefinition = defineModule(
         "Module1",
         (m) => {
-          const sameContract1 = m.contractAt(
+          const sameContract1 = m.contractAtFromArtifact(
             "SameContract",
             "0x123",
-
+            fakeArtifact,
             { id: "first" }
           );
-          const sameContract2 = m.contractAt(
+          const sameContract2 = m.contractAtFromArtifact(
             "SameContract",
             "0x123",
-
+            fakeArtifact,
             {
               id: "second",
             }
@@ -142,12 +151,12 @@ describe("contractAt", () => {
 
     it("should throw if the same contract is deployed twice without differentiating ids", () => {
       const moduleDefinition = defineModule("Module1", (m) => {
-        const sameContract1 = m.contractAt(
+        const sameContract1 = m.contractAtFromArtifact(
           "SameContract",
           "0x123",
           fakeArtifact
         );
-        const sameContract2 = m.contractAt(
+        const sameContract2 = m.contractAtFromArtifact(
           "SameContract",
           "0x123",
           fakeArtifact
@@ -166,18 +175,18 @@ describe("contractAt", () => {
 
     it("should throw if a contract tries to pass the same id twice", () => {
       const moduleDefinition = defineModule("Module1", (m) => {
-        const sameContract1 = m.contractAt(
+        const sameContract1 = m.contractAtFromArtifact(
           "SameContract",
           "0x123",
-
+          fakeArtifact,
           {
             id: "same",
           }
         );
-        const sameContract2 = m.contractAt(
+        const sameContract2 = m.contractAtFromArtifact(
           "SameContract",
           "0x123",
-
+          fakeArtifact,
           {
             id: "same",
           }

--- a/packages/core/test/new-api/stored-deployment-serializer.ts
+++ b/packages/core/test/new-api/stored-deployment-serializer.ts
@@ -105,11 +105,9 @@ describe("stored deployment serializer", () => {
   });
 
   describe("contractAt", () => {
-    const fakeArtifact = ["FAKE ARTIFACT"];
-
     it("should serialize a contractAt", () => {
       const moduleDefinition = defineModule("Module1", (m) => {
-        const contract1 = m.contractAt("Contract1", "0x0", fakeArtifact);
+        const contract1 = m.contractAt("Contract1", "0x0");
 
         return { contract1 };
       });
@@ -123,12 +121,108 @@ describe("stored deployment serializer", () => {
       });
     });
 
+    it("should serialize a contractAt with a future address", () => {
+      const moduleDefinition = defineModule("Module1", (m) => {
+        const contract1 = m.contractAt("Contract1", "0x0");
+        const call = m.staticCall(contract1, "getAddress");
+        const contract2 = m.contractAt("Contract2", call);
+
+        return { contract1, contract2 };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const module = constructor.construct(moduleDefinition);
+
+      assertSerializableModuleIn({
+        details,
+        module,
+      });
+    });
+
     it("should serialize a contractAt with dependency", () => {
       const moduleDefinition = defineModule("Module1", (m) => {
-        const contract1 = m.contractAt("Contract1", "0x0", fakeArtifact);
-        const contract2 = m.contractAt("Contract2", "0x0", fakeArtifact, {
+        const contract1 = m.contractAt("Contract1", "0x0");
+        const contract2 = m.contractAt("Contract2", "0x0", {
           after: [contract1],
         });
+
+        return { contract1, contract2 };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const module = constructor.construct(moduleDefinition);
+
+      assertSerializableModuleIn({
+        details,
+        module,
+      });
+    });
+  });
+
+  describe("contractAtFromArtifact", () => {
+    const fakeArtifact = ["FAKE ARTIFACT"];
+
+    it("should serialize a contractAt", () => {
+      const moduleDefinition = defineModule("Module1", (m) => {
+        const contract1 = m.contractAtFromArtifact(
+          "Contract1",
+          "0x0",
+          fakeArtifact
+        );
+
+        return { contract1 };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const module = constructor.construct(moduleDefinition);
+
+      assertSerializableModuleIn({
+        details,
+        module,
+      });
+    });
+
+    it("should serialize a contractAt with a future address", () => {
+      const moduleDefinition = defineModule("Module1", (m) => {
+        const contract1 = m.contractAtFromArtifact(
+          "Contract1",
+          "0x0",
+          fakeArtifact
+        );
+        const call = m.staticCall(contract1, "getAddress");
+        const contract2 = m.contractAtFromArtifact(
+          "Contract2",
+          call,
+          fakeArtifact
+        );
+
+        return { contract1, contract2 };
+      });
+
+      const constructor = new ModuleConstructor(0, []);
+      const module = constructor.construct(moduleDefinition);
+
+      assertSerializableModuleIn({
+        details,
+        module,
+      });
+    });
+
+    it("should serialize a contractAt with dependency", () => {
+      const moduleDefinition = defineModule("Module1", (m) => {
+        const contract1 = m.contractAtFromArtifact(
+          "Contract1",
+          "0x0",
+          fakeArtifact
+        );
+        const contract2 = m.contractAtFromArtifact(
+          "Contract2",
+          "0x0",
+          fakeArtifact,
+          {
+            after: [contract1],
+          }
+        );
 
         return { contract1, contract2 };
       });

--- a/packages/ui/src/pages/future-details/components/future-summary.tsx
+++ b/packages/ui/src/pages/future-details/components/future-summary.tsx
@@ -46,8 +46,14 @@ function resolveTitleFor(future: UiFuture): string {
       return `Call - ${future.contract.contractName}/${future.functionName}`;
     case FutureType.NAMED_STATIC_CALL:
       return `Static call - ${future.contract.contractName}/${future.functionName}`;
-    case FutureType.CONTRACT_AT:
-      return `Existing contract - ${future.contractName} (${future.address})`;
+    case FutureType.NAMED_CONTRACT_AT:
+      return `Existing contract - ${future.contractName} (${
+        typeof future.address === "string" ? future.address : future.address.id
+      })`;
+    case FutureType.ARTIFACT_CONTRACT_AT:
+      return `Existing contract from Artifact - ${future.contractName} (${
+        typeof future.address === "string" ? future.address : future.address.id
+      })`;
   }
 }
 
@@ -119,11 +125,29 @@ const FutureDetailsSection: React.FC<{ future: UiFuture }> = ({ future }) => {
           </ul>
         </div>
       );
-    case FutureType.CONTRACT_AT:
+    case FutureType.NAMED_CONTRACT_AT:
       return (
         <div>
           <p>Contract - {future.contractName}</p>
-          <p>Address - {future.address}</p>
+          <p>
+            Address -{" "}
+            {typeof future.address === "string"
+              ? future.address
+              : future.address.id}
+          </p>
+        </div>
+      );
+
+    case FutureType.ARTIFACT_CONTRACT_AT:
+      return (
+        <div>
+          <p>Contract - {future.contractName}</p>
+          <p>
+            Address -{" "}
+            {typeof future.address === "string"
+              ? future.address
+              : future.address.id}
+          </p>
         </div>
       );
   }

--- a/packages/ui/src/pages/plan-overview/components/action.tsx
+++ b/packages/ui/src/pages/plan-overview/components/action.tsx
@@ -36,8 +36,14 @@ function toDisplayText(future: UiFuture): string {
       return `Call ${future.contract.contractName}/${future.functionName}`;
     case FutureType.NAMED_STATIC_CALL:
       return `Static call ${future.contract.contractName}/${future.functionName}`;
-    case FutureType.CONTRACT_AT:
-      return `Existing contract ${future.contractName} (${future.address})`;
+    case FutureType.NAMED_CONTRACT_AT:
+      return `Existing contract ${future.contractName} (${
+        typeof future.address === "string" ? future.address : future.address.id
+      })`;
+    case FutureType.ARTIFACT_CONTRACT_AT:
+      return `Existing contract ${future.contractName} from artifact (${
+        typeof future.address === "string" ? future.address : future.address.id
+      })`;
   }
 }
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -1,7 +1,8 @@
 import {
+  ArtifactContractAtFuture,
   ArtifactContractDeploymentFuture,
   ArtifactLibraryDeploymentFuture,
-  ContractAtFuture,
+  NamedContractAtFuture,
   NamedContractCallFuture,
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
@@ -18,4 +19,8 @@ export type UiCallFuture =
   | NamedContractCallFuture<string, string>
   | NamedStaticCallFuture<string, string>;
 
-export type UiFuture = UiContractFuture | UiCallFuture | ContractAtFuture;
+export type UiContractAtFuture =
+  | NamedContractAtFuture<string>
+  | ArtifactContractAtFuture;
+
+export type UiFuture = UiContractFuture | UiCallFuture | UiContractAtFuture;

--- a/packages/ui/src/utils/to-mermaid.ts
+++ b/packages/ui/src/utils/to-mermaid.ts
@@ -68,7 +68,13 @@ function toLabel(f: UiFuture): string {
       return `Call ${f.contract.contractName}/${f.functionName}`;
     case FutureType.NAMED_STATIC_CALL:
       return `Static call ${f.contract.contractName}/${f.functionName}`;
-    case FutureType.CONTRACT_AT:
-      return `Existing contract ${f.contractName} (${f.address})`;
+    case FutureType.NAMED_CONTRACT_AT:
+      return `Existing contract ${f.contractName} (${
+        typeof f.address === "string" ? f.address : f.address.id
+      })`;
+    case FutureType.ARTIFACT_CONTRACT_AT:
+      return `Existing contract from artifact ${f.contractName} (${
+        typeof f.address === "string" ? f.address : f.address.id
+      })`;
   }
 }


### PR DESCRIPTION
- added support for passing static call futures into `contractAt` as an address
- added named and artifact variants for `contractAt` futures
- updated plan UI to handle new features

fixes #225 