### PR TITLE
execution/timeouts (PR F)

### DIFF
--- a/packages/core/src/new-api/deploy.ts
+++ b/packages/core/src/new-api/deploy.ts
@@ -4,7 +4,7 @@ import { FileDeploymentLoader } from "./internal/deployment-loader/file-deployme
 import { ChainDispatcherImpl } from "./internal/execution/chain-dispatcher";
 import { Adapters } from "./types/adapters";
 import { ArtifactResolver } from "./types/artifact";
-import { DeploymentResult } from "./types/deployer";
+import { DeployConfig, DeploymentResult } from "./types/deployer";
 import { IgnitionModuleResult, ModuleParameters } from "./types/module";
 import { IgnitionModuleDefinition } from "./types/module-builder";
 
@@ -14,6 +14,7 @@ import { IgnitionModuleDefinition } from "./types/module-builder";
  * @beta
  */
 export async function deploy({
+  config,
   artifactResolver,
   adapters,
   deploymentDir,
@@ -22,6 +23,7 @@ export async function deploy({
   accounts,
   verbose,
 }: {
+  config?: Partial<DeployConfig>;
   artifactResolver: ArtifactResolver;
   adapters: Adapters;
   deploymentDir?: string;
@@ -42,6 +44,7 @@ export async function deploy({
   const chainDispatcher = new ChainDispatcherImpl(adapters);
 
   const deployer = new Deployer({
+    config: config ?? {},
     artifactResolver,
     deploymentLoader,
     chainDispatcher,

--- a/packages/core/src/new-api/internal/batcher.ts
+++ b/packages/core/src/new-api/internal/batcher.ts
@@ -76,6 +76,7 @@ export class Batcher {
         switch (executionState.status) {
           case ExecutionStatus.FAILED:
           case ExecutionStatus.HOLD:
+          case ExecutionStatus.TIMEOUT:
           case ExecutionStatus.STARTED:
             return [f.id, VisitStatus.UNVISITED];
           case ExecutionStatus.SUCCESS:

--- a/packages/core/src/new-api/internal/execution/guards.ts
+++ b/packages/core/src/new-api/internal/execution/guards.ts
@@ -9,6 +9,7 @@ import {
   ExecutionHold,
   ExecutionResultMessage,
   ExecutionSuccess,
+  ExecutionTimeout,
   JournalableMessage,
   OnchainInteractionMessage,
   ReadEventArgumentExecutionSuccess,
@@ -24,6 +25,7 @@ export function isExecutionResultMessage(
 ): potential is ExecutionResultMessage {
   return (
     isExecutionSuccess(potential) ||
+    isExecutionTimeout(potential) ||
     isExecutionFailure(potential) ||
     isExecutionHold(potential)
   );
@@ -39,6 +41,12 @@ export function isExecutionFailure(
   potential: JournalableMessage
 ): potential is ExecutionFailure {
   return potential.type === "execution-failure";
+}
+
+export function isExecutionTimeout(
+  potential: JournalableMessage
+): potential is ExecutionTimeout {
+  return potential.type === "execution-timeout";
 }
 
 export function isExecutionHold(

--- a/packages/core/src/new-api/internal/execution/transaction-lookup-timer.ts
+++ b/packages/core/src/new-api/internal/execution/transaction-lookup-timer.ts
@@ -1,0 +1,57 @@
+import {
+  TransactionLookup,
+  TransactionLookupTimer,
+} from "../types/transaction-timer";
+import { assertIgnitionInvariant } from "../utils/assertions";
+
+type TransactionLookupEntry = TransactionLookup & {
+  start: Date;
+};
+
+export class TranactionLookupTimerImpl implements TransactionLookupTimer {
+  private _startTimes: { [key: string]: TransactionLookupEntry };
+
+  constructor(private _timeoutInMilliseconds: number) {
+    this._startTimes = {};
+  }
+
+  public registerStartTimeIfNeeded({
+    txHash,
+    futureId,
+    executionId,
+  }: TransactionLookup): void {
+    if (txHash in this._startTimes) {
+      return;
+    }
+
+    this._startTimes[txHash] = {
+      txHash,
+      futureId,
+      executionId,
+      start: new Date(),
+    };
+  }
+
+  public isTimedOut(txHash: string): boolean {
+    assertIgnitionInvariant(
+      txHash in this._startTimes,
+      "Cannot calculate timeout if start time not set"
+    );
+
+    const startTime = this._startTimes[txHash].start.getTime();
+    const currentTime = new Date().getTime();
+
+    return currentTime - startTime > this._timeoutInMilliseconds;
+  }
+
+  public getTimedOutTransactions(): TransactionLookup[] {
+    return Object.keys(this._startTimes)
+      .filter((txHash) => this.isTimedOut(txHash))
+      .map((txHash) => this._startTimes[txHash])
+      .map(({ futureId, executionId, txHash }) => ({
+        futureId,
+        executionId,
+        txHash,
+      }));
+  }
+}

--- a/packages/core/src/new-api/internal/journal/type-guards.ts
+++ b/packages/core/src/new-api/internal/journal/type-guards.ts
@@ -19,12 +19,33 @@ import {
   OnchainTransactionReset,
   ReadEventArgumentStartMessage,
   SendDataStartMessage,
+  StartRunMessage,
   StaticCallStartMessage,
   TransactionMessage,
   WipeMessage,
 } from "../../types/journal";
 import { FutureType } from "../../types/module";
 import { isOnchainInteractionMessage } from "../execution/guards";
+
+/**
+ * Determines if potential is a StartRunMessage.
+ *
+ * @beta
+ */
+export function isStartRunMessage(
+  potential: JournalableMessage
+): potential is StartRunMessage {
+  return potential.type === "run-start";
+}
+
+/**
+ * Determines if potential is a Wipe message
+ */
+export function isWipeMessage(
+  potential: JournalableMessage
+): potential is WipeMessage {
+  return potential.type === "wipe";
+}
 
 /**
  * Returns true if potential is ane execution start message.
@@ -250,10 +271,4 @@ export function isOnchainFailureMessage(
   message: JournalableMessage
 ): message is OnchainFailureMessage {
   return isOnChainResultMessage(message) && message.subtype === "failure";
-}
-
-export function isWipeMessage(
-  potential: JournalableMessage
-): potential is WipeMessage {
-  return potential.type === "wipe";
 }

--- a/packages/core/src/new-api/internal/journal/utils/log.ts
+++ b/packages/core/src/new-api/internal/journal/utils/log.ts
@@ -9,6 +9,7 @@ import {
   isDeployedContractExecutionSuccess,
   isExecutionFailure,
   isExecutionHold,
+  isExecutionTimeout,
   isReadEventArgumentExecutionSuccess,
   isReadEventArgumentInteraction,
   isSendDataExecutionSuccess,
@@ -32,11 +33,18 @@ import {
   isOnchainTransactionReset,
   isReadEventArgumentStartMessage,
   isSendDataStartMessage,
+  isStartRunMessage,
   isStaticCallStartMessage,
   isWipeMessage,
 } from "../type-guards";
 
 export function logJournalableMessage(message: JournalableMessage): void {
+  /* run messages */
+
+  if (isStartRunMessage(message)) {
+    return console.log(`deployment run starting`);
+  }
+
   /* start messages */
 
   if (isDeployContractStartMessage(message)) {
@@ -218,6 +226,12 @@ export function logJournalableMessage(message: JournalableMessage): void {
   if (isOnChainFailureMessage(message)) {
     return console.log(
       `on chain failure - futureId: '${message.futureId}' - executionId: ${message.executionId} - error: '${message.error.message}'`
+    );
+  }
+
+  if (isExecutionTimeout(message)) {
+    return console.log(
+      `execution timeout - futureId: '${message.futureId}' - executionId: ${message.executionId}'`
     );
   }
 

--- a/packages/core/src/new-api/internal/types/execution-engine.ts
+++ b/packages/core/src/new-api/internal/types/execution-engine.ts
@@ -13,15 +13,19 @@ import {
 
 import { ChainDispatcher } from "./chain-dispatcher";
 import { ExecutionState, ExecutionStateMap } from "./execution-state";
+import { TransactionLookupTimer } from "./transaction-timer";
+
+export interface ExecutionConfig {
+  blockPollingInterval: number;
+  transactionTimeoutInterval: number;
+}
 
 export interface ExecutionEngineState {
   block: {
     number: number;
     hash: string;
   };
-  config: {
-    blockPollingInterval: number;
-  };
+  config: ExecutionConfig;
   batches: string[][];
   module: IgnitionModule<string, string, IgnitionModuleResult<string>>;
   executionStateMap: ExecutionStateMap;
@@ -31,6 +35,7 @@ export interface ExecutionEngineState {
   artifactResolver: ArtifactResolver;
   deploymentLoader: DeploymentLoader;
   chainDispatcher: ChainDispatcher;
+  transactionLookupTimer: TransactionLookupTimer;
 }
 
 export interface ExecutionStrategyContext {

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -95,6 +95,7 @@ type ExecutionHistory = TransactionMessage[];
 export enum ExecutionStatus {
   STARTED,
   HOLD,
+  TIMEOUT,
   SUCCESS,
   FAILED,
 }

--- a/packages/core/src/new-api/internal/types/transaction-timer.ts
+++ b/packages/core/src/new-api/internal/types/transaction-timer.ts
@@ -1,0 +1,32 @@
+export interface TransactionLookup {
+  futureId: string;
+  executionId: number;
+  txHash: string;
+}
+
+export interface TransactionLookupTimer {
+  /**
+   * Register the start time of a transaction lookup.
+   *
+   * The registration is idempotent.
+   *
+   * @param txHash - the transaction hash being looked up.
+   */
+  registerStartTimeIfNeeded(transactionLookup: TransactionLookup): void;
+
+  /**
+   * Based on the registered start time of the transaction lookup, determine
+   * whether it has timed out.
+   *
+   * @param txHash  - the transaction hash being looked up.
+   * @result whether the transaction lookup has timed out.
+   */
+  isTimedOut(txHash: string): boolean;
+
+  /**
+   * Get all the currently timed out transactions.
+   *
+   * @result the currently timed out transactions.
+   */
+  getTimedOutTransactions(): TransactionLookup[];
+}

--- a/packages/core/src/new-api/types/deployer.ts
+++ b/packages/core/src/new-api/types/deployer.ts
@@ -1,6 +1,16 @@
 import { IgnitionModule, IgnitionModuleResult } from "./module";
 
 /**
+ * Configuration options for the deployment.
+ *
+ * @beta
+ */
+export interface DeployConfig {
+  blockPollingInterval: number;
+  transactionTimeoutInterval: number;
+}
+
+/**
  * The result of a deployment run.
  *
  * @beta
@@ -8,6 +18,7 @@ import { IgnitionModule, IgnitionModuleResult } from "./module";
 export type DeploymentResult =
   | DeploymentResultSuccess
   | DeploymentResultFailure
+  | DeploymentResultTimeout
   | {
       status: "hold";
     };
@@ -24,14 +35,25 @@ export interface DeploymentResultSuccess {
 }
 
 /**
- * The result of a failed deployment run (at least one future had an
- * failed transaction).
+ * The result of a failed deployment run where at least one future had a
+ * failed transaction.
  *
  * @beta
  */
 export interface DeploymentResultFailure {
   status: "failure";
   errors: { [key: string]: Error };
+}
+
+/**
+ * The result a deployment run where at least one transaction has timed
+ * out and is still pending.
+ *
+ * @beta
+ */
+export interface DeploymentResultTimeout {
+  status: "timeout";
+  timeouts: Array<{ futureId: string; executionId: number; txHash: string }>;
 }
 
 /**

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -17,9 +17,24 @@ export interface Journal {
  * @beta
  */
 export type JournalableMessage =
+  | StartRunMessage
   | TransactionMessage
   | ExecutionMessage
   | WipeMessage;
+
+// #region "StartRunMessage"
+
+/**
+ * A message indicating the start of a new run.
+ *
+ * @beta
+ */
+export interface StartRunMessage {
+  // TODO: we should add chain id, so we can reconcile on previous chain id
+  type: "run-start";
+}
+
+// #endregion
 
 // #region "TransactionMessage"
 
@@ -473,6 +488,7 @@ export interface ContractAtStartMessage {
 export type ExecutionResultMessage =
   | ExecutionSuccess
   | ExecutionFailure
+  | ExecutionTimeout
   | ExecutionHold;
 
 /**
@@ -483,6 +499,7 @@ export type ExecutionResultMessage =
 export type ExecutionResultTypes = [
   "execution-success",
   "execution-failure",
+  "execution-timeout",
   "execution-hold"
 ];
 
@@ -596,6 +613,18 @@ export interface ExecutionFailure {
 }
 
 /**
+ * A journal message indicating a future execution timed out.
+ *
+ * @beta
+ */
+export interface ExecutionTimeout {
+  type: "execution-timeout";
+  futureId: string;
+  executionId: number;
+  txHash: string;
+}
+
+/**
  * A journal message indicating a future's execution was not completed within
  * the timeout.
  *
@@ -603,6 +632,8 @@ export interface ExecutionFailure {
  */
 export interface ExecutionHold {
   type: "execution-hold";
+  futureId: string;
+  executionId: number;
 }
 
 // #endregion

--- a/packages/core/test/new-api/execution/execution-engine.ts
+++ b/packages/core/test/new-api/execution/execution-engine.ts
@@ -104,6 +104,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -228,6 +229,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -330,6 +332,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -419,6 +422,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Library1",
           type: "execution-start",
@@ -530,6 +534,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Library1",
           type: "execution-start",
@@ -632,6 +637,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Library1",
           type: "execution-start",
@@ -729,6 +735,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -896,6 +903,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -1050,6 +1058,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -1220,6 +1229,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -1376,6 +1386,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -1518,6 +1529,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -1639,6 +1651,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           type: "execution-start",
           futureType: FutureType.NAMED_CONTRACT_AT,
@@ -1735,6 +1748,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -1887,6 +1901,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Contract1",
           type: "execution-start",
@@ -2046,6 +2061,7 @@ describe("execution engine", () => {
       const journalMessages = await accumulateMessages(journal);
 
       assert.deepStrictEqual(journalMessages, [
+        { type: "run-start" },
         {
           futureId: "Module1:Library1",
           type: "execution-start",

--- a/packages/core/test/new-api/helpers.ts
+++ b/packages/core/test/new-api/helpers.ts
@@ -419,7 +419,7 @@ export class MockChainDispatcher implements ChainDispatcher {
       );
     }
 
-    return { _kind: "fake-transaction" } as any;
+    return { _kind: "fake-transaction", ...response } as any;
   }
 
   public async getCurrentBlock(): Promise<{ number: number; hash: string }> {

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -299,8 +299,17 @@ task("deploy2")
 
             console.log(`Future ${futureId} failed: ${errorMessage}`);
           }
+        } else if (result.status === "timeout") {
+          console.log("Deployment halted due to timeout");
+          console.log("");
+
+          for (const { futureId, executionId, txHash } of result.timeouts) {
+            console.log(`  ${txHash} (${futureId}/${executionId})`);
+          }
         } else if (result.status === "hold") {
           console.log("Deployment held");
+        } else {
+          assertNeverResult(result);
         }
       } catch (err) {
         // TODO: bring back cli ui
@@ -514,4 +523,8 @@ function resolveParametersString(paramString: string): ModuleParams {
     console.warn(`Could not parse JSON parameters`);
     process.exit(0);
   }
+}
+
+function assertNeverResult(result: never) {
+  throw new Error(`Unknown result from deploy: ${JSON.stringify(result)}`);
 }

--- a/packages/hardhat-plugin/test/execution/timeouts/deploy-run-times-out.ts
+++ b/packages/hardhat-plugin/test/execution/timeouts/deploy-run-times-out.ts
@@ -1,0 +1,40 @@
+/* eslint-disable import/no-unused-modules */
+import { defineModule } from "@ignored/ignition-core";
+import { assert } from "chai";
+
+import {
+  TestChainHelper,
+  useDeploymentDirectory,
+} from "../nonce-checks/useDeploymentDirectory";
+
+/**
+ * A run that deploys a contract times out
+ */
+describe("execution - deploy run times out", () => {
+  useDeploymentDirectory("minimal-new-api", "deploy-run-times-out", {
+    transactionTimeoutInterval: 400,
+  });
+
+  it("should error naming timed out transactions", async function () {
+    // Setup a module with a contract deploy on accounts[2]
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account2 = m.getAccount(2);
+
+      const foo = m.contract("Foo", [], { from: account2 });
+
+      return {
+        foo,
+      };
+    });
+
+    // Deploying the module that uses accounts[2] throws with a warning
+    await assert.isRejected(
+      this.deploy(moduleDefinition, async (c: TestChainHelper) => {
+        // wait for the deploy transaction to hit the memory pool,
+        // but then never mine the block that will complete it.
+        await c.waitForPendingTxs(1);
+      }),
+      "The deployment has been halted due to transaction timeouts:\n  0xc5ed278cdc282e8cf6ffa96234e680592c22a2c0afbdac114616ea02b132091b (FooModule:Foo/1)"
+    );
+  });
+});

--- a/packages/hardhat-plugin/test/execution/timeouts/rerun-a-deploy-that-timed-out.ts
+++ b/packages/hardhat-plugin/test/execution/timeouts/rerun-a-deploy-that-timed-out.ts
@@ -1,0 +1,51 @@
+/* eslint-disable import/no-unused-modules */
+import { defineModule } from "@ignored/ignition-core";
+import { assert } from "chai";
+
+import {
+  TestChainHelper,
+  useDeploymentDirectory,
+} from "../nonce-checks/useDeploymentDirectory";
+
+/**
+ * A run that deploys a contract times out
+ */
+describe("execution - rerun a deploy that timed out", () => {
+  useDeploymentDirectory("minimal-new-api", "rerun-a-deploy-that-timed-out", {
+    transactionTimeoutInterval: 400,
+  });
+
+  it("should error naming timed out transactions", async function () {
+    // Setup a module with a contract deploy on accounts[2]
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account2 = m.getAccount(2);
+
+      const foo = m.contract("Foo", [], { from: account2 });
+
+      return {
+        foo,
+      };
+    });
+
+    // Deploying the module that uses accounts[2], but force timeout,
+    // by not processing any blocks
+    await assert.isRejected(
+      this.deploy(moduleDefinition, async (c: TestChainHelper) => {
+        // wait for the deploy transaction to hit the memory pool,
+        // but then never mine the block that will complete it.
+        await c.waitForPendingTxs(1);
+      })
+    );
+
+    const result = await this.deploy(
+      moduleDefinition,
+      async (c: TestChainHelper) => {
+        // Mine the block, confirming foo
+        await c.mineBlock(1);
+      }
+    );
+
+    assert.isDefined(result);
+    assert.equal(await result.foo.x(), Number(1));
+  });
+});


### PR DESCRIPTION
The timeout is checked on lookup of a pending transaction. If the configured timeout is passed then the future is moved to the `timeout` state via a message.

Resolves #293.