### PR TITLE
Include Call in Execution (PR 7)

### DIFF
--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -157,20 +157,20 @@ pragma solidity ^0.8.5;
 import "@openzeppelin/contracts/utils/Create2.sol";
 
 contract Create2Factory {
-    event Deployed(bytes32 indexed salt, address deployed);
+  event Deployed(bytes32 indexed salt, address deployed);
 
-    function deploy(
-        uint256 amount,
-        bytes32 salt,
-        bytes memory bytecode
-    ) public returns (address) {
-        address deployedAddress;
+  function deploy(
+    uint256 amount,
+    bytes32 salt,
+    bytes memory bytecode
+  ) public returns (address) {
+    address deployedAddress;
 
-        deployedAddress = Create2.deploy(amount, salt, bytecode);
-        emit Deployed(salt, deployedAddress);
+    deployedAddress = Create2.deploy(amount, salt, bytecode);
+    emit Deployed(salt, deployedAddress);
 
-        return deployedAddress;
-    }
+    return deployedAddress;
+  }
 }
 ```
 

--- a/examples/complete/ignition/CompleteModule.js
+++ b/examples/complete/ignition/CompleteModule.js
@@ -21,7 +21,7 @@ module.exports = defineModule("CompleteModule", (m) => {
 
   m.call(basic, "basicFunction", [40]);
   // const eventArg = m.readEventArgument(call, "BasicEvent", "eventArg");
-  // m.staticCall(withLib, "readonlyFunction", [eventArg]);
+  m.staticCall(withLib, "readonlyFunction", [42]);
 
   // const duplicate = m.contractAt("BasicContract", basic);
   // const duplicateWithLib = m.contractAtFromArtifact(

--- a/examples/complete/ignition/CompleteModule.js
+++ b/examples/complete/ignition/CompleteModule.js
@@ -19,7 +19,7 @@ module.exports = defineModule("CompleteModule", (m) => {
     }
   );
 
-  // const call = m.call(basic, "basicFunction", [40]);
+  m.call(basic, "basicFunction", [40]);
   // const eventArg = m.readEventArgument(call, "BasicEvent", "eventArg");
   // m.staticCall(withLib, "readonlyFunction", [eventArg]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20987,6 +20987,7 @@
         "@ethersproject/address": "5.6.1",
         "debug": "^4.3.2",
         "ethers": "^5.4.7",
+        "fs-extra": "^10.0.0",
         "js-graph-algorithms": "1.0.18",
         "lodash": "4.17.21",
         "ndjson": "2.0.0",

--- a/packages/core/src/new-api/deploy.ts
+++ b/packages/core/src/new-api/deploy.ts
@@ -40,11 +40,8 @@ export function deploy({
 
   const transactionService = new TransactionServiceImplementation(
     deploymentLoader,
-    new EthersChainDispatcher(
-      adapters.signer,
-      adapters.gas,
-      adapters.transactions
-    )
+    adapters.signer,
+    new EthersChainDispatcher(adapters.gas, adapters.transactions)
   );
 
   const deployer = new Deployer({

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -293,7 +293,7 @@ export class ExecutionEngine {
         };
 
         return state;
-      case FutureType.NAMED_CONTRACT_CALL:
+      case FutureType.NAMED_CONTRACT_CALL: {
         const { contractAddress, storedArtifactPath } = executionStateMap[
           future.contract.id
         ] as DeploymentExecutionState;
@@ -319,7 +319,34 @@ export class ExecutionEngine {
           from: resolveFromAddress(future.from, { accounts }),
         };
         return state;
-      case FutureType.NAMED_STATIC_CALL:
+      }
+      case FutureType.NAMED_STATIC_CALL: {
+        const { contractAddress, storedArtifactPath } = executionStateMap[
+          future.contract.id
+        ] as DeploymentExecutionState;
+
+        if (contractAddress === undefined) {
+          throw new Error(
+            "internal error - call executed before contract dependency"
+          );
+        }
+
+        state = {
+          type: "execution-start",
+          futureId: future.id,
+          futureType: future.type,
+          strategy,
+          // status: ExecutionStatus.STARTED,
+          dependencies: [...future.dependencies].map((f) => f.id),
+          // history: [],
+          args: future.args,
+          functionName: future.functionName,
+          contractAddress,
+          storedArtifactPath,
+          from: resolveFromAddress(future.from, { accounts }),
+        };
+        return state;
+      }
       case FutureType.NAMED_CONTRACT_AT:
       case FutureType.ARTIFACT_CONTRACT_AT:
       case FutureType.READ_EVENT_ARGUMENT:

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -19,7 +19,11 @@ import {
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
 } from "../../types/module";
-import { isDeploymentExecutionState } from "../type-guards";
+import {
+  isCallExecutionState,
+  isDeploymentExecutionState,
+  isStaticCallExecutionState,
+} from "../type-guards";
 import {
   ExecutionEngineState,
   ExecutionStrategyContext,
@@ -461,9 +465,12 @@ export class ExecutionEngine {
   ): ExecutionStrategyContext {
     const exState = state.executionStateMap[future.id];
 
-    const sender = isDeploymentExecutionState(exState)
-      ? exState.from ?? state.accounts[0]
-      : undefined;
+    const sender =
+      isDeploymentExecutionState(exState) ||
+      isCallExecutionState(exState) ||
+      isStaticCallExecutionState(exState)
+        ? exState.from ?? state.accounts[0]
+        : undefined;
 
     const context = {
       executionState: exState,

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -294,9 +294,9 @@ export class ExecutionEngine {
 
         return state;
       case FutureType.NAMED_CONTRACT_CALL:
-        const contractAddress = (
-          executionStateMap[future.contract.id] as DeploymentExecutionState
-        ).contractAddress;
+        const { contractAddress, storedArtifactPath } = executionStateMap[
+          future.contract.id
+        ] as DeploymentExecutionState;
 
         assertIgnitionInvariant(
           contractAddress !== undefined,
@@ -314,8 +314,9 @@ export class ExecutionEngine {
           args: future.args,
           functionName: future.functionName,
           contractAddress,
+          storedArtifactPath,
           value: future.value.toString(),
-          from: this._resolveAddress(future.from, { accounts }),
+          from: resolveFromAddress(future.from, { accounts }),
         };
         return state;
       case FutureType.NAMED_STATIC_CALL:

--- a/packages/core/src/new-api/internal/execution/execution-strategy.ts
+++ b/packages/core/src/new-api/internal/execution/execution-strategy.ts
@@ -53,7 +53,7 @@ export class BasicExecutionStrategy
     }
 
     if (isStaticCallExecutionState(executionState)) {
-      return this._executeStaticCall({ executionState, accounts });
+      return this._executeStaticCall({ executionState, sender });
     }
 
     throw new IgnitionError(
@@ -151,15 +151,20 @@ export class BasicExecutionStrategy
 
   private async *_executeStaticCall({
     executionState: staticCallExecutionState,
-    accounts,
+    sender,
   }: {
     executionState: StaticCallExecutionState;
-    accounts: string[];
+    sender?: string;
   }): AsyncGenerator<
     StaticCallInteractionMessage,
     StaticCallExecutionSuccess,
     StaticCallResultMessage | null
   > {
+    assertIgnitionInvariant(
+      sender !== undefined,
+      "Sender must be defined for static call execution"
+    );
+
     const result = yield {
       type: "onchain-action",
       subtype: "static-call",
@@ -168,8 +173,8 @@ export class BasicExecutionStrategy
       contractAddress: staticCallExecutionState.contractAddress,
       storedArtifactPath: staticCallExecutionState.storedArtifactPath,
       args: staticCallExecutionState.args,
-      from: staticCallExecutionState.from ?? accounts[0],
       functionName: staticCallExecutionState.functionName,
+      from: sender,
     };
 
     if (result === null) {

--- a/packages/core/src/new-api/internal/execution/execution-strategy.ts
+++ b/packages/core/src/new-api/internal/execution/execution-strategy.ts
@@ -117,6 +117,7 @@ export class BasicExecutionStrategy
       futureId: callExecutionState.id,
       transactionId: 1,
       contractAddress: callExecutionState.contractAddress,
+      storedArtifactPath: callExecutionState.storedArtifactPath,
       value: callExecutionState.value.toString(),
       args: callExecutionState.args,
       functionName: callExecutionState.functionName,

--- a/packages/core/src/new-api/internal/execution/executionStateReducer.ts
+++ b/packages/core/src/new-api/internal/execution/executionStateReducer.ts
@@ -111,6 +111,7 @@ function initialiseExecutionStateFor(
       dependencies: new Set(futureStart.dependencies),
       history: [],
       contractAddress: futureStart.contractAddress,
+      storedArtifactPath: futureStart.storedArtifactPath,
       args: futureStart.args,
       from: futureStart.from,
       functionName: futureStart.functionName,

--- a/packages/core/src/new-api/internal/execution/guards.ts
+++ b/packages/core/src/new-api/internal/execution/guards.ts
@@ -1,4 +1,5 @@
 import {
+  CallFunctionInteractionMessage,
   DeployContractInteractionMessage,
   DeployedContractExecutionSuccess,
   ExecutionResultMessage,
@@ -50,13 +51,22 @@ export function isOnchainResult(
 export function isOnchainInteractionMessage(
   potential: JournalableMessage
 ): potential is OnchainInteractionMessage {
-  return isDeployContractInteraction(potential);
+  return (
+    isDeployContractInteraction(potential) ||
+    isCallFunctionInteraction(potential)
+  );
 }
 
 export function isDeployContractInteraction(
   potential: JournalableMessage
 ): potential is DeployContractInteractionMessage {
   return isOnChainAction(potential) && potential.subtype === "deploy-contract";
+}
+
+export function isCallFunctionInteraction(
+  potential: JournalableMessage
+): potential is CallFunctionInteractionMessage {
+  return isOnChainAction(potential) && potential.subtype === "call-function";
 }
 
 export function isDeployedContractExecutionSuccess(

--- a/packages/core/src/new-api/internal/execution/guards.ts
+++ b/packages/core/src/new-api/internal/execution/guards.ts
@@ -54,7 +54,8 @@ export function isOnchainInteractionMessage(
 ): potential is OnchainInteractionMessage {
   return (
     isDeployContractInteraction(potential) ||
-    isCallFunctionInteraction(potential)
+    isCallFunctionInteraction(potential) ||
+    isStaticCallInteraction(potential)
   );
 }
 

--- a/packages/core/src/new-api/internal/execution/guards.ts
+++ b/packages/core/src/new-api/internal/execution/guards.ts
@@ -8,6 +8,7 @@ import {
   JournalableMessage,
   OnchainInteractionMessage,
   OnchainResultMessage,
+  StaticCallInteractionMessage,
 } from "../../types/journal";
 
 export function isExecutionResult(
@@ -67,6 +68,12 @@ export function isCallFunctionInteraction(
   potential: JournalableMessage
 ): potential is CallFunctionInteractionMessage {
   return isOnChainAction(potential) && potential.subtype === "call-function";
+}
+
+export function isStaticCallInteraction(
+  potential: JournalableMessage
+): potential is StaticCallInteractionMessage {
+  return isOnChainAction(potential) && potential.subtype === "static-call";
 }
 
 export function isDeployedContractExecutionSuccess(

--- a/packages/core/src/new-api/internal/journal/type-guards.ts
+++ b/packages/core/src/new-api/internal/journal/type-guards.ts
@@ -1,0 +1,47 @@
+import {
+  CallFunctionStartMessage,
+  DeployContractStartMessage,
+  FutureStartMessage,
+  StaticCallStartMessage,
+} from "../../types/journal";
+import { FutureType } from "../../types/module";
+
+/**
+ * Returns true if potential is a contract deployment start message
+ *
+ * @beta
+ */
+export function isDeployContractStartMessage(
+  potential: FutureStartMessage
+): potential is DeployContractStartMessage {
+  const deploymentTypes = [
+    FutureType.NAMED_CONTRACT_DEPLOYMENT,
+    FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
+    FutureType.NAMED_LIBRARY_DEPLOYMENT,
+    FutureType.ARTIFACT_LIBRARY_DEPLOYMENT,
+  ];
+
+  return deploymentTypes.includes(potential.futureType);
+}
+
+/**
+ * Returns true if potential is a call function start message
+ *
+ * @beta
+ */
+export function isCallFunctionStartMessage(
+  potential: FutureStartMessage
+): potential is CallFunctionStartMessage {
+  return potential.futureType === FutureType.NAMED_CONTRACT_CALL;
+}
+
+/**
+ * Returns true if potential is a call function start message
+ *
+ * @beta
+ */
+export function isStaticCallStartMessage(
+  potential: FutureStartMessage
+): potential is StaticCallStartMessage {
+  return potential.futureType === FutureType.NAMED_STATIC_CALL;
+}

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -135,6 +135,7 @@ export interface DeploymentExecutionState
 
 export interface CallExecutionState
   extends BaseExecutionState<FutureType.NAMED_CONTRACT_CALL> {
+  storedArtifactPath: string; // As stored in the deployment directory.
   contractAddress: string;
   functionName: string;
   args: ArgumentType[];

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -146,6 +146,7 @@ export interface CallExecutionState
 
 export interface StaticCallExecutionState
   extends BaseExecutionState<FutureType.NAMED_STATIC_CALL> {
+  storedArtifactPath: string; // As stored in the deployment directory.
   contractAddress: string;
   functionName: string;
   args: ArgumentType[];

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -140,6 +140,7 @@ export interface CallExecutionState
   args: ArgumentType[];
   value: bigint;
   from: string | undefined;
+  txId?: string;
 }
 
 export interface StaticCallExecutionState

--- a/packages/core/src/new-api/type-guards.ts
+++ b/packages/core/src/new-api/type-guards.ts
@@ -1,6 +1,11 @@
 import { Adapters } from "./types/adapters";
 import { Artifact } from "./types/artifact";
 import {
+  CallFunctionStartMessage,
+  DeployContractStartMessage,
+  FutureStartMessage,
+} from "./types/journal";
+import {
   AccountRuntimeValue,
   AddressResolvableFuture,
   ContractFuture,
@@ -248,4 +253,33 @@ export function isAdapters(potential: unknown): potential is Adapters {
     "gas" in potential &&
     "transactions" in potential
   );
+}
+
+/**
+ * Returns true if potential is a contract deployment start message
+ *
+ * @beta
+ */
+export function isDeployContractStartMessage(
+  potential: FutureStartMessage
+): potential is DeployContractStartMessage {
+  const deploymentTypes = [
+    FutureType.NAMED_CONTRACT_DEPLOYMENT,
+    FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
+    FutureType.NAMED_LIBRARY_DEPLOYMENT,
+    FutureType.ARTIFACT_LIBRARY_DEPLOYMENT,
+  ];
+
+  return deploymentTypes.includes(potential.futureType);
+}
+
+/**
+ * Returns true if potential is a call function start message
+ *
+ * @beta
+ */
+export function isCallFunctionStartMessage(
+  potential: FutureStartMessage
+): potential is CallFunctionStartMessage {
+  return potential.futureType === FutureType.NAMED_CONTRACT_CALL;
 }

--- a/packages/core/src/new-api/type-guards.ts
+++ b/packages/core/src/new-api/type-guards.ts
@@ -1,11 +1,6 @@
 import { Adapters } from "./types/adapters";
 import { Artifact } from "./types/artifact";
 import {
-  CallFunctionStartMessage,
-  DeployContractStartMessage,
-  FutureStartMessage,
-} from "./types/journal";
-import {
   AccountRuntimeValue,
   AddressResolvableFuture,
   ContractFuture,
@@ -253,33 +248,4 @@ export function isAdapters(potential: unknown): potential is Adapters {
     "gas" in potential &&
     "transactions" in potential
   );
-}
-
-/**
- * Returns true if potential is a contract deployment start message
- *
- * @beta
- */
-export function isDeployContractStartMessage(
-  potential: FutureStartMessage
-): potential is DeployContractStartMessage {
-  const deploymentTypes = [
-    FutureType.NAMED_CONTRACT_DEPLOYMENT,
-    FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
-    FutureType.NAMED_LIBRARY_DEPLOYMENT,
-    FutureType.ARTIFACT_LIBRARY_DEPLOYMENT,
-  ];
-
-  return deploymentTypes.includes(potential.futureType);
-}
-
-/**
- * Returns true if potential is a call function start message
- *
- * @beta
- */
-export function isCallFunctionStartMessage(
-  potential: FutureStartMessage
-): potential is CallFunctionStartMessage {
-  return potential.futureType === FutureType.NAMED_CONTRACT_CALL;
 }

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -1,4 +1,4 @@
-import { ArgumentType, FutureType } from "./module";
+import { ArgumentType, FutureType, PrimitiveArgType } from "./module";
 
 /**
  * Store a deployments execution state as a transaction log.
@@ -38,7 +38,8 @@ export type TransactionMessage =
  */
 export type OnchainInteractionMessage =
   | DeployContractInteractionMessage
-  | CallFunctionInteractionMessage;
+  | CallFunctionInteractionMessage
+  | StaticCallInteractionMessage;
 
 /**
  * A on-chain interaction request to deploy a contract/library.
@@ -75,6 +76,23 @@ export interface CallFunctionInteractionMessage {
   from: string;
 }
 
+/**
+ * A on-chain interaction request to statically call a function.
+ *
+ * @beta
+ */
+export interface StaticCallInteractionMessage {
+  type: "onchain-action";
+  subtype: "static-call";
+  futureId: string;
+  transactionId: number;
+  args: ArgumentType[];
+  functionName: string;
+  contractAddress: string;
+  storedArtifactPath: string;
+  from: string;
+}
+
 // #endregion
 
 // #region "OnchainResult"
@@ -86,7 +104,8 @@ export interface CallFunctionInteractionMessage {
  */
 export type OnchainResultMessage =
   | DeployContractResultMessage
-  | CallFunctionResultMessage;
+  | CallFunctionResultMessage
+  | StaticCallResultMessage;
 
 /**
  * A successful deploy contract transaction result.
@@ -112,6 +131,19 @@ export interface CallFunctionResultMessage {
   futureId: string;
   transactionId: number;
   txId: string;
+}
+
+/**
+ * A successful static function call transaction result.
+ *
+ * @beta
+ */
+export interface StaticCallResultMessage {
+  type: "onchain-result";
+  subtype: "static-call";
+  futureId: string;
+  transactionId: number;
+  result: PrimitiveArgType | PrimitiveArgType[];
 }
 
 // #endregion
@@ -143,7 +175,8 @@ export type ExecutionUpdateMessage = FutureStartMessage | FutureRestartMessage;
  */
 export type FutureStartMessage =
   | DeployContractStartMessage
-  | CallFunctionStartMessage;
+  | CallFunctionStartMessage
+  | StaticCallStartMessage;
 
 /**
  * A journal message to initialise the execution state for a contract deployment.
@@ -186,6 +219,24 @@ export interface CallFunctionStartMessage {
   contractAddress: string;
   from: string | undefined;
   storedArtifactPath: string;
+}
+
+/**
+ * A journal message to initialise the execution state for a static call.
+ *
+ * @beta
+ */
+export interface StaticCallStartMessage {
+  type: "execution-start";
+  futureId: string;
+  futureType: FutureType.NAMED_STATIC_CALL;
+  strategy: string;
+  dependencies: string[];
+  args: ArgumentType[];
+  functionName: string;
+  contractAddress: string;
+  storedArtifactPath: string;
+  from: string;
 }
 
 /**
@@ -232,7 +283,8 @@ export type ExecutionResultTypes = [
  */
 export type ExecutionSuccess =
   | DeployedContractExecutionSuccess
-  | CalledFunctionExecutionSuccess;
+  | CalledFunctionExecutionSuccess
+  | StaticCallExecutionSuccess;
 
 /**
  * A journal message indicating a contract/library deployed successfully.
@@ -258,6 +310,20 @@ export interface CalledFunctionExecutionSuccess {
   futureId: string;
   functionName: string;
   txId: string;
+  contractAddress: string;
+}
+
+/**
+ * A journal message indicating a static function was called successfully.
+ *
+ * @beta
+ */
+export interface StaticCallExecutionSuccess {
+  type: "execution-success";
+  subtype: "static-call";
+  futureId: string;
+  functionName: string;
+  result: PrimitiveArgType | PrimitiveArgType[];
   contractAddress: string;
 }
 

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -36,7 +36,9 @@ export type TransactionMessage =
  *
  * @beta
  */
-export type OnchainInteractionMessage = DeployContractInteractionMessage;
+export type OnchainInteractionMessage =
+  | DeployContractInteractionMessage
+  | CallFunctionInteractionMessage;
 
 /**
  * A on-chain interaction request to deploy a contract/library.
@@ -55,6 +57,23 @@ export interface DeployContractInteractionMessage {
   from: string;
 }
 
+/**
+ * A on-chain interaction request to call a function.
+ *
+ * @beta
+ */
+export interface CallFunctionInteractionMessage {
+  type: "onchain-action";
+  subtype: "call-function";
+  futureId: string;
+  transactionId: number;
+  args: ArgumentType[];
+  functionName: string;
+  value: string;
+  contractAddress: string;
+  from: string;
+}
+
 // #endregion
 
 // #region "OnchainResult"
@@ -64,7 +83,9 @@ export interface DeployContractInteractionMessage {
  *
  * @beta
  */
-export type OnchainResultMessage = DeployContractResultMessage;
+export type OnchainResultMessage =
+  | DeployContractResultMessage
+  | CallFunctionResultMessage;
 
 /**
  * A successful deploy contract transaction result.
@@ -77,6 +98,19 @@ export interface DeployContractResultMessage {
   futureId: string;
   transactionId: number;
   contractAddress: string;
+}
+
+/**
+ * A successful call function transaction result.
+ *
+ * @beta
+ */
+export interface CallFunctionResultMessage {
+  type: "onchain-result";
+  subtype: "call-function";
+  futureId: string;
+  transactionId: number;
+  txId: string;
 }
 
 // #endregion
@@ -106,10 +140,23 @@ export type ExecutionUpdateMessage = FutureStartMessage | FutureRestartMessage;
  *
  * @beta
  */
-export interface FutureStartMessage {
+export type FutureStartMessage =
+  | DeployContractStartMessage
+  | CallFunctionStartMessage;
+
+/**
+ * A journal message to initialise the execution state for a contract deployment.
+ *
+ * @beta
+ */
+export interface DeployContractStartMessage {
   type: "execution-start";
   futureId: string;
-  futureType: FutureType;
+  futureType:
+    | FutureType.NAMED_CONTRACT_DEPLOYMENT
+    | FutureType.NAMED_LIBRARY_DEPLOYMENT
+    | FutureType.ARTIFACT_CONTRACT_DEPLOYMENT
+    | FutureType.ARTIFACT_LIBRARY_DEPLOYMENT;
   strategy: string;
   dependencies: string[];
   storedArtifactPath: string;
@@ -118,6 +165,24 @@ export interface FutureStartMessage {
   constructorArgs: ArgumentType[];
   libraries: { [key: string]: string };
   value: string;
+  from: string | undefined;
+}
+
+/**
+ * A journal message to initialise the execution state for a function call.
+ *
+ * @beta
+ */
+export interface CallFunctionStartMessage {
+  type: "execution-start";
+  futureId: string;
+  futureType: FutureType.NAMED_CONTRACT_CALL;
+  strategy: string;
+  dependencies: string[];
+  args: ArgumentType[];
+  functionName: string;
+  value: string;
+  contractAddress: string;
   from: string | undefined;
 }
 
@@ -163,7 +228,9 @@ export type ExecutionResultTypes = [
  *
  * @beta
  */
-export type ExecutionSuccess = DeployedContractExecutionSuccess;
+export type ExecutionSuccess =
+  | DeployedContractExecutionSuccess
+  | CalledFunctionExecutionSuccess;
 
 /**
  * A journal message indicating a contract/library deployed successfully.
@@ -175,6 +242,20 @@ export interface DeployedContractExecutionSuccess {
   subtype: "deploy-contract";
   futureId: string;
   contractName: string;
+  contractAddress: string;
+}
+
+/**
+ * A journal message indicating a contract function was called successfully.
+ *
+ * @beta
+ */
+export interface CalledFunctionExecutionSuccess {
+  type: "execution-success";
+  subtype: "call-function";
+  futureId: string;
+  functionName: string;
+  txId: string;
   contractAddress: string;
 }
 

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -71,6 +71,7 @@ export interface CallFunctionInteractionMessage {
   functionName: string;
   value: string;
   contractAddress: string;
+  storedArtifactPath: string;
   from: string;
 }
 
@@ -184,6 +185,7 @@ export interface CallFunctionStartMessage {
   value: string;
   contractAddress: string;
   from: string | undefined;
+  storedArtifactPath: string;
 }
 
 /**

--- a/packages/core/src/new-api/types/module.ts
+++ b/packages/core/src/new-api/types/module.ts
@@ -1,16 +1,20 @@
 import { Artifact } from "./artifact";
 
 /**
+ * Argument type representing primitive values expressed in smart contracts.
+ *
+ * @beta
+ */
+export type PrimitiveArgType = number | bigint | string | boolean;
+
+/**
  * Base argument type that smart contracts can receive in their constructors
  * and functions.
  *
  * @beta
  */
 export type BaseArgumentType =
-  | number
-  | bigint
-  | string
-  | boolean
+  | PrimitiveArgType
   | ContractFuture<string>
   | NamedStaticCallFuture<string, string>
   | ReadEventArgumentFuture

--- a/packages/core/test/new-api/reconciliation/futures/reconcileArtifactContractAt.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileArtifactContractAt.ts
@@ -59,6 +59,7 @@ describe("Reconciliation - artifact contract at", () => {
     dependencies: new Set<string>(),
     history: [],
     contractAddress: exampleAddress,
+    storedArtifactPath: "./artifact.json",
     functionName: "function",
     args: [],
     from: exampleAccounts[0],

--- a/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractAt.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractAt.ts
@@ -51,6 +51,7 @@ describe("Reconciliation - named contract at", () => {
     dependencies: new Set<string>(),
     history: [],
     contractAddress: exampleAddress,
+    storedArtifactPath: "./artifact.json",
     functionName: "function",
     args: [],
     from: exampleAccounts[0],

--- a/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractCall.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractCall.ts
@@ -44,6 +44,7 @@ describe("Reconciliation - named contract call", () => {
     dependencies: new Set<string>(),
     history: [],
     contractAddress: differentAddress,
+    storedArtifactPath: "./artifact.json",
     functionName: "function",
     args: [],
     value: BigInt("0"),

--- a/packages/core/test/new-api/reconciliation/futures/reconcileNamedStaticCall.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileNamedStaticCall.ts
@@ -43,6 +43,7 @@ describe("Reconciliation - named static call", () => {
     dependencies: new Set<string>(),
     history: [],
     contractAddress: exampleAddress,
+    storedArtifactPath: "./artifact.json",
     functionName: "function",
     args: [],
     from: exampleAccounts[0],


### PR DESCRIPTION
- Added support for `m.call(...)` execution
- Added support for `m.staticCall(...)` execution
- Moved `signerAdapter` and contract-specific logic from `ChainDispatcher` to `TransactionService`

fixes #264 