### PR TITLE
fix: execution state from should always be set (PR 6)

### DIFF
--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -1,7 +1,6 @@
 import identity from "lodash/identity";
 
 import { IgnitionError } from "../../../errors";
-import { isRuntimeValue } from "../../type-guards";
 import { ArtifactResolver } from "../../types/artifact";
 import { DeploymentResult } from "../../types/deployer";
 import { DeploymentLoader } from "../../types/deployment-loader";
@@ -12,21 +11,19 @@ import {
   JournalableMessage,
 } from "../../types/journal";
 import {
-  AccountRuntimeValue,
   ArgumentType,
   Future,
   FutureType,
   ModuleParameters,
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
-  RuntimeValueType,
 } from "../../types/module";
-import { accountRuntimeValueToErrorString } from "../reconciliation/utils";
 import { isDeploymentExecutionState } from "../type-guards";
 import { ExecutionEngineState } from "../types/execution-engine";
 import { ExecutionStateMap, ExecutionStatus } from "../types/execution-state";
 import { getFuturesFromModule } from "../utils/get-futures-from-module";
 import { replaceWithinArg } from "../utils/replace-within-arg";
+import { resolveFromAddress } from "../utils/resolve-from-address";
 import { resolveFutureToValue } from "../utils/resolve-future-to-value";
 import { resolveModuleParameter } from "../utils/resolve-module-parameter";
 
@@ -162,32 +159,6 @@ export class ExecutionEngine {
     );
   }
 
-  private _resolveAddress(
-    potential: string | AccountRuntimeValue | undefined,
-    { accounts }: { accounts: string[] }
-  ) {
-    if (typeof potential === "string") {
-      return potential;
-    }
-
-    if (
-      isRuntimeValue(potential) &&
-      potential.type === RuntimeValueType.ACCOUNT
-    ) {
-      return accounts[potential.accountIndex];
-    }
-
-    if (potential === undefined) {
-      return accounts[0];
-    }
-
-    throw new IgnitionError(
-      `Unable to resolve address: ${accountRuntimeValueToErrorString(
-        potential
-      )} `
-    );
-  }
-
   private async _initCommandFor(
     future: Future,
     {
@@ -230,7 +201,7 @@ export class ExecutionEngine {
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
-          from: this._resolveAddress(future.from, { accounts }),
+          from: resolveFromAddress(future.from, { accounts }),
         };
 
         return state;
@@ -261,7 +232,7 @@ export class ExecutionEngine {
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
-          from: this._resolveAddress(future.from, { accounts }),
+          from: resolveFromAddress(future.from, { accounts }),
         };
 
         return state;
@@ -288,7 +259,7 @@ export class ExecutionEngine {
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
-          from: this._resolveAddress(future.from, { accounts }),
+          from: resolveFromAddress(future.from, { accounts }),
         };
 
         return state;
@@ -312,7 +283,7 @@ export class ExecutionEngine {
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
-          from: this._resolveAddress(future.from, { accounts }),
+          from: resolveFromAddress(future.from, { accounts }),
         };
 
         return state;

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -11,6 +11,7 @@ import {
   JournalableMessage,
 } from "../../types/journal";
 import {
+  AccountRuntimeValue,
   ArgumentType,
   Future,
   FutureType,
@@ -93,6 +94,7 @@ export class ExecutionEngine {
 
     const context = {
       executionState: state.executionStateMap[future.id],
+      accounts: state.accounts,
     };
 
     const exectionStrategy = state.strategy.executeStrategy(context);
@@ -201,7 +203,7 @@ export class ExecutionEngine {
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
-          from: resolveFromAddress(future.from, { accounts }),
+          from: this._resolveAddress(future.from, { accounts }),
         };
 
         return state;
@@ -232,7 +234,7 @@ export class ExecutionEngine {
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
-          from: resolveFromAddress(future.from, { accounts }),
+          from: this._resolveAddress(future.from, { accounts }),
         };
 
         return state;
@@ -259,7 +261,7 @@ export class ExecutionEngine {
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
-          from: resolveFromAddress(future.from, { accounts }),
+          from: this._resolveAddress(future.from, { accounts }),
         };
 
         return state;
@@ -283,7 +285,7 @@ export class ExecutionEngine {
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
-          from: resolveFromAddress(future.from, { accounts }),
+          from: this._resolveAddress(future.from, { accounts }),
         };
 
         return state;
@@ -296,6 +298,21 @@ export class ExecutionEngine {
         throw new Error(`Not implemented yet: FutureType ${future.type}`);
       }
     }
+  }
+
+  /**
+   * Resolve the address like from to either undefined - which passes the
+   * user intent to the execution strategy, or to a usable string address.
+   */
+  private _resolveAddress(
+    from: string | AccountRuntimeValue | undefined,
+    { accounts }: { accounts: string[] }
+  ): string | undefined {
+    if (from === undefined) {
+      return undefined;
+    }
+
+    return resolveFromAddress(from, { accounts });
   }
 
   private async _storeArtifactAndBuildInfoAgainstDeployment(

--- a/packages/core/src/new-api/internal/execution/execution-strategy.ts
+++ b/packages/core/src/new-api/internal/execution/execution-strategy.ts
@@ -48,6 +48,8 @@ export class BasicExecutionStrategy
     const result = yield {
       type: "onchain-action",
       subtype: "deploy-contract",
+      futureId: deploymentExecutionState.id,
+      transactionId: 1,
       contractName: deploymentExecutionState.contractName,
       value: deploymentExecutionState.value.toString(),
       args: deploymentExecutionState.constructorArgs,

--- a/packages/core/src/new-api/internal/execution/execution-strategy.ts
+++ b/packages/core/src/new-api/internal/execution/execution-strategy.ts
@@ -20,8 +20,10 @@ export class BasicExecutionStrategy
 {
   public executeStrategy({
     executionState,
+    accounts,
   }: {
     executionState: ExecutionState;
+    accounts: string[];
   }): AsyncGenerator<
     OnchainInteractionMessage,
     JournalableMessage,
@@ -33,13 +35,15 @@ export class BasicExecutionStrategy
       );
     }
 
-    return this._executeDeployment({ executionState });
+    return this._executeDeployment({ executionState, accounts });
   }
 
   public async *_executeDeployment({
     executionState: deploymentExecutionState,
+    accounts,
   }: {
     executionState: DeploymentExecutionState;
+    accounts: string[];
   }): AsyncGenerator<
     OnchainInteractionMessage,
     JournalableMessage,
@@ -55,7 +59,7 @@ export class BasicExecutionStrategy
       args: deploymentExecutionState.constructorArgs,
       // TODO: the possibily of undefined for `from` needs
       // a working resolution
-      from: deploymentExecutionState.from ?? "n/a",
+      from: deploymentExecutionState.from ?? accounts[0],
       storedArtifactPath: deploymentExecutionState.storedArtifactPath,
     };
 

--- a/packages/core/src/new-api/internal/execution/executionStateReducer.ts
+++ b/packages/core/src/new-api/internal/execution/executionStateReducer.ts
@@ -12,7 +12,7 @@ import { assertIgnitionInvariant } from "../utils/assertions";
 export function executionStateReducer(
   executionStateMap: ExecutionStateMap,
   action: JournalableMessage
-) {
+): ExecutionStateMap {
   if (action.type === "execution-start") {
     return {
       ...executionStateMap,
@@ -38,6 +38,25 @@ export function executionStateReducer(
     return {
       ...executionStateMap,
       [action.futureId]: updatedExecutionState,
+    };
+  }
+
+  if (action.type === "onchain-action" || action.type === "onchain-result") {
+    const previousExState = executionStateMap[action.futureId];
+
+    assertIgnitionInvariant(
+      previousExState !== undefined,
+      "On chain message for nonexistant future"
+    );
+
+    const updateWithOnchainAction: ExecutionState = {
+      ...previousExState,
+      history: [...previousExState.history, action],
+    };
+
+    return {
+      ...executionStateMap,
+      [action.futureId]: updateWithOnchainAction,
     };
   }
 

--- a/packages/core/src/new-api/internal/execution/guards.ts
+++ b/packages/core/src/new-api/internal/execution/guards.ts
@@ -36,9 +36,7 @@ export function isExecutionMessage(
 export function isOnChainAction(
   potential: JournalableMessage
 ): potential is OnchainInteractionMessage {
-  const resultTypes = ["onchain-action"];
-
-  return resultTypes.includes(potential.type);
+  return potential.type === "onchain-action";
 }
 
 export function isOnchainResult(
@@ -47,6 +45,12 @@ export function isOnchainResult(
   const resultTypes = ["onchain-result"];
 
   return resultTypes.includes(potential.type);
+}
+
+export function isOnchainInteractionMessage(
+  potential: JournalableMessage
+): potential is OnchainInteractionMessage {
+  return isDeployContractInteraction(potential);
 }
 
 export function isDeployContractInteraction(

--- a/packages/core/src/new-api/internal/execution/transactions/transaction-service.ts
+++ b/packages/core/src/new-api/internal/execution/transactions/transaction-service.ts
@@ -68,6 +68,8 @@ export class TransactionServiceImplementation implements TransactionService {
     return {
       type: "onchain-result",
       subtype: "deploy-contract",
+      futureId: deployContractInteraction.futureId,
+      transactionId: deployContractInteraction.transactionId,
       contractAddress,
     };
   }

--- a/packages/core/src/new-api/internal/reconciliation/execution-state-resolver.ts
+++ b/packages/core/src/new-api/internal/reconciliation/execution-state-resolver.ts
@@ -226,12 +226,12 @@ export class ExecutionStateResolver {
       return executionState.from;
     }
 
-    const froms = executionState.history
+    const senders = executionState.history
       .filter(isOnchainInteractionMessage)
       .map((m) => m.from);
 
-    if (froms.length > 0) {
-      return froms[0];
+    if (senders.length > 0) {
+      return senders[0];
     }
 
     return undefined;

--- a/packages/core/src/new-api/internal/reconciliation/execution-state-resolver.ts
+++ b/packages/core/src/new-api/internal/reconciliation/execution-state-resolver.ts
@@ -14,7 +14,9 @@ import {
   Future,
   ModuleParameterRuntimeValue,
 } from "../../types/module";
+import { isOnchainInteractionMessage } from "../execution/guards";
 import {
+  CallExecutionState,
   DeploymentExecutionState,
   ExecutionState,
   ExecutionStateMap,
@@ -207,6 +209,32 @@ export class ExecutionStateResolver {
     }
 
     return to;
+  }
+
+  /**
+   * Return the from, or if from is undefined return the first from based
+   * on the onchain interactions, if there are no interactions return undefined.
+   */
+  public static resolveFromAddress(
+    executionState:
+      | DeploymentExecutionState
+      | SendDataExecutionState
+      | StaticCallExecutionState
+      | CallExecutionState
+  ): string | undefined {
+    if (executionState.from !== undefined) {
+      return executionState.from;
+    }
+
+    const froms = executionState.history
+      .filter(isOnchainInteractionMessage)
+      .map((m) => m.from);
+
+    if (froms.length > 0) {
+      return froms[0];
+    }
+
+    return undefined;
   }
 
   private static _resolveFromExecutionState<

--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileArtifactContractDeployment.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileArtifactContractDeployment.ts
@@ -32,7 +32,6 @@ export function reconcileArtifactContractDeployment(
       future.libraries,
       context
     );
-
   if (!isEqual(resolvedLibraries, executionState.libraries)) {
     return fail(future, "Libraries have been changed");
   }
@@ -44,13 +43,18 @@ export function reconcileArtifactContractDeployment(
     );
   }
 
-  const fromAddress = resolveFromAddress(future.from, context);
-  if (!isEqual(fromAddress, executionState.from)) {
+  const resolvedFutureFromAddress = resolveFromAddress(future.from, context);
+  const executionStateFrom =
+    ExecutionStateResolver.resolveFromAddress(executionState);
+  if (
+    executionStateFrom !== undefined &&
+    !isEqual(resolvedFutureFromAddress, executionStateFrom)
+  ) {
     return fail(
       future,
       `From account has been changed from ${addressToErrorString(
-        executionState.from
-      )} to ${addressToErrorString(fromAddress)}`
+        executionStateFrom
+      )} to ${addressToErrorString(resolvedFutureFromAddress)}`
     );
   }
 

--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileArtifactLibraryDeployment.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileArtifactLibraryDeployment.ts
@@ -29,13 +29,18 @@ export function reconcileArtifactLibraryDeployment(
     return fail(future, "Libraries have been changed");
   }
 
-  const fromAddress = resolveFromAddress(future.from, context);
-  if (!isEqual(fromAddress, executionState.from)) {
+  const resolvedFutureFromAddress = resolveFromAddress(future.from, context);
+  const executionStateFrom =
+    ExecutionStateResolver.resolveFromAddress(executionState);
+  if (
+    executionStateFrom !== undefined &&
+    !isEqual(resolvedFutureFromAddress, executionStateFrom)
+  ) {
     return fail(
       future,
       `From account has been changed from ${addressToErrorString(
-        executionState.from
-      )} to ${addressToErrorString(fromAddress)}`
+        executionStateFrom
+      )} to ${addressToErrorString(resolvedFutureFromAddress)}`
     );
   }
 

--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileNamedContractCall.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileNamedContractCall.ts
@@ -47,13 +47,18 @@ export function reconcileNamedContractCall(
     );
   }
 
-  const fromAddress = resolveFromAddress(future.from, context);
-  if (!isEqual(fromAddress, executionState.from)) {
+  const resolvedFutureFromAddress = resolveFromAddress(future.from, context);
+  const executionStateFrom =
+    ExecutionStateResolver.resolveFromAddress(executionState);
+  if (
+    executionStateFrom !== undefined &&
+    !isEqual(resolvedFutureFromAddress, executionStateFrom)
+  ) {
     return fail(
       future,
       `From account has been changed from ${addressToErrorString(
-        executionState.from
-      )} to ${addressToErrorString(fromAddress)}`
+        executionStateFrom
+      )} to ${addressToErrorString(resolvedFutureFromAddress)}`
     );
   }
 

--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileNamedContractDeployment.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileNamedContractDeployment.ts
@@ -44,13 +44,18 @@ export function reconcileNamedContractDeployment(
     );
   }
 
-  const fromAddress = resolveFromAddress(future.from, context);
-  if (!isEqual(fromAddress, executionState.from)) {
+  const resolvedFutureFromAddress = resolveFromAddress(future.from, context);
+  const executionStateFrom =
+    ExecutionStateResolver.resolveFromAddress(executionState);
+  if (
+    executionStateFrom !== undefined &&
+    !isEqual(resolvedFutureFromAddress, executionStateFrom)
+  ) {
     return fail(
       future,
       `From account has been changed from ${addressToErrorString(
-        executionState.from
-      )} to ${addressToErrorString(fromAddress)}`
+        executionStateFrom
+      )} to ${addressToErrorString(resolvedFutureFromAddress)}`
     );
   }
 

--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileNamedLibraryDeployment.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileNamedLibraryDeployment.ts
@@ -29,13 +29,18 @@ export function reconcileNamedLibraryDeployment(
     return fail(future, "Libraries have been changed");
   }
 
-  const fromAddress = resolveFromAddress(future.from, context);
-  if (!isEqual(fromAddress, executionState.from)) {
+  const resolvedFutureFromAddress = resolveFromAddress(future.from, context);
+  const executionStateFrom =
+    ExecutionStateResolver.resolveFromAddress(executionState);
+  if (
+    executionStateFrom !== undefined &&
+    !isEqual(resolvedFutureFromAddress, executionStateFrom)
+  ) {
     return fail(
       future,
       `From account has been changed from ${addressToErrorString(
-        executionState.from
-      )} to ${addressToErrorString(fromAddress)}`
+        executionStateFrom
+      )} to ${addressToErrorString(resolvedFutureFromAddress)}`
     );
   }
 

--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileNamedStaticCall.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileNamedStaticCall.ts
@@ -40,13 +40,18 @@ export function reconcileNamedStaticCall(
     return fail(future, "Function args have been changed");
   }
 
-  const fromAddress = resolveFromAddress(future.from, context);
-  if (!isEqual(fromAddress, executionState.from)) {
+  const resolvedFutureFromAddress = resolveFromAddress(future.from, context);
+  const executionStateFrom =
+    ExecutionStateResolver.resolveFromAddress(executionState);
+  if (
+    executionStateFrom !== undefined &&
+    !isEqual(resolvedFutureFromAddress, executionStateFrom)
+  ) {
     return fail(
       future,
       `From account has been changed from ${addressToErrorString(
-        executionState.from
-      )} to ${addressToErrorString(fromAddress)}`
+        executionStateFrom
+      )} to ${addressToErrorString(resolvedFutureFromAddress)}`
     );
   }
 

--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileSendData.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileSendData.ts
@@ -40,13 +40,18 @@ export function reconcileSendData(
     );
   }
 
-  const fromAddress = resolveFromAddress(future.from, context);
-  if (!isEqual(fromAddress, executionState.from)) {
+  const resolvedFutureFromAddress = resolveFromAddress(future.from, context);
+  const executionStateFrom =
+    ExecutionStateResolver.resolveFromAddress(executionState);
+  if (
+    executionStateFrom !== undefined &&
+    !isEqual(resolvedFutureFromAddress, executionStateFrom)
+  ) {
     return fail(
       future,
-      `From account has been changed from ${
-        executionState.from ?? "undefined"
-      } to ${addressToErrorString(fromAddress)}`
+      `From account has been changed from ${addressToErrorString(
+        executionStateFrom
+      )} to ${addressToErrorString(resolvedFutureFromAddress)}`
     );
   }
 

--- a/packages/core/src/new-api/internal/types/execution-engine.ts
+++ b/packages/core/src/new-api/internal/types/execution-engine.ts
@@ -29,8 +29,10 @@ export interface ExecutionEngineState {
 export interface ExecutionStrategy {
   executeStrategy: ({
     executionState,
+    accounts,
   }: {
     executionState: ExecutionState;
+    accounts: string[];
   }) => AsyncGenerator<
     OnchainInteractionMessage,
     JournalableMessage,

--- a/packages/core/src/new-api/internal/types/execution-engine.ts
+++ b/packages/core/src/new-api/internal/types/execution-engine.ts
@@ -26,14 +26,16 @@ export interface ExecutionEngineState {
   deploymentLoader: DeploymentLoader;
 }
 
+export interface ExecutionStrategyContext {
+  executionState: ExecutionState;
+  sender?: string;
+}
+
 export interface ExecutionStrategy {
   executeStrategy: ({
     executionState,
-    accounts,
-  }: {
-    executionState: ExecutionState;
-    accounts: string[];
-  }) => AsyncGenerator<
+    sender,
+  }: ExecutionStrategyContext) => AsyncGenerator<
     OnchainInteractionMessage,
     JournalableMessage,
     OnchainResultMessage | null

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -129,7 +129,7 @@ export interface DeploymentExecutionState
   constructorArgs: ArgumentType[];
   libraries: Record<string, string>; // TODO: Do we need to store their future ids for the reconciliation process?
   value: bigint;
-  from: string;
+  from: string | undefined;
   contractAddress?: string; // The result
 }
 
@@ -139,7 +139,7 @@ export interface CallExecutionState
   functionName: string;
   args: ArgumentType[];
   value: bigint;
-  from: string;
+  from: string | undefined;
 }
 
 export interface StaticCallExecutionState
@@ -147,7 +147,7 @@ export interface StaticCallExecutionState
   contractAddress: string;
   functionName: string;
   args: ArgumentType[];
-  from: string;
+  from: string | undefined;
   result?: SolidityParameterType;
 }
 
@@ -173,7 +173,7 @@ export interface SendDataExecutionState
   to: string;
   data: string | undefined;
   value: bigint;
-  from: string;
+  from: string | undefined;
 }
 
 export type ExecutionState =

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -128,7 +128,7 @@ export interface DeploymentExecutionState
   constructorArgs: ArgumentType[];
   libraries: Record<string, string>; // TODO: Do we need to store their future ids for the reconciliation process?
   value: bigint;
-  from: string | undefined;
+  from: string;
   contractAddress?: string; // The result
 }
 
@@ -138,7 +138,7 @@ export interface CallExecutionState
   functionName: string;
   args: ArgumentType[];
   value: bigint;
-  from: string | undefined;
+  from: string;
 }
 
 export interface StaticCallExecutionState
@@ -146,7 +146,7 @@ export interface StaticCallExecutionState
   contractAddress: string;
   functionName: string;
   args: ArgumentType[];
-  from: string | undefined;
+  from: string;
   result?: SolidityParameterType;
 }
 
@@ -172,7 +172,7 @@ export interface SendDataExecutionState
   to: string;
   data: string | undefined;
   value: bigint;
-  from: string | undefined;
+  from: string;
 }
 
 export type ExecutionState =

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -1,3 +1,4 @@
+import { TransactionMessage } from "../../types/journal";
 import {
   ArgumentType,
   FutureType,
@@ -76,7 +77,7 @@ interface SendOnchainInteraction
   transactions: Transaction[];
 }
 
-type OnchainInteraction =
+export type OnchainInteraction =
   | DeploymentOnchainInteraction
   | FunctionCallOnchainInteraction
   | SendOnchainInteraction;
@@ -84,7 +85,7 @@ type OnchainInteraction =
 /**
  * The execution history of a future is a sequence of onchain interactions.
  */
-type ExecutionHistory = OnchainInteraction[];
+type ExecutionHistory = TransactionMessage[];
 
 /**
  * The different status that the execution can be at.

--- a/packages/core/src/new-api/internal/utils/resolve-from-address.ts
+++ b/packages/core/src/new-api/internal/utils/resolve-from-address.ts
@@ -1,5 +1,4 @@
-import { IgnitionError } from "../../../errors";
-import { isRuntimeValue } from "../../type-guards";
+import { isAccountRuntimeValue } from "../../type-guards";
 import { AccountRuntimeValue } from "../../types/module";
 import { isAddress } from "../utils";
 
@@ -8,21 +7,23 @@ import { assertIgnitionInvariant } from "./assertions";
 export function resolveFromAddress(
   from: string | AccountRuntimeValue | undefined,
   { accounts }: { accounts: string[] }
-): string | undefined {
+): string {
   if (from === undefined) {
-    return from;
+    const address = accounts[0];
+
+    assertIgnitionInvariant(isAddress(address), `Account[0] is not an address`);
+
+    return address;
   }
 
   if (typeof from === "string") {
-    if (!isAddress(from)) {
-      throw new IgnitionError("From is not a usable address");
-    }
+    assertIgnitionInvariant(isAddress(from), `from is not an address`);
 
     return from;
   }
 
   assertIgnitionInvariant(
-    isRuntimeValue(from),
+    isAccountRuntimeValue(from),
     `Could not resolve from address: ${JSON.stringify(from)}`
   );
 

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -46,6 +46,8 @@ export type OnchainInteractionMessage = DeployContractInteractionMessage;
 export interface DeployContractInteractionMessage {
   type: "onchain-action";
   subtype: "deploy-contract";
+  futureId: string;
+  transactionId: number;
   args: ArgumentType[];
   contractName: string;
   storedArtifactPath: string;
@@ -72,6 +74,8 @@ export type OnchainResultMessage = DeployContractResultMessage;
 export interface DeployContractResultMessage {
   type: "onchain-result";
   subtype: "deploy-contract";
+  futureId: string;
+  transactionId: number;
   contractAddress: string;
 }
 

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -118,7 +118,7 @@ export interface FutureStartMessage {
   constructorArgs: ArgumentType[];
   libraries: { [key: string]: string };
   value: string;
-  from: string;
+  from: string | undefined;
 }
 
 /**

--- a/packages/core/test/new-api/execution/execution-engine.ts
+++ b/packages/core/test/new-api/execution/execution-engine.ts
@@ -85,6 +85,8 @@ describe("execution engine", () => {
       {
         type: "onchain-action",
         subtype: "deploy-contract",
+        futureId: "Module1:Contract1",
+        transactionId: 1,
         contractName: "Contract1",
         args: [
           "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
@@ -98,6 +100,8 @@ describe("execution engine", () => {
       {
         type: "onchain-result",
         subtype: "deploy-contract",
+        futureId: "Module1:Contract1",
+        transactionId: 1,
         contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
       },
       {
@@ -166,6 +170,8 @@ describe("execution engine", () => {
       {
         type: "onchain-action",
         subtype: "deploy-contract",
+        futureId: "Module1:Library1",
+        transactionId: 1,
         contractName: "Library1",
         args: [],
         value: BigInt(0).toString(),
@@ -175,6 +181,8 @@ describe("execution engine", () => {
       {
         type: "onchain-result",
         subtype: "deploy-contract",
+        futureId: "Module1:Library1",
+        transactionId: 1,
         contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
       },
       {
@@ -253,6 +261,8 @@ describe("execution engine", () => {
           {
             type: "onchain-action",
             subtype: "deploy-contract",
+            futureId: "Module1:Contract1",
+            transactionId: 1,
             contractName: "Contract1",
             args: [],
             value: BigInt(0).toString(),
@@ -262,6 +272,8 @@ describe("execution engine", () => {
           {
             type: "onchain-result",
             subtype: "deploy-contract",
+            futureId: "Module1:Contract1",
+            transactionId: 1,
             contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
           },
           {
@@ -346,6 +358,8 @@ describe("execution engine", () => {
         {
           type: "onchain-action",
           subtype: "deploy-contract",
+          futureId: "Module1:Library1",
+          transactionId: 1,
           contractName: "Library1",
           args: [],
           value: BigInt(0).toString(),
@@ -355,6 +369,8 @@ describe("execution engine", () => {
         {
           type: "onchain-result",
           subtype: "deploy-contract",
+          futureId: "Module1:Library1",
+          transactionId: 1,
           contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
         },
         {
@@ -388,6 +404,8 @@ describe("execution engine", () => {
         {
           type: "onchain-action",
           subtype: "deploy-contract",
+          futureId: "Module1:Contract1",
+          transactionId: 1,
           contractName: "Contract1",
           args: [
             {
@@ -402,6 +420,8 @@ describe("execution engine", () => {
         {
           type: "onchain-result",
           subtype: "deploy-contract",
+          futureId: "Module1:Contract1",
+          transactionId: 1,
           contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
         },
         {
@@ -420,9 +440,11 @@ function setupMockTransactionService(): TransactionService {
   const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 
   return {
-    onchain: async () => ({
+    onchain: async (message) => ({
       type: "onchain-result",
       subtype: "deploy-contract",
+      futureId: message.futureId,
+      transactionId: message.transactionId,
       contractAddress: exampleAddress,
     }),
   } as TransactionService;

--- a/packages/core/test/new-api/execution/execution-engine.ts
+++ b/packages/core/test/new-api/execution/execution-engine.ts
@@ -94,8 +94,8 @@ describe("execution engine", () => {
           { nested: 2000 },
         ],
         value: BigInt(0).toString(),
-        from: accounts[1],
         storedArtifactPath: "Module1:Contract1.json",
+        from: accounts[1],
       },
       {
         type: "onchain-result",
@@ -176,8 +176,8 @@ describe("execution engine", () => {
         contractName: "Library1",
         args: [],
         value: BigInt(0).toString(),
-        from: accounts[2],
         storedArtifactPath: "Module1:Library1.json",
+        from: accounts[2],
       },
       {
         type: "onchain-result",
@@ -368,8 +368,8 @@ describe("execution engine", () => {
           contractName: "Library1",
           args: [],
           value: BigInt(0).toString(),
-          from: accounts[1],
           storedArtifactPath: "Module1:Library1.json",
+          from: accounts[1],
         },
         {
           type: "onchain-result",
@@ -419,8 +419,8 @@ describe("execution engine", () => {
             },
           ],
           value: BigInt(0).toString(),
-          from: exampleAccounts[1],
           storedArtifactPath: "Module1:Contract1.json",
+          from: exampleAccounts[1],
         },
         {
           type: "onchain-result",

--- a/packages/core/test/new-api/execution/execution-engine.ts
+++ b/packages/core/test/new-api/execution/execution-engine.ts
@@ -21,11 +21,11 @@ describe("execution engine", () => {
       const account1 = m.getAccount(1);
       const supply = m.getParameter("supply", 1000);
 
-      const contract1 = m.contract("Contract1", [
-        account1,
-        supply,
-        { nested: supply },
-      ]);
+      const contract1 = m.contract(
+        "Contract1",
+        [account1, supply, { nested: supply }],
+        { from: account1 }
+      );
 
       return { contract1 };
     });
@@ -80,7 +80,7 @@ describe("execution engine", () => {
           { nested: 2000 },
         ],
         libraries: {},
-        from: accounts[0],
+        from: accounts[1],
       },
       {
         type: "onchain-action",
@@ -94,7 +94,7 @@ describe("execution engine", () => {
           { nested: 2000 },
         ],
         value: BigInt(0).toString(),
-        from: exampleAccounts[0],
+        from: accounts[1],
         storedArtifactPath: "Module1:Contract1.json",
       },
       {
@@ -116,7 +116,8 @@ describe("execution engine", () => {
 
   it("should execute a library deploy", async () => {
     const moduleDefinition = defineModule("Module1", (m) => {
-      const library1 = m.library("Library1");
+      const account2 = m.getAccount(2);
+      const library1 = m.library("Library1", { from: account2 });
 
       return { library1 };
     });
@@ -165,7 +166,7 @@ describe("execution engine", () => {
         value: BigInt(0).toString(),
         constructorArgs: [],
         libraries: {},
-        from: accounts[0],
+        from: accounts[2],
       },
       {
         type: "onchain-action",
@@ -175,7 +176,7 @@ describe("execution engine", () => {
         contractName: "Library1",
         args: [],
         value: BigInt(0).toString(),
-        from: exampleAccounts[0],
+        from: accounts[2],
         storedArtifactPath: "Module1:Library1.json",
       },
       {
@@ -204,7 +205,10 @@ describe("execution engine", () => {
     };
 
     const moduleDefinition = defineModule("Module1", (m) => {
-      const contract1 = m.contractFromArtifact("Contract1", fakeArtifact);
+      const account2 = m.getAccount(2);
+      const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [], {
+        from: account2,
+      });
 
       return { contract1 };
     });
@@ -256,7 +260,7 @@ describe("execution engine", () => {
             value: BigInt(0).toString(),
             constructorArgs: [],
             libraries: {},
-            from: accounts[0],
+            from: accounts[2],
           },
           {
             type: "onchain-action",
@@ -266,7 +270,7 @@ describe("execution engine", () => {
             contractName: "Contract1",
             args: [],
             value: BigInt(0).toString(),
-            from: exampleAccounts[0],
+            from: accounts[2],
             storedArtifactPath: "Module1:Contract1.json",
           },
           {
@@ -291,10 +295,10 @@ describe("execution engine", () => {
   describe("with complex arguments", () => {
     it("should execute deploy when futures are passed as nested arguments", async () => {
       const moduleDefinition = defineModule("Module1", (m) => {
-        const library1 = m.library("Library1");
-
         const account1 = m.getAccount(1);
         const supply = m.getParameter("supply", 1000);
+
+        const library1 = m.library("Library1", { from: account1 });
 
         const contract1 = m.contract(
           "Contract1",
@@ -303,6 +307,7 @@ describe("execution engine", () => {
             libraries: {
               Library1: library1,
             },
+            from: account1,
           }
         );
 
@@ -353,7 +358,7 @@ describe("execution engine", () => {
           value: BigInt(0).toString(),
           constructorArgs: [],
           libraries: {},
-          from: accounts[0],
+          from: accounts[1],
         },
         {
           type: "onchain-action",
@@ -363,7 +368,7 @@ describe("execution engine", () => {
           contractName: "Library1",
           args: [],
           value: BigInt(0).toString(),
-          from: exampleAccounts[0],
+          from: accounts[1],
           storedArtifactPath: "Module1:Library1.json",
         },
         {
@@ -399,7 +404,7 @@ describe("execution engine", () => {
           libraries: {
             Library1: "Module1:Library1",
           },
-          from: accounts[0],
+          from: accounts[1],
         },
         {
           type: "onchain-action",
@@ -414,7 +419,7 @@ describe("execution engine", () => {
             },
           ],
           value: BigInt(0).toString(),
-          from: exampleAccounts[0],
+          from: exampleAccounts[1],
           storedArtifactPath: "Module1:Contract1.json",
         },
         {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileArtifactContractAt.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileArtifactContractAt.ts
@@ -10,6 +10,7 @@ import {
   StaticCallExecutionState,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import { assertSuccessReconciliation, reconcile } from "../helpers";
 
 describe("Reconciliation - artifact contract at", () => {
@@ -47,7 +48,7 @@ describe("Reconciliation - artifact contract at", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   const exampleStaticCallState: StaticCallExecutionState = {
@@ -60,7 +61,7 @@ describe("Reconciliation - artifact contract at", () => {
     contractAddress: exampleAddress,
     functionName: "function",
     args: [],
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile when using an address string", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileArtifactContractDeployment.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileArtifactContractDeployment.ts
@@ -7,6 +7,7 @@ import {
   ExecutionStatus,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import {
   assertSuccessReconciliation,
   oneAddress,
@@ -37,7 +38,7 @@ describe("Reconciliation - artifact contract", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileArtifactLibraryDeployment.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileArtifactLibraryDeployment.ts
@@ -7,6 +7,7 @@ import {
   ExecutionStatus,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import {
   assertSuccessReconciliation,
   oneAddress,
@@ -37,7 +38,7 @@ describe("Reconciliation - artifact library", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractAt.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractAt.ts
@@ -9,6 +9,7 @@ import {
   StaticCallExecutionState,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import { assertSuccessReconciliation, reconcile } from "../helpers";
 
 describe("Reconciliation - named contract at", () => {
@@ -39,7 +40,7 @@ describe("Reconciliation - named contract at", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   const exampleStaticCallState: StaticCallExecutionState = {
@@ -52,7 +53,7 @@ describe("Reconciliation - named contract at", () => {
     contractAddress: exampleAddress,
     functionName: "function",
     args: [],
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged when using an address string", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractCall.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractCall.ts
@@ -7,6 +7,7 @@ import {
   ExecutionStatus,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import {
   assertSuccessReconciliation,
   oneAddress,
@@ -31,7 +32,7 @@ describe("Reconciliation - named contract call", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
     contractAddress: differentAddress,
   };
 
@@ -46,7 +47,7 @@ describe("Reconciliation - named contract call", () => {
     functionName: "function",
     args: [],
     value: BigInt("0"),
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractDeployment.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileNamedContractDeployment.ts
@@ -6,6 +6,7 @@ import {
   ExecutionStatus,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import {
   assertSuccessReconciliation,
   oneAddress,
@@ -29,7 +30,7 @@ describe("Reconciliation - named contract", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileNamedLibraryDeployment.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileNamedLibraryDeployment.ts
@@ -6,6 +6,7 @@ import {
   ExecutionStatus,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import {
   assertSuccessReconciliation,
   oneAddress,
@@ -29,7 +30,7 @@ describe("Reconciliation - named library", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileNamedStaticCall.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileNamedStaticCall.ts
@@ -7,6 +7,7 @@ import {
   StaticCallExecutionState,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import {
   assertSuccessReconciliation,
   oneAddress,
@@ -31,7 +32,7 @@ describe("Reconciliation - named static call", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   const exampleStaticCallState: StaticCallExecutionState = {
@@ -44,7 +45,7 @@ describe("Reconciliation - named static call", () => {
     contractAddress: exampleAddress,
     functionName: "function",
     args: [],
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileReadEventArgument.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileReadEventArgument.ts
@@ -7,6 +7,7 @@ import {
   ReadEventArgumentExecutionState,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import { assertSuccessReconciliation, reconcile } from "../helpers";
 
 describe("Reconciliation - read event argument", () => {
@@ -39,7 +40,7 @@ describe("Reconciliation - read event argument", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged", () => {

--- a/packages/core/test/new-api/reconciliation/futures/reconcileSendData.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileSendData.ts
@@ -6,6 +6,7 @@ import {
   SendDataExecutionState,
 } from "../../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../../src/new-api/types/module";
+import { exampleAccounts } from "../../helpers";
 import { assertSuccessReconciliation, reconcile } from "../helpers";
 
 describe("Reconciliation - send data", () => {
@@ -22,7 +23,7 @@ describe("Reconciliation - send data", () => {
     to: exampleAddress,
     data: "example_data",
     value: BigInt("0"),
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should reconcile unchanged", () => {

--- a/packages/core/test/new-api/reconciliation/reconciler.ts
+++ b/packages/core/test/new-api/reconciliation/reconciler.ts
@@ -6,6 +6,7 @@ import {
   ExecutionStatus,
 } from "../../../src/new-api/internal/types/execution-state";
 import { FutureType } from "../../../src/new-api/types/module";
+import { exampleAccounts } from "../helpers";
 
 import { assertSuccessReconciliation, reconcile } from "./helpers";
 
@@ -23,7 +24,7 @@ describe("Reconciliation", () => {
     value: BigInt("0"),
     constructorArgs: [],
     libraries: {},
-    from: undefined,
+    from: exampleAccounts[0],
   };
 
   it("should successfully reconcile on an empty execution state", () => {


### PR DESCRIPTION
In execution state the `from` address should always be set. If the future specifies undefined, this should be reconcilied as `account[0]` the same way it is during execution.

Fixes #281