### PR TITLE
fix:library-deploy (PR H)

### DIFF
--- a/packages/core/src/new-api/internal/execution/execution-strategy.ts
+++ b/packages/core/src/new-api/internal/execution/execution-strategy.ts
@@ -114,6 +114,7 @@ export class BasicExecutionStrategy
       value: deploymentExecutionState.value.toString(),
       args: deploymentExecutionState.constructorArgs,
       storedArtifactPath: deploymentExecutionState.storedArtifactPath,
+      libraries: deploymentExecutionState.libraries,
       from: sender,
     };
 

--- a/packages/core/src/new-api/internal/execution/onchain-state-transitions.ts
+++ b/packages/core/src/new-api/internal/execution/onchain-state-transitions.ts
@@ -457,9 +457,9 @@ async function _convertRequestToDeployTransaction(
   const args = request.args;
   const value = BigInt(request.value);
   const from = request.from;
+  const libraries = request.libraries;
 
-  // TODO: fix libraries
-  const linkedByteCode = await collectLibrariesAndLink(artifact, {});
+  const linkedByteCode = await collectLibrariesAndLink(artifact, libraries);
 
   const tx = state.chainDispatcher.constructDeployTransaction(
     linkedByteCode,

--- a/packages/core/src/new-api/types/journal.ts
+++ b/packages/core/src/new-api/types/journal.ts
@@ -79,6 +79,7 @@ export interface DeployContractInteractionMessage {
   contractName: string;
   storedArtifactPath: string;
   value: string;
+  libraries: { [key: string]: string };
   from: string;
 }
 

--- a/packages/core/test/new-api/execution/execution-engine.ts
+++ b/packages/core/test/new-api/execution/execution-engine.ts
@@ -136,6 +136,7 @@ describe("execution engine", () => {
           ],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -255,6 +256,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           from: accounts[2],
+          libraries: {},
           storedArtifactPath: "Module1:Contract1.json",
         },
         {
@@ -356,6 +358,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           from: accounts[1],
+          libraries: {},
           storedArtifactPath: "Module1:Contract1.json",
         },
         {
@@ -446,6 +449,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Library1.json",
+          libraries: {},
           from: accounts[2],
         },
         {
@@ -560,6 +564,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           from: accounts[2],
+          libraries: {},
           storedArtifactPath: "Module1:Library1.json",
         },
         {
@@ -661,6 +666,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           from: accounts[1],
+          libraries: {},
           storedArtifactPath: "Module1:Library1.json",
         },
         {
@@ -759,6 +765,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -927,6 +934,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -1082,6 +1090,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -1253,6 +1262,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -1410,6 +1420,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -1553,6 +1564,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -1772,6 +1784,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -1925,6 +1938,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -2007,9 +2021,6 @@ describe("execution engine", () => {
           "Contract1",
           [{ nested: library1, arr: [account1, supply] }],
           {
-            libraries: {
-              Library1: library1,
-            },
             from: account1,
           }
         );
@@ -2085,6 +2096,7 @@ describe("execution engine", () => {
           args: [],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Library1.json",
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -2136,9 +2148,7 @@ describe("execution engine", () => {
               nested: differentAddress,
             },
           ],
-          libraries: {
-            Library1: "Module1:Library1",
-          },
+          libraries: {},
           from: accounts[1],
         },
         {
@@ -2155,6 +2165,7 @@ describe("execution engine", () => {
           ],
           value: BigInt(0).toString(),
           storedArtifactPath: "Module1:Contract1.json",
+          libraries: {},
           from: exampleAccounts[1],
         },
         {

--- a/packages/core/test/new-api/reconciliation/reconciler.ts
+++ b/packages/core/test/new-api/reconciliation/reconciler.ts
@@ -136,6 +136,7 @@ describe("Reconciliation", () => {
               args: [],
               contractName: "Contract1",
               storedArtifactPath: "./Module1:Contract1.json",
+              libraries: {},
               value: BigInt(0).toString(),
               // history indicates from was accounts[3]
               from: exampleAccounts[0],
@@ -192,6 +193,7 @@ describe("Reconciliation", () => {
               args: [],
               contractName: "Contract1",
               storedArtifactPath: "./Module1:Contract1.json",
+              libraries: {},
               value: BigInt(0).toString(),
               // history indicates from was accounts[3]
               from: exampleAccounts[3],

--- a/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/WithLibrary.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/WithLibrary.sol
@@ -2,17 +2,33 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 library RubbishMath {
-    function add(uint16 left, uint16 right) public pure returns (uint16) {
-        return left + right;
-    }
+  function add(uint16 left, uint16 right) public pure returns (uint16) {
+    return left + right;
+  }
 }
 
 contract DependsOnLib {
-    function addThreeNumbers(
-        uint16 first,
-        uint16 second,
-        uint16 third
-    ) public pure returns (uint16) {
-        return RubbishMath.add(first, RubbishMath.add(second, third));
-    }
+  function addThreeNumbers(
+    uint16 first,
+    uint16 second,
+    uint16 third
+  ) public pure returns (uint16) {
+    return RubbishMath.add(first, RubbishMath.add(second, third));
+  }
+}
+
+library LibDependsOnLib {
+  function add(uint16 left, uint16 right) public pure returns (uint16) {
+    return RubbishMath.add(left, right);
+  }
+}
+
+contract DependsOnLibThatDependsOnLib {
+  function addThreeNumbers(
+    uint16 first,
+    uint16 second,
+    uint16 third
+  ) public pure returns (uint16) {
+    return LibDependsOnLib.add(first, LibDependsOnLib.add(second, third));
+  }
 }

--- a/packages/hardhat-plugin/test/use-ignition-project.ts
+++ b/packages/hardhat-plugin/test/use-ignition-project.ts
@@ -28,6 +28,7 @@ export function useEphemeralIgnitionProject(
     const hre = require("hardhat");
 
     await hre.network.provider.send("evm_setAutomine", [true]);
+    await hre.run("compile", { quiet: true });
 
     this.hre = hre;
     this.deploymentDir = undefined;


### PR DESCRIPTION
This fixes the deployment of contracts/libraries that need linked to other libraries.

This is done by resolving the library deps to the deployed libraries during the init command for execution state, then passing the library to contract address mapping into the deploy request messages.