### PR TITLE
feat/restart-on-error (PR 8)

### DIFF
--- a/examples/sample/contracts/Lock.sol
+++ b/examples/sample/contracts/Lock.sol
@@ -5,30 +5,30 @@ pragma solidity ^0.8.9;
 // import "hardhat/console.sol";
 
 contract Lock {
-    uint public unlockTime;
-    address payable public owner;
+  uint public unlockTime;
+  address payable public owner;
 
-    event Withdrawal(uint amount, uint when);
+  event Withdrawal(uint amount, uint when);
 
-    constructor(uint _unlockTime) payable {
-        require(
-            block.timestamp < _unlockTime,
-            "Unlock time should be in the future"
-        );
+  constructor(uint _unlockTime) payable {
+    require(
+      block.timestamp < _unlockTime,
+      "Unlock time should be in the future"
+    );
 
-        unlockTime = _unlockTime;
-        owner = payable(msg.sender);
-    }
+    unlockTime = _unlockTime;
+    owner = payable(msg.sender);
+  }
 
-    function withdraw() public {
-        // Uncomment this line, and the import of "hardhat/console.sol", to print a log in your terminal
-        // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
+  function withdraw() public {
+    // Uncomment this line, and the import of "hardhat/console.sol", to print a log in your terminal
+    // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
 
-        require(block.timestamp >= unlockTime, "You can't withdraw yet");
-        require(msg.sender == owner, "You aren't the owner");
+    require(block.timestamp >= unlockTime, "You can't withdraw yet");
+    require(msg.sender == owner, "You aren't the owner");
 
-        emit Withdrawal(address(this).balance, block.timestamp);
+    emit Withdrawal(address(this).balance, block.timestamp);
 
-        owner.transfer(address(this).balance);
-    }
+    owner.transfer(address(this).balance);
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./errors";
 export * from "./initialization";
 export { defineModule } from "./new-api/define-module";
 export { deploy } from "./new-api/deploy";
+export { wipe } from "./new-api/wipe";
 /* TODO: how is module constructor getting exposed? */
 export { ModuleConstructor } from "./new-api/internal/module-builder";
 export { StoredDeploymentSerializer } from "./new-api/stored-deployment-serializer";

--- a/packages/core/src/new-api/internal/deployer.ts
+++ b/packages/core/src/new-api/internal/deployer.ts
@@ -32,8 +32,8 @@ export class Deployer {
 
   constructor(options: {
     artifactResolver: ArtifactResolver;
-    transactionService: TransactionService;
     deploymentLoader: DeploymentLoader;
+    transactionService: TransactionService;
   }) {
     this._strategy = new BasicExecutionStrategy();
     this._artifactResolver = options.artifactResolver;

--- a/packages/core/src/new-api/internal/execution/execution-strategy.ts
+++ b/packages/core/src/new-api/internal/execution/execution-strategy.ts
@@ -1,17 +1,17 @@
 import { IgnitionError } from "../../../errors";
 import {
   CallFunctionInteractionMessage,
-  CallFunctionResultMessage,
   CalledFunctionExecutionSuccess,
   DeployContractInteractionMessage,
-  DeployContractResultMessage,
   DeployedContractExecutionSuccess,
   JournalableMessage,
+  OnchainCallFunctionSuccessMessage,
+  OnchainDeployContractSuccessMessage,
   OnchainInteractionMessage,
   OnchainResultMessage,
+  OnchainStaticCallSuccessMessage,
   StaticCallExecutionSuccess,
   StaticCallInteractionMessage,
-  StaticCallResultMessage,
 } from "../../types/journal";
 import {
   isCallExecutionState,
@@ -70,7 +70,7 @@ export class BasicExecutionStrategy
   }): AsyncGenerator<
     DeployContractInteractionMessage,
     DeployedContractExecutionSuccess,
-    DeployContractResultMessage | null
+    OnchainDeployContractSuccessMessage | null
   > {
     assertIgnitionInvariant(
       sender !== undefined,
@@ -113,7 +113,7 @@ export class BasicExecutionStrategy
   }): AsyncGenerator<
     CallFunctionInteractionMessage,
     CalledFunctionExecutionSuccess,
-    CallFunctionResultMessage | null
+    OnchainCallFunctionSuccessMessage | null
   > {
     assertIgnitionInvariant(
       sender !== undefined,
@@ -158,7 +158,7 @@ export class BasicExecutionStrategy
   }): AsyncGenerator<
     StaticCallInteractionMessage,
     StaticCallExecutionSuccess,
-    StaticCallResultMessage | null
+    OnchainStaticCallSuccessMessage | null
   > {
     assertIgnitionInvariant(
       sender !== undefined,

--- a/packages/core/src/new-api/internal/execution/executionStateReducer.ts
+++ b/packages/core/src/new-api/internal/execution/executionStateReducer.ts
@@ -2,6 +2,7 @@ import { FutureStartMessage, JournalableMessage } from "../../types/journal";
 import {
   isCallFunctionStartMessage,
   isDeployContractStartMessage,
+  isExecutionStartMessage,
   isStaticCallStartMessage,
 } from "../journal/type-guards";
 import {
@@ -17,8 +18,8 @@ import { assertIgnitionInvariant } from "../utils/assertions";
 export function executionStateReducer(
   executionStateMap: ExecutionStateMap,
   action: JournalableMessage
-): ExecutionStateMap {
-  if (action.type === "execution-start") {
+) {
+  if (isExecutionStartMessage(action)) {
     return {
       ...executionStateMap,
       [action.futureId]: initialiseExecutionStateFor(action),
@@ -89,6 +90,16 @@ export function executionStateReducer(
       ...executionStateMap,
       [action.futureId]: updateWithOnchainAction,
     };
+  }
+
+  if (action.type === "wipe") {
+    const updated = {
+      ...executionStateMap,
+    };
+
+    delete updated[action.futureId];
+
+    return updated;
   }
 
   return executionStateMap;

--- a/packages/core/src/new-api/internal/execution/guards.ts
+++ b/packages/core/src/new-api/internal/execution/guards.ts
@@ -2,25 +2,23 @@ import {
   CallFunctionInteractionMessage,
   DeployContractInteractionMessage,
   DeployedContractExecutionSuccess,
+  ExecutionFailure,
+  ExecutionHold,
   ExecutionResultMessage,
-  ExecutionResultTypes,
   ExecutionSuccess,
   JournalableMessage,
   OnchainInteractionMessage,
-  OnchainResultMessage,
   StaticCallInteractionMessage,
 } from "../../types/journal";
 
-export function isExecutionResult(
+export function isExecutionResultMessage(
   potential: JournalableMessage
 ): potential is ExecutionResultMessage {
-  const resultTypes: ExecutionResultTypes = [
-    "execution-success",
-    "execution-failure",
-    "execution-hold",
-  ];
-
-  return (resultTypes as string[]).includes(potential.type);
+  return (
+    isExecutionSuccess(potential) ||
+    isExecutionFailure(potential) ||
+    isExecutionHold(potential)
+  );
 }
 
 export function isExecutionSuccess(
@@ -29,24 +27,22 @@ export function isExecutionSuccess(
   return potential.type === "execution-success";
 }
 
-export function isExecutionMessage(
+export function isExecutionFailure(
   potential: JournalableMessage
-): potential is ExecutionResultMessage {
-  return isExecutionResult(potential);
+): potential is ExecutionFailure {
+  return potential.type === "execution-failure";
+}
+
+export function isExecutionHold(
+  potential: JournalableMessage
+): potential is ExecutionHold {
+  return potential.type === "execution-hold";
 }
 
 export function isOnChainAction(
   potential: JournalableMessage
 ): potential is OnchainInteractionMessage {
   return potential.type === "onchain-action";
-}
-
-export function isOnchainResult(
-  potential: JournalableMessage
-): potential is OnchainResultMessage {
-  const resultTypes = ["onchain-result"];
-
-  return resultTypes.includes(potential.type);
 }
 
 export function isOnchainInteractionMessage(

--- a/packages/core/src/new-api/internal/journal/memory-journal.ts
+++ b/packages/core/src/new-api/internal/journal/memory-journal.ts
@@ -1,21 +1,26 @@
 import { Journal, JournalableMessage } from "../../types/journal";
 
+import { deserializeReplacer } from "./utils/deserialize-replacer";
+import { serializeReplacer } from "./utils/serialize-replacer";
+
 /**
  * An in-memory journal.
  *
  * @beta
  */
-
 export class MemoryJournal implements Journal {
   private messages: string[] = [];
 
   public record(message: JournalableMessage): void {
-    this.messages.push(JSON.stringify(message));
+    this.messages.push(JSON.stringify(message, serializeReplacer.bind(this)));
   }
 
   public async *read(): AsyncGenerator<JournalableMessage> {
     for (const entry of this.messages) {
-      const message: JournalableMessage = JSON.parse(entry);
+      const message: JournalableMessage = JSON.parse(
+        entry,
+        deserializeReplacer.bind(this)
+      );
 
       yield message;
     }

--- a/packages/core/src/new-api/internal/journal/type-guards.ts
+++ b/packages/core/src/new-api/internal/journal/type-guards.ts
@@ -2,9 +2,27 @@ import {
   CallFunctionStartMessage,
   DeployContractStartMessage,
   FutureStartMessage,
+  JournalableMessage,
+  OnchainCallFunctionSuccessMessage,
+  OnchainDeployContractSuccessMessage,
+  OnchainResultFailureMessage,
+  OnchainResultMessage,
+  OnchainResultSuccessMessage,
+  OnchainStaticCallSuccessMessage,
   StaticCallStartMessage,
 } from "../../types/journal";
 import { FutureType } from "../../types/module";
+
+/**
+ * Returns true if potential is ane execution start message.
+ *
+ * @beta
+ */
+export function isExecutionStartMessage(
+  potential: JournalableMessage
+): potential is FutureStartMessage {
+  return potential.type === "execution-start";
+}
 
 /**
  * Returns true if potential is a contract deployment start message
@@ -44,4 +62,52 @@ export function isStaticCallStartMessage(
   potential: FutureStartMessage
 ): potential is StaticCallStartMessage {
   return potential.futureType === FutureType.NAMED_STATIC_CALL;
+}
+
+export function isOnChainResultMessage(
+  message: JournalableMessage
+): message is OnchainResultMessage {
+  return message.type === "onchain-result";
+}
+
+export function isOnChainSuccessMessage(
+  message: JournalableMessage
+): message is OnchainResultSuccessMessage {
+  return (
+    isOnchainDeployContractSuccessMessage(message) ||
+    isOnchainCallFunctionSuccessMessage(message) ||
+    isOnchainStaticCallSuccessMessage(message)
+  );
+}
+
+export function isOnChainFailureMessage(
+  message: JournalableMessage
+): message is OnchainResultFailureMessage {
+  return isOnChainResultMessage(message) && message.subtype === "failure";
+}
+
+export function isOnchainDeployContractSuccessMessage(
+  message: JournalableMessage
+): message is OnchainDeployContractSuccessMessage {
+  return (
+    isOnChainResultMessage(message) &&
+    message.subtype === "deploy-contract-success"
+  );
+}
+
+export function isOnchainCallFunctionSuccessMessage(
+  message: JournalableMessage
+): message is OnchainCallFunctionSuccessMessage {
+  return (
+    isOnChainResultMessage(message) &&
+    message.subtype === "call-function-success"
+  );
+}
+
+export function isOnchainStaticCallSuccessMessage(
+  message: JournalableMessage
+): message is OnchainStaticCallSuccessMessage {
+  return (
+    isOnChainResultMessage(message) && message.subtype === "static-call-success"
+  );
 }

--- a/packages/core/src/new-api/internal/wiper.ts
+++ b/packages/core/src/new-api/internal/wiper.ts
@@ -1,0 +1,52 @@
+import { IgnitionError } from "../../errors";
+import { Journal, WipeMessage } from "../types/journal";
+
+import { executionStateReducer } from "./execution/executionStateReducer";
+import { ExecutionStateMap } from "./types/execution-state";
+
+export class Wiper {
+  constructor(private _journal: Journal) {}
+
+  public async wipe(futureId: string) {
+    const previousStateMap = await this._loadExecutionStateFrom(this._journal);
+
+    const executionState = previousStateMap[futureId];
+
+    if (executionState === undefined) {
+      throw new IgnitionError(
+        `Cannot wipe ${futureId} as no state recorded against it`
+      );
+    }
+
+    const dependents = Object.values(previousStateMap).filter((psm) =>
+      psm.dependencies.has(futureId)
+    );
+
+    if (dependents.length > 0) {
+      throw new IgnitionError(
+        `Cannot wipe ${futureId} as there are dependent futures that have already started:\n${dependents
+          .map((state) => `  ${state.id}\n`)
+          .join()}`
+      );
+    }
+
+    const wipeMessage: WipeMessage = {
+      type: "wipe",
+      futureId,
+    };
+
+    return this._journal.record(wipeMessage);
+  }
+
+  private async _loadExecutionStateFrom(
+    journal: Journal
+  ): Promise<ExecutionStateMap> {
+    let state: ExecutionStateMap = {};
+
+    for await (const message of journal.read()) {
+      state = executionStateReducer(state, message);
+    }
+
+    return state;
+  }
+}

--- a/packages/core/src/new-api/types/deployer.ts
+++ b/packages/core/src/new-api/types/deployer.ts
@@ -7,8 +7,9 @@ import { IgnitionModule, IgnitionModuleResult } from "./module";
  */
 export type DeploymentResult =
   | DeploymentResultSuccess
+  | DeploymentResultFailure
   | {
-      status: "failed" | "hold";
+      status: "hold";
     };
 
 /**
@@ -20,6 +21,17 @@ export interface DeploymentResultSuccess {
   status: "success";
   contracts: DeploymentResultContracts;
   module: IgnitionModule<string, string, IgnitionModuleResult<string>>;
+}
+
+/**
+ * The result of a failed deployment run (at least one future had an
+ * failed transaction).
+ *
+ * @beta
+ */
+export interface DeploymentResultFailure {
+  status: "failure";
+  errors: { [key: string]: Error };
 }
 
 /**

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -16,7 +16,10 @@ export interface Journal {
  *
  * @beta
  */
-export type JournalableMessage = TransactionMessage | ExecutionMessage;
+export type JournalableMessage =
+  | TransactionMessage
+  | ExecutionMessage
+  | WipeMessage;
 
 // #region "TransactionMessage"
 
@@ -103,18 +106,24 @@ export interface StaticCallInteractionMessage {
  * @beta
  */
 export type OnchainResultMessage =
-  | DeployContractResultMessage
-  | CallFunctionResultMessage
-  | StaticCallResultMessage;
+  | OnchainResultSuccessMessage
+  | OnchainResultFailureMessage;
+
+export type OnchainResultSuccessMessage =
+  | OnchainDeployContractSuccessMessage
+  | OnchainCallFunctionSuccessMessage
+  | OnchainStaticCallSuccessMessage;
+
+export type OnchainResultFailureMessage = OnchainFailureMessage;
 
 /**
  * A successful deploy contract transaction result.
  *
  * @beta
  */
-export interface DeployContractResultMessage {
+export interface OnchainDeployContractSuccessMessage {
   type: "onchain-result";
-  subtype: "deploy-contract";
+  subtype: "deploy-contract-success";
   futureId: string;
   transactionId: number;
   contractAddress: string;
@@ -125,9 +134,9 @@ export interface DeployContractResultMessage {
  *
  * @beta
  */
-export interface CallFunctionResultMessage {
+export interface OnchainCallFunctionSuccessMessage {
   type: "onchain-result";
-  subtype: "call-function";
+  subtype: "call-function-success";
   futureId: string;
   transactionId: number;
   txId: string;
@@ -138,12 +147,25 @@ export interface CallFunctionResultMessage {
  *
  * @beta
  */
-export interface StaticCallResultMessage {
+export interface OnchainStaticCallSuccessMessage {
   type: "onchain-result";
-  subtype: "static-call";
+  subtype: "static-call-success";
   futureId: string;
   transactionId: number;
   result: PrimitiveArgType | PrimitiveArgType[];
+}
+
+/**
+ * A failed on-chain transaction result.
+ *
+ * @beta
+ */
+export interface OnchainFailureMessage {
+  type: "onchain-result";
+  subtype: "failure";
+  futureId: string;
+  transactionId: number;
+  error: Error;
 }
 
 // #endregion
@@ -336,6 +358,8 @@ export interface StaticCallExecutionSuccess {
  */
 export interface ExecutionFailure {
   type: "execution-failure";
+  futureId: string;
+  error: Error;
 }
 
 /**
@@ -349,5 +373,20 @@ export interface ExecutionHold {
 }
 
 // #endregion
+
+// #endregion
+
+// #region "WipeMessage"
+
+/**
+ * A journal message indicating the user has instructed Ignition to clear
+ * the futures state so it can be rerun.
+ *
+ * @beta
+ */
+export interface WipeMessage {
+  type: "wipe";
+  futureId: string;
+}
 
 // #endregion

--- a/packages/core/src/new-api/wipe.ts
+++ b/packages/core/src/new-api/wipe.ts
@@ -1,0 +1,20 @@
+import path from "path";
+
+import { FileJournal } from "./internal/journal/file-journal";
+import { Wiper } from "./internal/wiper";
+
+/**
+ * Clear the state against a future within a deployment
+ *
+ * @param deploymentDir - the file directory of the deployment
+ * @param futureId - the future to be cleared
+ *
+ * @beta
+ */
+export async function wipe(deploymentDir: string, futureId: string) {
+  const fileJournalPath = path.join(deploymentDir, "journal.jsonl");
+
+  const wiper = new Wiper(new FileJournal(fileJournalPath));
+
+  return wiper.wipe(futureId);
+}

--- a/packages/core/test/new-api/call.ts
+++ b/packages/core/test/new-api/call.ts
@@ -558,7 +558,7 @@ describe("call", () => {
       await assert.isRejected(
         validateNamedContractCall(
           future as any,
-          setupMockArtifactResolver({} as any)
+          setupMockArtifactResolver({ Another: {} as any })
         ),
         /Artifact for contract 'Another' is invalid/
       );
@@ -586,10 +586,7 @@ describe("call", () => {
       );
 
       await assert.isRejected(
-        validateNamedContractCall(
-          future as any,
-          setupMockArtifactResolver(fakeArtifact)
-        ),
+        validateNamedContractCall(future as any, setupMockArtifactResolver()),
         /Contract 'Another' doesn't have a function test/
       );
     });
@@ -630,10 +627,7 @@ describe("call", () => {
       );
 
       await assert.isRejected(
-        validateNamedContractCall(
-          future as any,
-          setupMockArtifactResolver(fakeArtifact)
-        ),
+        validateNamedContractCall(future as any, setupMockArtifactResolver()),
         /Function inc in contract Another expects 1 arguments but 2 were given/
       );
     });
@@ -692,10 +686,7 @@ describe("call", () => {
       );
 
       await assert.isRejected(
-        validateNamedContractCall(
-          future as any,
-          setupMockArtifactResolver(fakeArtifact)
-        ),
+        validateNamedContractCall(future as any, setupMockArtifactResolver()),
         /Function inc in contract Another is overloaded, but no overload expects 3 arguments/
       );
     });

--- a/packages/core/test/new-api/contract.ts
+++ b/packages/core/test/new-api/contract.ts
@@ -554,7 +554,9 @@ describe("contract", () => {
       await assert.isRejected(
         validateNamedContractDeployment(
           future as any,
-          setupMockArtifactResolver({} as any)
+          setupMockArtifactResolver({
+            Another: {} as any,
+          })
         ),
         /Artifact for contract 'Another' is invalid/
       );
@@ -586,7 +588,7 @@ describe("contract", () => {
       await assert.isRejected(
         validateNamedContractDeployment(
           future as any,
-          setupMockArtifactResolver(fakeArtifact)
+          setupMockArtifactResolver({ Test: fakeArtifact })
         ),
         /The constructor of the contract 'Test' expects 0 arguments but 3 were given/
       );

--- a/packages/core/test/new-api/contractAt.ts
+++ b/packages/core/test/new-api/contractAt.ts
@@ -270,7 +270,9 @@ describe("contractAt", () => {
       await assert.isRejected(
         validateNamedContractAt(
           future as any,
-          setupMockArtifactResolver(fakeArtifact)
+          setupMockArtifactResolver({
+            Another: fakeArtifact,
+          })
         ),
         /Artifact for contract 'Another' is invalid/
       );

--- a/packages/core/test/new-api/contractFromArtifact.ts
+++ b/packages/core/test/new-api/contractFromArtifact.ts
@@ -629,7 +629,7 @@ describe("contractFromArtifact", () => {
       await assert.isRejected(
         validateArtifactContractDeployment(
           future as any,
-          setupMockArtifactResolver(fakeArtifact)
+          setupMockArtifactResolver()
         ),
         /The constructor of the contract 'Test' expects 0 arguments but 3 were given/
       );

--- a/packages/core/test/new-api/execution/execution-engine.ts
+++ b/packages/core/test/new-api/execution/execution-engine.ts
@@ -2,21 +2,52 @@ import { assert } from "chai";
 
 import { Artifact, FutureType } from "../../../src";
 import { defineModule } from "../../../src/new-api/define-module";
-import { Batcher } from "../../../src/new-api/internal/batcher";
-import { ExecutionEngine } from "../../../src/new-api/internal/execution/execution-engine";
-import { BasicExecutionStrategy } from "../../../src/new-api/internal/execution/execution-strategy";
 import { MemoryJournal } from "../../../src/new-api/internal/journal/memory-journal";
-import { ModuleConstructor } from "../../../src/new-api/internal/module-builder";
-import { DeploymentLoader } from "../../../src/new-api/types/deployment-loader";
 import {
-  Journal,
-  JournalableMessage,
-} from "../../../src/new-api/types/journal";
-import { TransactionService } from "../../../src/new-api/types/transaction-service";
-import { exampleAccounts, setupMockArtifactResolver } from "../helpers";
+  accumulateMessages,
+  assertDeploymentFailure,
+  assertDeploymentSuccess,
+  exampleAccounts,
+  setupDeployerWithMocks,
+} from "../helpers";
 
 describe("execution engine", () => {
+  const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+  const differentAddress = "0xBA12222222228d8Ba445958a75a0704d566BF2C8";
+  const accounts = exampleAccounts;
+
+  const contractWithThreeArgConstructorArtifact = {
+    abi: [
+      {
+        type: "constructor",
+        stateMutability: "payable",
+        inputs: [
+          {
+            name: "_first",
+            type: "string",
+            internalType: "string",
+          },
+          {
+            name: "_second",
+            type: "string",
+            internalType: "string",
+          },
+          {
+            name: "_third",
+            type: "string",
+            internalType: "string",
+          },
+        ],
+      },
+    ],
+    contractName: "Contract1",
+    bytecode: "",
+    linkReferences: {},
+  };
+
   it("should execute a contract deploy", async () => {
+    const journal = new MemoryJournal();
+
     const moduleDefinition = defineModule("Module1", (m) => {
       const account1 = m.getAccount(1);
       const supply = m.getParameter("supply", 1000);
@@ -30,37 +61,40 @@ describe("execution engine", () => {
       return { contract1 };
     });
 
-    const constructor = new ModuleConstructor();
-    const module = constructor.construct(moduleDefinition);
-
-    assert.isDefined(module);
-
-    const executionStateMap = {};
-
-    const batches = Batcher.batch(module, {});
-
-    const executionEngine = new ExecutionEngine();
-    const journal = new MemoryJournal();
-    const accounts: string[] = exampleAccounts;
-    const mockTransactionService = setupMockTransactionService();
-    const mockArtifactResolver = setupMockArtifactResolver({} as any);
-    const mockDeploymentLoader = setupMockDeploymentLoader(journal);
-
-    const result = await executionEngine.execute({
-      batches,
-      module,
-      executionStateMap,
-      accounts,
-      strategy: new BasicExecutionStrategy(),
-      transactionService: mockTransactionService,
-      artifactResolver: mockArtifactResolver,
-      deploymentLoader: mockDeploymentLoader,
-      deploymentParameters: {
-        Module1: { supply: 2000 },
+    const deployer = setupDeployerWithMocks({
+      journal,
+      artifacts: {
+        Contract1: contractWithThreeArgConstructorArtifact,
+      },
+      transactionResponses: {
+        "Module1:Contract1": {
+          1: {
+            type: "onchain-result",
+            subtype: "deploy-contract-success",
+            futureId: "Module1:Contract1",
+            transactionId: 1,
+            contractAddress: exampleAddress,
+          },
+        },
       },
     });
 
-    assert.isDefined(result);
+    const result = await deployer.deploy(
+      moduleDefinition,
+      {
+        Module1: { supply: 2000 },
+      },
+      exampleAccounts
+    );
+
+    assertDeploymentSuccess(result, {
+      "Module1:Contract1": {
+        contractName: "Contract1",
+        contractAddress: exampleAddress,
+        storedArtifactPath: "Module1:Contract1.json",
+      },
+    });
+
     const journalMessages = await accumulateMessages(journal);
 
     assert.deepStrictEqual(journalMessages, [
@@ -99,17 +133,99 @@ describe("execution engine", () => {
       },
       {
         type: "onchain-result",
-        subtype: "deploy-contract",
+        subtype: "deploy-contract-success",
         futureId: "Module1:Contract1",
         transactionId: 1,
-        contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+        contractAddress: exampleAddress,
       },
       {
         type: "execution-success",
         subtype: "deploy-contract",
         futureId: "Module1:Contract1",
         contractName: "Contract1",
-        contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+        contractAddress: exampleAddress,
+      },
+    ]);
+  });
+
+  it("should record a reverted contract deploy", async () => {
+    const moduleDefinition = defineModule("Module1", (m) => {
+      const account1 = m.getAccount(1);
+      const contract1 = m.contract("Contract1", [], { from: account1 });
+
+      return { contract1 };
+    });
+
+    const journal = new MemoryJournal();
+
+    const deployer = setupDeployerWithMocks({
+      journal,
+      transactionResponses: {
+        "Module1:Contract1": {
+          1: {
+            type: "onchain-result",
+            subtype: "failure",
+            futureId: "Module1:Contract1",
+            transactionId: 1,
+            error: new Error(
+              "Cannot estimate gas; transaction may fail or may require manual gas limit"
+            ),
+          },
+        },
+      },
+    });
+
+    const result = await deployer.deploy(moduleDefinition, {}, exampleAccounts);
+
+    assertDeploymentFailure(result, {
+      "Module1:Contract1": new Error(
+        "Cannot estimate gas; transaction may fail or may require manual gas limit"
+      ),
+    });
+
+    const journalMessages = await accumulateMessages(journal);
+
+    assert.deepStrictEqual(journalMessages, [
+      {
+        futureId: "Module1:Contract1",
+        type: "execution-start",
+        futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
+        strategy: "basic",
+        dependencies: [],
+        storedArtifactPath: "Module1:Contract1.json",
+        storedBuildInfoPath: "build-info-12345.json",
+        contractName: "Contract1",
+        value: BigInt(0).toString(),
+        constructorArgs: [],
+        libraries: {},
+        from: accounts[1],
+      },
+      {
+        type: "onchain-action",
+        subtype: "deploy-contract",
+        futureId: "Module1:Contract1",
+        transactionId: 1,
+        contractName: "Contract1",
+        args: [],
+        value: BigInt(0).toString(),
+        from: accounts[1],
+        storedArtifactPath: "Module1:Contract1.json",
+      },
+      {
+        type: "onchain-result",
+        subtype: "failure",
+        futureId: "Module1:Contract1",
+        transactionId: 1,
+        error: new Error(
+          "Cannot estimate gas; transaction may fail or may require manual gas limit"
+        ),
+      },
+      {
+        type: "execution-failure",
+        futureId: "Module1:Contract1",
+        error: new Error(
+          "Cannot estimate gas; transaction may fail or may require manual gas limit"
+        ),
       },
     ]);
   });
@@ -122,35 +238,33 @@ describe("execution engine", () => {
       return { library1 };
     });
 
-    const constructor = new ModuleConstructor();
-    const module = constructor.construct(moduleDefinition);
-
-    assert.isDefined(module);
-
-    const executionStateMap = {};
-
-    const batches = Batcher.batch(module, {});
-
-    const executionEngine = new ExecutionEngine();
     const journal = new MemoryJournal();
-    const accounts: string[] = exampleAccounts;
-    const mockTransactionService = setupMockTransactionService();
-    const mockArtifactResolver = setupMockArtifactResolver({} as any);
-    const mockDeploymentLoader = setupMockDeploymentLoader(journal);
 
-    const result = await executionEngine.execute({
-      batches,
-      module,
-      executionStateMap,
-      accounts,
-      strategy: new BasicExecutionStrategy(),
-      transactionService: mockTransactionService,
-      artifactResolver: mockArtifactResolver,
-      deploymentLoader: mockDeploymentLoader,
-      deploymentParameters: {},
+    const deployer = setupDeployerWithMocks({
+      journal,
+      transactionResponses: {
+        "Module1:Library1": {
+          1: {
+            type: "onchain-result",
+            subtype: "deploy-contract-success",
+            futureId: "Module1:Library1",
+            transactionId: 1,
+            contractAddress: exampleAddress,
+          },
+        },
+      },
     });
 
-    assert.isDefined(result);
+    const result = await deployer.deploy(moduleDefinition, {}, exampleAccounts);
+
+    assertDeploymentSuccess(result, {
+      "Module1:Library1": {
+        contractName: "Library1",
+        storedArtifactPath: "Module1:Library1.json",
+        contractAddress: exampleAddress,
+      },
+    });
+
     const journalMessages = await accumulateMessages(journal);
 
     assert.deepStrictEqual(journalMessages, [
@@ -181,17 +295,17 @@ describe("execution engine", () => {
       },
       {
         type: "onchain-result",
-        subtype: "deploy-contract",
+        subtype: "deploy-contract-success",
         futureId: "Module1:Library1",
         transactionId: 1,
-        contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+        contractAddress: exampleAddress,
       },
       {
         type: "execution-success",
         subtype: "deploy-contract",
         futureId: "Module1:Library1",
         contractName: "Library1",
-        contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+        contractAddress: exampleAddress,
       },
     ]);
   });
@@ -213,35 +327,33 @@ describe("execution engine", () => {
       return { contract1 };
     });
 
-    const constructor = new ModuleConstructor();
-    const module = constructor.construct(moduleDefinition);
-
-    assert.isDefined(module);
-
-    const executionStateMap = {};
-
-    const batches = Batcher.batch(module, {});
-
-    const executionEngine = new ExecutionEngine();
     const journal = new MemoryJournal();
-    const accounts: string[] = exampleAccounts;
-    const mockTransactionService = setupMockTransactionService();
-    const mockArtifactResolver = setupMockArtifactResolver();
-    const mockDeploymentLoader = setupMockDeploymentLoader(journal);
 
-    const result = await executionEngine.execute({
-      batches,
-      module,
-      executionStateMap,
-      accounts,
-      strategy: new BasicExecutionStrategy(),
-      transactionService: mockTransactionService,
-      artifactResolver: mockArtifactResolver,
-      deploymentLoader: mockDeploymentLoader,
-      deploymentParameters: {},
+    const deployer = setupDeployerWithMocks({
+      journal,
+      transactionResponses: {
+        "Module1:Contract1": {
+          1: {
+            type: "onchain-result",
+            subtype: "deploy-contract-success",
+            futureId: "Module1:Contract1",
+            transactionId: 1,
+            contractAddress: exampleAddress,
+          },
+        },
+      },
     });
 
-    assert.isDefined(result);
+    const result = await deployer.deploy(moduleDefinition, {}, exampleAccounts);
+
+    assertDeploymentSuccess(result, {
+      "Module1:Contract1": {
+        contractName: "Contract1",
+        storedArtifactPath: "Module1:Contract1.json",
+        contractAddress: exampleAddress,
+      },
+    });
+
     const journalMessages = await accumulateMessages(journal);
 
     assert.deepStrictEqual(
@@ -275,17 +387,17 @@ describe("execution engine", () => {
           },
           {
             type: "onchain-result",
-            subtype: "deploy-contract",
+            subtype: "deploy-contract-success",
             futureId: "Module1:Contract1",
             transactionId: 1,
-            contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+            contractAddress: exampleAddress,
           },
           {
             type: "execution-success",
             subtype: "deploy-contract",
             futureId: "Module1:Contract1",
             contractName: "Contract1",
-            contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+            contractAddress: exampleAddress,
           },
         ])
       )
@@ -314,35 +426,51 @@ describe("execution engine", () => {
         return { library1, contract1 };
       });
 
-      const constructor = new ModuleConstructor();
-      const module = constructor.construct(moduleDefinition);
-
-      assert.isDefined(module);
-
-      const executionStateMap = {};
-
-      const batches = Batcher.batch(module, {});
-
-      const executionEngine = new ExecutionEngine();
       const journal = new MemoryJournal();
-      const accounts: string[] = exampleAccounts;
-      const mockTransactionService = setupMockTransactionService();
-      const mockArtifactResolver = setupMockArtifactResolver({} as any);
-      const mockDeploymentLoader = setupMockDeploymentLoader(journal);
 
-      const result = await executionEngine.execute({
-        batches,
-        module,
-        executionStateMap,
-        accounts,
-        strategy: new BasicExecutionStrategy(),
-        transactionService: mockTransactionService,
-        artifactResolver: mockArtifactResolver,
-        deploymentLoader: mockDeploymentLoader,
-        deploymentParameters: {},
+      const deployer = setupDeployerWithMocks({
+        journal,
+        transactionResponses: {
+          "Module1:Contract1": {
+            1: {
+              type: "onchain-result",
+              subtype: "deploy-contract-success",
+              futureId: "Module1:Contract1",
+              transactionId: 1,
+              contractAddress: exampleAddress,
+            },
+          },
+          "Module1:Library1": {
+            1: {
+              type: "onchain-result",
+              subtype: "deploy-contract-success",
+              futureId: "Module1:Library1",
+              transactionId: 1,
+              contractAddress: differentAddress,
+            },
+          },
+        },
       });
 
-      assert.isDefined(result);
+      const result = await deployer.deploy(
+        moduleDefinition,
+        {},
+        exampleAccounts
+      );
+
+      assertDeploymentSuccess(result, {
+        "Module1:Contract1": {
+          contractName: "Contract1",
+          storedArtifactPath: "Module1:Contract1.json",
+          contractAddress: exampleAddress,
+        },
+        "Module1:Library1": {
+          contractName: "Library1",
+          storedArtifactPath: "Module1:Library1.json",
+          contractAddress: differentAddress,
+        },
+      });
+
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
@@ -373,17 +501,17 @@ describe("execution engine", () => {
         },
         {
           type: "onchain-result",
-          subtype: "deploy-contract",
+          subtype: "deploy-contract-success",
           futureId: "Module1:Library1",
           transactionId: 1,
-          contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+          contractAddress: differentAddress,
         },
         {
           type: "execution-success",
           subtype: "deploy-contract",
           futureId: "Module1:Library1",
           contractName: "Library1",
-          contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+          contractAddress: differentAddress,
         },
         {
           futureId: "Module1:Contract1",
@@ -398,7 +526,7 @@ describe("execution engine", () => {
           constructorArgs: [
             {
               arr: ["0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", 1000],
-              nested: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+              nested: differentAddress,
             },
           ],
           libraries: {
@@ -414,7 +542,7 @@ describe("execution engine", () => {
           contractName: "Contract1",
           args: [
             {
-              nested: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+              nested: differentAddress,
               arr: ["0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", 1000],
             },
           ],
@@ -424,61 +552,19 @@ describe("execution engine", () => {
         },
         {
           type: "onchain-result",
-          subtype: "deploy-contract",
+          subtype: "deploy-contract-success",
           futureId: "Module1:Contract1",
           transactionId: 1,
-          contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+          contractAddress: exampleAddress,
         },
         {
           type: "execution-success",
           subtype: "deploy-contract",
           futureId: "Module1:Contract1",
           contractName: "Contract1",
-          contractAddress: "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+          contractAddress: exampleAddress,
         },
       ]);
     });
   });
 });
-
-function setupMockTransactionService(): TransactionService {
-  const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
-
-  return {
-    onchain: async (message) => ({
-      type: "onchain-result",
-      subtype: "deploy-contract",
-      futureId: message.futureId,
-      transactionId: message.transactionId,
-      contractAddress: exampleAddress,
-    }),
-  } as TransactionService;
-}
-
-function setupMockDeploymentLoader(journal: Journal): DeploymentLoader {
-  return {
-    journal,
-    recordDeployedAddress: async () => {},
-    storeArtifact: async (futureId, _artifact) => {
-      return `${futureId}.json`;
-    },
-    storeBuildInfo: async (buildInfo) => {
-      return `build-info-${buildInfo.id}.json`;
-    },
-    loadArtifact: async (_storedArtifactPath) => {
-      throw new Error("Not implemented");
-    },
-  };
-}
-
-async function accumulateMessages(
-  journal: Journal
-): Promise<JournalableMessage[]> {
-  const messages: JournalableMessage[] = [];
-
-  for await (const message of journal.read()) {
-    messages.push(message);
-  }
-
-  return messages;
-}

--- a/packages/core/test/new-api/execution/restart.ts
+++ b/packages/core/test/new-api/execution/restart.ts
@@ -1,0 +1,118 @@
+import { defineModule } from "../../../src/new-api/define-module";
+import { MemoryJournal } from "../../../src/new-api/internal/journal/memory-journal";
+import { Wiper } from "../../../src/new-api/internal/wiper";
+import {
+  assertDeploymentFailure,
+  assertDeploymentSuccess,
+  exampleAccounts,
+  setupDeployerWithMocks,
+} from "../helpers";
+
+describe("execution engine", () => {
+  const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+
+  describe("restart - error", () => {
+    const contractWithOneArgConstructorArtifact = {
+      abi: [
+        {
+          type: "constructor",
+          stateMutability: "payable",
+          inputs: [
+            {
+              name: "_first",
+              type: "uint256",
+              internalType: "uint256",
+            },
+          ],
+        },
+      ],
+      contractName: "Contract1",
+      bytecode: "",
+      linkReferences: {},
+    };
+
+    it("should allow restart", async () => {
+      const firstRunModDef = defineModule("Module1", (m) => {
+        // Invalid constructor arg - causes revert
+        const contract1 = m.contract("Contract1", [0]);
+
+        return { contract1 };
+      });
+
+      const secondRunModDef = defineModule("Module1", (m) => {
+        // Valid constructor arg
+        const contract1 = m.contract("Contract1", [1]);
+
+        return { contract1 };
+      });
+
+      const journal = new MemoryJournal();
+
+      // Act - first run with revert on contract deploy
+
+      const initialDeployer = setupDeployerWithMocks({
+        journal,
+        artifacts: {
+          Contract1: contractWithOneArgConstructorArtifact,
+        },
+        transactionResponses: {
+          "Module1:Contract1": {
+            1: {
+              type: "onchain-result",
+              subtype: "failure",
+              futureId: "Module1:Contract1",
+              transactionId: 1,
+              error: new Error("EVM revert"),
+            },
+          },
+        },
+      });
+
+      const firstRunResult = await initialDeployer.deploy(
+        firstRunModDef,
+        {},
+        exampleAccounts
+      );
+
+      assertDeploymentFailure(firstRunResult, {
+        "Module1:Contract1": new Error("EVM revert"),
+      });
+
+      // Act - wipe the state for the failed future
+      await new Wiper(journal).wipe("Module1:Contract1");
+
+      // Act - rerun the deployment to success
+      const rerunDeployer = setupDeployerWithMocks({
+        journal,
+        artifacts: {
+          Contract1: contractWithOneArgConstructorArtifact,
+        },
+        transactionResponses: {
+          "Module1:Contract1": {
+            1: {
+              type: "onchain-result",
+              subtype: "deploy-contract-success",
+              futureId: "Module1:Contract1",
+              transactionId: 1,
+              contractAddress: exampleAddress,
+            },
+          },
+        },
+      });
+
+      const secondRunResult = await rerunDeployer.deploy(
+        secondRunModDef,
+        {},
+        exampleAccounts
+      );
+
+      assertDeploymentSuccess(secondRunResult, {
+        "Module1:Contract1": {
+          contractName: "Contract1",
+          contractAddress: exampleAddress,
+          storedArtifactPath: "Module1:Contract1.json",
+        },
+      });
+    });
+  });
+});

--- a/packages/core/test/new-api/library.ts
+++ b/packages/core/test/new-api/library.ts
@@ -311,7 +311,7 @@ describe("library", () => {
       await assert.isRejected(
         validateNamedLibraryDeployment(
           future as any,
-          setupMockArtifactResolver({} as any)
+          setupMockArtifactResolver({ Another: {} as any })
         ),
         /Artifact for contract 'Another' is invalid/
       );

--- a/packages/core/test/new-api/readEventArgument.ts
+++ b/packages/core/test/new-api/readEventArgument.ts
@@ -235,7 +235,7 @@ describe("Read event argument", () => {
       await assert.isRejected(
         validateReadEventArgument(
           future as any,
-          setupMockArtifactResolver({} as any)
+          setupMockArtifactResolver({ Another: {} as any })
         ),
         /Artifact for contract 'Another' is invalid/
       );
@@ -263,10 +263,7 @@ describe("Read event argument", () => {
       );
 
       await assert.isRejected(
-        validateReadEventArgument(
-          future as any,
-          setupMockArtifactResolver(fakeArtifact)
-        ),
+        validateReadEventArgument(future as any, setupMockArtifactResolver()),
         /Contract 'Another' doesn't have an event test/
       );
     });

--- a/packages/core/test/new-api/staticCall.ts
+++ b/packages/core/test/new-api/staticCall.ts
@@ -544,7 +544,7 @@ describe("static call", () => {
       await assert.isRejected(
         validateNamedStaticCall(
           future as any,
-          setupMockArtifactResolver({} as any)
+          setupMockArtifactResolver({ Another: {} as any })
         ),
         /Artifact for contract 'Another' is invalid/
       );
@@ -572,10 +572,7 @@ describe("static call", () => {
       );
 
       await assert.isRejected(
-        validateNamedStaticCall(
-          future as any,
-          setupMockArtifactResolver(fakeArtifact)
-        ),
+        validateNamedStaticCall(future as any, setupMockArtifactResolver()),
         /Contract 'Another' doesn't have a function test/
       );
     });
@@ -616,10 +613,7 @@ describe("static call", () => {
       );
 
       await assert.isRejected(
-        validateNamedStaticCall(
-          future as any,
-          setupMockArtifactResolver(fakeArtifact)
-        ),
+        validateNamedStaticCall(future as any, setupMockArtifactResolver()),
         /Function inc in contract Another expects 1 arguments but 2 were given/
       );
     });
@@ -678,10 +672,7 @@ describe("static call", () => {
       );
 
       await assert.isRejected(
-        validateNamedStaticCall(
-          future as any,
-          setupMockArtifactResolver(fakeArtifact)
-        ),
+        validateNamedStaticCall(future as any, setupMockArtifactResolver()),
         /Function inc in contract Another is overloaded, but no overload expects 3 arguments/
       );
     });
@@ -722,10 +713,7 @@ describe("static call", () => {
       );
 
       await assert.isRejected(
-        validateNamedStaticCall(
-          future as any,
-          setupMockArtifactResolver(fakeArtifact)
-        ),
+        validateNamedStaticCall(future as any, setupMockArtifactResolver()),
         /Function inc in contract Another is not 'pure' or 'view' and cannot be statically called/
       );
     });

--- a/packages/core/test/new-api/wipe.ts
+++ b/packages/core/test/new-api/wipe.ts
@@ -1,0 +1,89 @@
+import { assert } from "chai";
+
+import { defineModule } from "../../src/new-api/define-module";
+import { MemoryJournal } from "../../src/new-api/internal/journal/memory-journal";
+import { Wiper } from "../../src/new-api/internal/wiper";
+import { Journal } from "../../src/new-api/types/journal";
+import { IgnitionModuleResult } from "../../src/new-api/types/module";
+import { IgnitionModuleDefinition } from "../../src/new-api/types/module-builder";
+
+import {
+  accumulateMessages,
+  exampleAccounts,
+  setupDeployerWithMocks,
+} from "./helpers";
+
+describe("wipe", () => {
+  const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+  let journal: Journal;
+  let moduleDefinition: IgnitionModuleDefinition<
+    string,
+    string,
+    IgnitionModuleResult<string>
+  >;
+  let wiper: Wiper;
+
+  beforeEach(async () => {
+    journal = new MemoryJournal();
+    wiper = new Wiper(journal);
+
+    moduleDefinition = defineModule("Module1", (m) => {
+      const contract1 = m.contract("Contract1", [], { after: [] });
+      const contract2 = m.contract("Contract2", [], { after: [contract1] });
+      const contract3 = m.contract("Contract3", [], { after: [contract2] });
+
+      return { contract1, contract2, contract3 };
+    });
+
+    const deployer = setupDeployerWithMocks({
+      journal,
+      transactionResponses: {
+        "Module1:Contract1": {
+          1: {
+            type: "onchain-result",
+            subtype: "deploy-contract-success",
+            futureId: "Module1:Contract1",
+            transactionId: 1,
+            contractAddress: exampleAddress,
+          },
+        },
+        "Module1:Contract2": {
+          1: {
+            type: "onchain-result",
+            subtype: "failure",
+            futureId: "Module1:Contract1",
+            transactionId: 1,
+            error: new Error("EVM revert"),
+          },
+        },
+      },
+    });
+
+    await deployer.deploy(moduleDefinition, {}, exampleAccounts);
+  });
+
+  it("should allow wiping of future", async () => {
+    await wiper.wipe("Module1:Contract2");
+
+    const messages = await accumulateMessages(journal);
+
+    assert.deepStrictEqual(messages[messages.length - 1], {
+      futureId: "Module1:Contract2",
+      type: "wipe",
+    });
+  });
+
+  it("should error if the future id doesn't exist", async () => {
+    await assert.isRejected(
+      wiper.wipe("Module1:Nonexistant"),
+      "Cannot wipe Module1:Nonexistant as no state recorded against it"
+    );
+  });
+
+  it("should error if other futures are depenent on the future being wiped", async () => {
+    await assert.isRejected(
+      wiper.wipe("Module1:Contract1"),
+      "Cannot wipe Module1:Contract1 as there are dependent futures that have already started:\n  Module1:Contract2"
+    );
+  });
+});


### PR DESCRIPTION
Support restarting a run after a failed future (i.e. a future that has a transaction that reverts).

A `wipe` cli command has been added to allow reruns on error by clearing
the state against a future:

```sh
npx hardhat wipe --deployment network-31337 --future LockModule:Lock
# LockModule:Lock state has been cleared
```

## TODO

- [x] Support error in journal messages
- [x] Display error messages at cli
- [x] Add cli task to remove future extension state
- [x] Add tests to cover error case

