### PR TITLE
Include readEventArgument in execution (PR 9)

### DIFF
--- a/examples/complete/ignition/CompleteModule.js
+++ b/examples/complete/ignition/CompleteModule.js
@@ -19,9 +19,9 @@ module.exports = defineModule("CompleteModule", (m) => {
     }
   );
 
-  m.call(basic, "basicFunction", [40]);
-  // const eventArg = m.readEventArgument(call, "BasicEvent", "eventArg");
-  m.staticCall(withLib, "readonlyFunction", [42]);
+  const call = m.call(basic, "basicFunction", [40]);
+  const eventArg = m.readEventArgument(call, "BasicEvent", "eventArg");
+  m.staticCall(withLib, "readonlyFunction", [eventArg]);
 
   // const duplicate = m.contractAt("BasicContract", basic);
   // const duplicateWithLib = m.contractAtFromArtifact(

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -124,10 +124,12 @@ export class ExecutionEngine {
     const deployedContracts = this._resolveDeployedContractsFrom(state);
 
     const libraries = Object.fromEntries(
-      dependencies.map((id) => {
-        const lib = deployedContracts[id];
-        return [lib.contractName, lib.contractAddress];
-      })
+      dependencies
+        .filter((id) => deployedContracts[id] !== undefined)
+        .map((id) => {
+          const lib = deployedContracts[id];
+          return [lib.contractName, lib.contractAddress];
+        })
     );
 
     while (!isExecutionResultMessage(current)) {
@@ -234,7 +236,11 @@ export class ExecutionEngine {
           storedBuildInfoPath: undefined,
           contractName: future.contractName,
           value: future.value.toString(),
-          constructorArgs: future.constructorArgs,
+          constructorArgs: this._resolveArgs(future.constructorArgs, {
+            accounts,
+            deploymentParameters,
+            executionStateMap,
+          }),
           libraries: Object.fromEntries(
             Object.entries(future.libraries).map(([key, lib]) => [key, lib.id])
           ),
@@ -342,7 +348,11 @@ export class ExecutionEngine {
           // status: ExecutionStatus.STARTED,
           dependencies: [...future.dependencies].map((f) => f.id),
           // history: [],
-          args: future.args,
+          args: this._resolveArgs(future.args, {
+            accounts,
+            deploymentParameters,
+            executionStateMap,
+          }),
           functionName: future.functionName,
           contractAddress,
           storedArtifactPath,
@@ -369,7 +379,11 @@ export class ExecutionEngine {
           // status: ExecutionStatus.STARTED,
           dependencies: [...future.dependencies].map((f) => f.id),
           // history: [],
-          args: future.args,
+          args: this._resolveArgs(future.args, {
+            accounts,
+            deploymentParameters,
+            executionStateMap,
+          }),
           functionName: future.functionName,
           contractAddress,
           storedArtifactPath,

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -392,10 +392,12 @@ export class ExecutionEngine {
         return state;
       }
       case FutureType.READ_EVENT_ARGUMENT: {
+        // TODO: This should also support contractAt
         const { contractAddress, storedArtifactPath } = executionStateMap[
           future.emitter.id
         ] as DeploymentExecutionState;
 
+        // TODO: This should support multiple transactions
         const { txId } = executionStateMap[
           future.futureToReadFrom.id
         ] as DeploymentExecutionState;

--- a/packages/core/src/new-api/internal/execution/guards.ts
+++ b/packages/core/src/new-api/internal/execution/guards.ts
@@ -8,6 +8,7 @@ import {
   ExecutionSuccess,
   JournalableMessage,
   OnchainInteractionMessage,
+  ReadEventArgumentInteractionMessage,
   StaticCallInteractionMessage,
 } from "../../types/journal";
 
@@ -71,6 +72,12 @@ export function isStaticCallInteraction(
   potential: JournalableMessage
 ): potential is StaticCallInteractionMessage {
   return isOnChainAction(potential) && potential.subtype === "static-call";
+}
+
+export function isReadEventArgumentInteraction(
+  potential: JournalableMessage
+): potential is ReadEventArgumentInteractionMessage {
+  return isOnChainAction(potential) && potential.subtype === "read-event-arg";
 }
 
 export function isDeployedContractExecutionSuccess(

--- a/packages/core/src/new-api/internal/execution/transactions/chain-dispatcher.ts
+++ b/packages/core/src/new-api/internal/execution/transactions/chain-dispatcher.ts
@@ -20,6 +20,7 @@ export interface ChainDispatcher {
     tx: ethers.providers.TransactionRequest,
     signer: ethers.Signer
   ): Promise<TransactionReceipt>;
+  getTxReceipt(txHash: string): Promise<ethers.providers.TransactionReceipt>;
 }
 
 /**
@@ -66,6 +67,7 @@ export class EthersChainDispatcher implements ChainDispatcher {
       return {
         type: "transaction-success",
         contractAddress: receipt.contractAddress,
+        txId: receipt.transactionHash,
       };
     } catch (error) {
       return {
@@ -76,5 +78,11 @@ export class EthersChainDispatcher implements ChainDispatcher {
             : new Error("Unknown issue during `sendTx`"),
       };
     }
+  }
+
+  public async getTxReceipt(
+    txHash: string
+  ): Promise<ethers.providers.TransactionReceipt> {
+    return this._transactionProvider.getTransactionReceipt(txHash);
   }
 }

--- a/packages/core/src/new-api/internal/execution/transactions/transaction-service.ts
+++ b/packages/core/src/new-api/internal/execution/transactions/transaction-service.ts
@@ -284,7 +284,9 @@ export class TransactionServiceImplementation implements TransactionService {
         subtype: "read-event-arg-success",
         futureId,
         transactionId,
-        result,
+        result: ethers.BigNumber.isBigNumber(result)
+          ? result.toString()
+          : result,
       };
     } catch (error) {
       return {

--- a/packages/core/src/new-api/internal/journal/type-guards.ts
+++ b/packages/core/src/new-api/internal/journal/type-guards.ts
@@ -9,6 +9,7 @@ import {
   OnchainResultMessage,
   OnchainResultSuccessMessage,
   OnchainStaticCallSuccessMessage,
+  ReadEventArgumentStartMessage,
   StaticCallStartMessage,
 } from "../../types/journal";
 import { FutureType } from "../../types/module";
@@ -54,7 +55,7 @@ export function isCallFunctionStartMessage(
 }
 
 /**
- * Returns true if potential is a call function start message
+ * Returns true if potential is a call static function start message
  *
  * @beta
  */
@@ -62,6 +63,17 @@ export function isStaticCallStartMessage(
   potential: FutureStartMessage
 ): potential is StaticCallStartMessage {
   return potential.futureType === FutureType.NAMED_STATIC_CALL;
+}
+
+/**
+ * Returns true if potential is a read event argument start message
+ *
+ * @beta
+ */
+export function isReadEventArgumentStartMessage(
+  potential: FutureStartMessage
+): potential is ReadEventArgumentStartMessage {
+  return potential.futureType === FutureType.READ_EVENT_ARGUMENT;
 }
 
 export function isOnChainResultMessage(

--- a/packages/core/src/new-api/internal/journal/type-guards.ts
+++ b/packages/core/src/new-api/internal/journal/type-guards.ts
@@ -5,6 +5,7 @@ import {
   JournalableMessage,
   OnchainCallFunctionSuccessMessage,
   OnchainDeployContractSuccessMessage,
+  OnchainReadEventArgumentSuccessMessage,
   OnchainResultFailureMessage,
   OnchainResultMessage,
   OnchainResultSuccessMessage,
@@ -88,7 +89,8 @@ export function isOnChainSuccessMessage(
   return (
     isOnchainDeployContractSuccessMessage(message) ||
     isOnchainCallFunctionSuccessMessage(message) ||
-    isOnchainStaticCallSuccessMessage(message)
+    isOnchainStaticCallSuccessMessage(message) ||
+    isOnchainReadEventArgumentSuccessMessage(message)
   );
 }
 
@@ -121,5 +123,14 @@ export function isOnchainStaticCallSuccessMessage(
 ): message is OnchainStaticCallSuccessMessage {
   return (
     isOnChainResultMessage(message) && message.subtype === "static-call-success"
+  );
+}
+
+export function isOnchainReadEventArgumentSuccessMessage(
+  message: JournalableMessage
+): message is OnchainReadEventArgumentSuccessMessage {
+  return (
+    isOnChainResultMessage(message) &&
+    message.subtype === "read-event-arg-success"
   );
 }

--- a/packages/core/src/new-api/internal/reconciliation/execution-state-resolver.ts
+++ b/packages/core/src/new-api/internal/reconciliation/execution-state-resolver.ts
@@ -228,7 +228,7 @@ export class ExecutionStateResolver {
 
     const senders = executionState.history
       .filter(isOnchainInteractionMessage)
-      .map((m) => m.from);
+      .map((m) => ("from" in m ? m.from : undefined));
 
     if (senders.length > 0) {
       return senders[0];

--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileReadEventArgument.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileReadEventArgument.ts
@@ -36,10 +36,10 @@ export function reconcileReadEventArgument(
       context
     );
 
-  if (resolvedEmitterAddress !== executionState.emitter) {
+  if (resolvedEmitterAddress !== executionState.emitterAddress) {
     return fail(
       future,
-      `Emitter has been changed from ${executionState.emitter} to ${resolvedEmitterAddress}`
+      `Emitter has been changed from ${executionState.emitterAddress} to ${resolvedEmitterAddress}`
     );
   }
 

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -131,6 +131,7 @@ export interface DeploymentExecutionState
   value: bigint;
   from: string | undefined;
   contractAddress?: string; // The result
+  txId?: string; // also stored after success for use when reading events
 }
 
 export interface CallExecutionState
@@ -164,10 +165,12 @@ export interface ContractAtExecutionState
 
 export interface ReadEventArgumentExecutionState
   extends BaseExecutionState<FutureType.READ_EVENT_ARGUMENT> {
+  storedArtifactPath: string; // As stored in the deployment directory.
   eventName: string;
   argumentName: string;
+  txToReadFrom: string;
+  emitterAddress: string;
   eventIndex: number;
-  emitter: string;
   result?: SolidityParameterType;
 }
 

--- a/packages/core/src/new-api/types/adapters.ts
+++ b/packages/core/src/new-api/types/adapters.ts
@@ -39,4 +39,7 @@ export interface GasAdapter {
  */
 export interface TransactionsAdapter {
   wait(txHash: string): Promise<ethers.providers.TransactionReceipt>;
+  getTransactionReceipt(
+    txHash: string
+  ): Promise<ethers.providers.TransactionReceipt>;
 }

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -1,4 +1,4 @@
-import { ArgumentType, FutureType, PrimitiveArgType } from "./module";
+import { ArgumentType, FutureType, SolidityParameterType } from "./module";
 
 /**
  * Store a deployments execution state as a transaction log.
@@ -42,7 +42,8 @@ export type TransactionMessage =
 export type OnchainInteractionMessage =
   | DeployContractInteractionMessage
   | CallFunctionInteractionMessage
-  | StaticCallInteractionMessage;
+  | StaticCallInteractionMessage
+  | ReadEventArgumentInteractionMessage;
 
 /**
  * A on-chain interaction request to deploy a contract/library.
@@ -96,6 +97,24 @@ export interface StaticCallInteractionMessage {
   from: string;
 }
 
+/**
+ * A on-chain interaction request to read an event argument.
+ *
+ * @beta
+ */
+export interface ReadEventArgumentInteractionMessage {
+  type: "onchain-action";
+  subtype: "read-event-arg";
+  futureId: string;
+  transactionId: number;
+  storedArtifactPath: string;
+  eventName: string;
+  argumentName: string;
+  txToReadFrom: string;
+  emitterAddress: string;
+  eventIndex: number;
+}
+
 // #endregion
 
 // #region "OnchainResult"
@@ -112,7 +131,8 @@ export type OnchainResultMessage =
 export type OnchainResultSuccessMessage =
   | OnchainDeployContractSuccessMessage
   | OnchainCallFunctionSuccessMessage
-  | OnchainStaticCallSuccessMessage;
+  | OnchainStaticCallSuccessMessage
+  | OnchainReadEventArgumentSuccessMessage;
 
 export type OnchainResultFailureMessage = OnchainFailureMessage;
 
@@ -127,6 +147,7 @@ export interface OnchainDeployContractSuccessMessage {
   futureId: string;
   transactionId: number;
   contractAddress: string;
+  txId: string;
 }
 
 /**
@@ -152,7 +173,20 @@ export interface OnchainStaticCallSuccessMessage {
   subtype: "static-call-success";
   futureId: string;
   transactionId: number;
-  result: PrimitiveArgType | PrimitiveArgType[];
+  result: SolidityParameterType;
+}
+
+/**
+ * A successful read event argument result.
+ *
+ * @beta
+ */
+export interface OnchainReadEventArgumentSuccessMessage {
+  type: "onchain-result";
+  subtype: "read-event-arg-success";
+  futureId: string;
+  transactionId: number;
+  result: SolidityParameterType;
 }
 
 /**
@@ -198,7 +232,8 @@ export type ExecutionUpdateMessage = FutureStartMessage | FutureRestartMessage;
 export type FutureStartMessage =
   | DeployContractStartMessage
   | CallFunctionStartMessage
-  | StaticCallStartMessage;
+  | StaticCallStartMessage
+  | ReadEventArgumentStartMessage;
 
 /**
  * A journal message to initialise the execution state for a contract deployment.
@@ -262,6 +297,25 @@ export interface StaticCallStartMessage {
 }
 
 /**
+ * A journal message to initialise the execution state for reading an event argument.
+ *
+ * @beta
+ */
+export interface ReadEventArgumentStartMessage {
+  type: "execution-start";
+  futureId: string;
+  futureType: FutureType.READ_EVENT_ARGUMENT;
+  strategy: string;
+  dependencies: string[];
+  storedArtifactPath: string;
+  eventName: string;
+  argumentName: string;
+  txToReadFrom: string;
+  emitterAddress: string;
+  eventIndex: number;
+}
+
+/**
  * A journal message to indicate a future is being restarted.
  *
  * @beta
@@ -306,7 +360,8 @@ export type ExecutionResultTypes = [
 export type ExecutionSuccess =
   | DeployedContractExecutionSuccess
   | CalledFunctionExecutionSuccess
-  | StaticCallExecutionSuccess;
+  | StaticCallExecutionSuccess
+  | ReadEventArgumentExecutionSuccess;
 
 /**
  * A journal message indicating a contract/library deployed successfully.
@@ -319,6 +374,7 @@ export interface DeployedContractExecutionSuccess {
   futureId: string;
   contractName: string;
   contractAddress: string;
+  txId: string;
 }
 
 /**
@@ -345,8 +401,22 @@ export interface StaticCallExecutionSuccess {
   subtype: "static-call";
   futureId: string;
   functionName: string;
-  result: PrimitiveArgType | PrimitiveArgType[];
+  result: SolidityParameterType;
   contractAddress: string;
+}
+
+/**
+ * A journal message indicating an event argument was read successfully.
+ *
+ * @beta
+ */
+export interface ReadEventArgumentExecutionSuccess {
+  type: "execution-success";
+  subtype: "read-event-arg";
+  futureId: string;
+  eventName: string;
+  argumentName: string;
+  result: SolidityParameterType;
 }
 
 // #endregion

--- a/packages/core/src/new-api/types/module.ts
+++ b/packages/core/src/new-api/types/module.ts
@@ -1,20 +1,16 @@
 import { Artifact } from "./artifact";
 
 /**
- * Argument type representing primitive values expressed in smart contracts.
- *
- * @beta
- */
-export type PrimitiveArgType = number | bigint | string | boolean;
-
-/**
  * Base argument type that smart contracts can receive in their constructors
  * and functions.
  *
  * @beta
  */
 export type BaseArgumentType =
-  | PrimitiveArgType
+  | number
+  | bigint
+  | string
+  | boolean
   | ContractFuture<string>
   | NamedStaticCallFuture<string, string>
   | ReadEventArgumentFuture

--- a/packages/core/test/new-api/execution/execution-engine.ts
+++ b/packages/core/test/new-api/execution/execution-engine.ts
@@ -15,6 +15,7 @@ describe("execution engine", () => {
   const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
   const differentAddress = "0xBA12222222228d8Ba445958a75a0704d566BF2C8";
   const accounts = exampleAccounts;
+  const txId = "0x123";
 
   const contractWithThreeArgConstructorArtifact = {
     abi: [
@@ -74,6 +75,7 @@ describe("execution engine", () => {
             futureId: "Module1:Contract1",
             transactionId: 1,
             contractAddress: exampleAddress,
+            txId,
           },
         },
       },
@@ -137,6 +139,7 @@ describe("execution engine", () => {
         futureId: "Module1:Contract1",
         transactionId: 1,
         contractAddress: exampleAddress,
+        txId,
       },
       {
         type: "execution-success",
@@ -144,6 +147,7 @@ describe("execution engine", () => {
         futureId: "Module1:Contract1",
         contractName: "Contract1",
         contractAddress: exampleAddress,
+        txId,
       },
     ]);
   });
@@ -250,6 +254,7 @@ describe("execution engine", () => {
             futureId: "Module1:Library1",
             transactionId: 1,
             contractAddress: exampleAddress,
+            txId,
           },
         },
       },
@@ -299,6 +304,7 @@ describe("execution engine", () => {
         futureId: "Module1:Library1",
         transactionId: 1,
         contractAddress: exampleAddress,
+        txId,
       },
       {
         type: "execution-success",
@@ -306,6 +312,7 @@ describe("execution engine", () => {
         futureId: "Module1:Library1",
         contractName: "Library1",
         contractAddress: exampleAddress,
+        txId,
       },
     ]);
   });
@@ -339,6 +346,7 @@ describe("execution engine", () => {
             futureId: "Module1:Contract1",
             transactionId: 1,
             contractAddress: exampleAddress,
+            txId,
           },
         },
       },
@@ -391,6 +399,7 @@ describe("execution engine", () => {
             futureId: "Module1:Contract1",
             transactionId: 1,
             contractAddress: exampleAddress,
+            txId,
           },
           {
             type: "execution-success",
@@ -398,6 +407,7 @@ describe("execution engine", () => {
             futureId: "Module1:Contract1",
             contractName: "Contract1",
             contractAddress: exampleAddress,
+            txId,
           },
         ])
       )
@@ -438,6 +448,7 @@ describe("execution engine", () => {
               futureId: "Module1:Contract1",
               transactionId: 1,
               contractAddress: exampleAddress,
+              txId,
             },
           },
           "Module1:Library1": {
@@ -447,6 +458,7 @@ describe("execution engine", () => {
               futureId: "Module1:Library1",
               transactionId: 1,
               contractAddress: differentAddress,
+              txId,
             },
           },
         },
@@ -505,6 +517,7 @@ describe("execution engine", () => {
           futureId: "Module1:Library1",
           transactionId: 1,
           contractAddress: differentAddress,
+          txId,
         },
         {
           type: "execution-success",
@@ -512,6 +525,7 @@ describe("execution engine", () => {
           futureId: "Module1:Library1",
           contractName: "Library1",
           contractAddress: differentAddress,
+          txId,
         },
         {
           futureId: "Module1:Contract1",
@@ -556,6 +570,7 @@ describe("execution engine", () => {
           futureId: "Module1:Contract1",
           transactionId: 1,
           contractAddress: exampleAddress,
+          txId,
         },
         {
           type: "execution-success",
@@ -563,6 +578,7 @@ describe("execution engine", () => {
           futureId: "Module1:Contract1",
           contractName: "Contract1",
           contractAddress: exampleAddress,
+          txId,
         },
       ]);
     });

--- a/packages/core/test/new-api/execution/restart.ts
+++ b/packages/core/test/new-api/execution/restart.ts
@@ -10,6 +10,7 @@ import {
 
 describe("execution engine", () => {
   const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+  const txId = "0x123";
 
   describe("restart - error", () => {
     const contractWithOneArgConstructorArtifact = {
@@ -95,6 +96,7 @@ describe("execution engine", () => {
               futureId: "Module1:Contract1",
               transactionId: 1,
               contractAddress: exampleAddress,
+              txId,
             },
           },
         },

--- a/packages/core/test/new-api/reconciliation/futures/reconcileReadEventArgument.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileReadEventArgument.ts
@@ -13,6 +13,7 @@ import { assertSuccessReconciliation, reconcile } from "../helpers";
 describe("Reconciliation - read event argument", () => {
   const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
   const differentAddress = "0xBA12222222228d8Ba445958a75a0704d566BF2C8";
+  const txId = "0x123";
 
   const exampleReadArgState: ReadEventArgumentExecutionState = {
     id: "Example",
@@ -21,10 +22,12 @@ describe("Reconciliation - read event argument", () => {
     status: ExecutionStatus.STARTED,
     dependencies: new Set<string>(),
     history: [],
+    storedArtifactPath: "./artifact.json",
     eventName: "event1",
     argumentName: "argument1",
     eventIndex: 0,
-    emitter: exampleAddress,
+    emitterAddress: exampleAddress,
+    txToReadFrom: txId,
   };
 
   const exampleDeploymentState: DeploymentExecutionState = {
@@ -41,6 +44,7 @@ describe("Reconciliation - read event argument", () => {
     constructorArgs: [],
     libraries: {},
     from: exampleAccounts[0],
+    txId,
   };
 
   it("should reconcile unchanged", () => {
@@ -211,7 +215,7 @@ describe("Reconciliation - read event argument", () => {
       "Module:ReadEvent": {
         ...exampleReadArgState,
         status: ExecutionStatus.STARTED,
-        emitter: exampleAddress,
+        emitterAddress: exampleAddress,
       },
     });
 
@@ -258,7 +262,7 @@ describe("Reconciliation - read event argument", () => {
         dependencies: new Set(["Module:Contract1"]),
         eventName: "event1",
         argumentName: "argument1",
-        emitter: exampleAddress,
+        emitterAddress: exampleAddress,
         result: "first",
       },
       "Module:ReadEvent2": {
@@ -267,7 +271,7 @@ describe("Reconciliation - read event argument", () => {
         dependencies: new Set(["Module:Contract1"]),
         eventName: "event2",
         argumentName: "argument2",
-        emitter: exampleAddress,
+        emitterAddress: exampleAddress,
         result: "second",
       },
       "Module:Contract2": {

--- a/packages/core/test/new-api/wipe.ts
+++ b/packages/core/test/new-api/wipe.ts
@@ -15,6 +15,7 @@ import {
 
 describe("wipe", () => {
   const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+  const txId = "0x123";
   let journal: Journal;
   let moduleDefinition: IgnitionModuleDefinition<
     string,
@@ -45,6 +46,7 @@ describe("wipe", () => {
             futureId: "Module1:Contract1",
             transactionId: 1,
             contractAddress: exampleAddress,
+            txId,
           },
         },
         "Module1:Contract2": {

--- a/packages/hardhat-plugin/src/buildAdaptersFrom.ts
+++ b/packages/hardhat-plugin/src/buildAdaptersFrom.ts
@@ -26,6 +26,11 @@ export function buildAdaptersFrom(hre: HardhatRuntimeEnvironment): Adapters {
     async wait(txHash: string): Promise<ethers.providers.TransactionReceipt> {
       return hre.ethers.provider.waitForTransaction(txHash);
     },
+    async getTransactionReceipt(
+      txHash: string
+    ): Promise<ethers.providers.TransactionReceipt> {
+      return hre.ethers.provider.getTransactionReceipt(txHash);
+    },
   };
 
   const adapters: Adapters = {


### PR DESCRIPTION
- support `m.readEventArgument` in execution engine
- support passing result of `m.readEventArgument` execution into other futures as arguments

fixes #266 