### PR TITLE
fix: artifact module loading (PR 3)

### DIFF
--- a/packages/core/src/new-api/type-guards.ts
+++ b/packages/core/src/new-api/type-guards.ts
@@ -4,6 +4,8 @@ import {
   AccountRuntimeValue,
   AddressResolvableFuture,
   ArtifactContractAtFuture,
+  ArtifactContractDeploymentFuture,
+  ArtifactLibraryDeploymentFuture,
   ContractFuture,
   DeploymentFuture,
   FunctionCallFuture,
@@ -11,6 +13,8 @@ import {
   FutureType,
   ModuleParameterRuntimeValue,
   NamedContractAtFuture,
+  NamedContractDeploymentFuture,
+  NamedLibraryDeploymentFuture,
   NamedStaticCallFuture,
   ReadEventArgumentFuture,
   RuntimeValue,
@@ -148,6 +152,50 @@ export function isReadEventArgumentFuture(
   future: Future
 ): future is NamedStaticCallFuture<string, string> {
   return future.type === FutureType.READ_EVENT_ARGUMENT;
+}
+
+/**
+ * Returns true if future is of type NamedContractDeploymentFuture.
+ *
+ * @beta
+ */
+export function isNamedContractDeploymentFuture(
+  future: Future
+): future is NamedContractDeploymentFuture<string> {
+  return future.type === FutureType.NAMED_CONTRACT_DEPLOYMENT;
+}
+
+/**
+ * Returns true if future is of type ArtifactContractDeploymentFuture.
+ *
+ * @beta
+ */
+export function isArtifactContractDeploymentFuture(
+  future: Future
+): future is ArtifactContractDeploymentFuture {
+  return future.type === FutureType.ARTIFACT_CONTRACT_DEPLOYMENT;
+}
+
+/**
+ * Returns true if future is of type NamedLibraryDeploymentFuture.
+ *
+ * @beta
+ */
+export function isNamedLibraryDeploymentFuture(
+  future: Future
+): future is NamedLibraryDeploymentFuture<string> {
+  return future.type === FutureType.NAMED_LIBRARY_DEPLOYMENT;
+}
+
+/**
+ * Returns true if future is of type ArtifactLibraryDeploymentFuture.
+ *
+ * @beta
+ */
+export function isArtifactLibraryDeploymentFuture(
+  future: Future
+): future is ArtifactLibraryDeploymentFuture {
+  return future.type === FutureType.ARTIFACT_LIBRARY_DEPLOYMENT;
 }
 
 /**

--- a/packages/hardhat-plugin/test/execution/deploy-contract-at-from-artifact.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract-at-from-artifact.ts
@@ -1,0 +1,57 @@
+/* eslint-disable import/no-unused-modules */
+import { defineModule } from "@ignored/ignition-core";
+import { assert } from "chai";
+
+import {
+  TestChainHelper,
+  useEphemeralIgnitionProject,
+} from "../use-ignition-project";
+
+/**
+ * Use an existingly deployed contract through the `contractAtFromArtifact` api.
+ *
+ * First deploy a working contract, then reuse it from a subsequent module
+ * with a passed in artifact.
+ */
+describe("execution - deploy contractAt from artifact", function () {
+  // TODO: rename back to minimal api once execution switched over
+  useEphemeralIgnitionProject("minimal-new-api");
+
+  it("should deploy a contract that is callable", async function () {
+    // Arrange
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const foo = m.contract("Foo");
+
+      return { foo };
+    });
+
+    const result = await this.deploy(
+      moduleDefinition,
+      async (c: TestChainHelper) => {
+        await c.mineBlock(1);
+      }
+    );
+
+    const fooAddress = result.foo.address;
+    assert.equal(fooAddress, "0x5FbDB2315678afecb367f032d93F642f64180aa3");
+
+    // Act
+    const fooArtifact = await this.hre.artifacts.readArtifact("Foo");
+
+    const contractAtModuleDefinition = defineModule("FooModule", (m) => {
+      const atFoo = m.contractAtFromArtifact("AtFoo", fooAddress, fooArtifact);
+
+      return { atFoo };
+    });
+
+    const contractAtFromArtifactResult = await this.deploy(
+      contractAtModuleDefinition,
+      async (c: TestChainHelper) => {
+        await c.mineBlock(1);
+      }
+    );
+
+    // Assert
+    assert.equal(await contractAtFromArtifactResult.atFoo.x(), Number(1));
+  });
+});

--- a/packages/hardhat-plugin/test/execution/deploy-contract-at.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract-at.ts
@@ -1,0 +1,52 @@
+/* eslint-disable import/no-unused-modules */
+import { defineModule } from "@ignored/ignition-core";
+import { assert } from "chai";
+
+import {
+  TestChainHelper,
+  useEphemeralIgnitionProject,
+} from "../use-ignition-project";
+
+/**
+ * Use an existingly deployed contract through the `contractAt` api.
+ *
+ * First deploy a working contract, then reuse it from a subsequent module.
+ */
+describe("execution - deploy contract at", function () {
+  // TODO: rename back to minimal api once execution switched over
+  useEphemeralIgnitionProject("minimal-new-api");
+
+  it("should deploy a contract that is callable", async function () {
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const foo = m.contract("Foo");
+
+      return { foo };
+    });
+
+    const result = await this.deploy(
+      moduleDefinition,
+      async (c: TestChainHelper) => {
+        await c.mineBlock(1);
+      }
+    );
+
+    const fooAddress = result.foo.address;
+
+    assert.equal(fooAddress, "0x5FbDB2315678afecb367f032d93F642f64180aa3");
+
+    const contractAtModuleDefinition = defineModule("FooModule", (m) => {
+      const foo = m.contractAt("Foo", fooAddress);
+
+      return { foo };
+    });
+
+    const contractAtResult = await this.deploy(
+      contractAtModuleDefinition,
+      async (c: TestChainHelper) => {
+        await c.mineBlock(1);
+      }
+    );
+
+    assert.equal(await contractAtResult.foo.x(), Number(1));
+  });
+});

--- a/packages/hardhat-plugin/test/execution/deploy-contract-from-artifact.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract-from-artifact.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Deploy a contract from an artifact.
  */
-describe("execution - deploy from artifact", function () {
+describe("execution - deploy contract from artifact", function () {
   // TODO: rename back to minimal api once execution switched over
   useEphemeralIgnitionProject("minimal-new-api");
 

--- a/packages/hardhat-plugin/test/execution/deploy-contract.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract.ts
@@ -12,7 +12,7 @@ import {
  *
  * Deploy a single contract with non-problematic network
  */
-describe("execution - minimal contract deploy", function () {
+describe("execution - deploy contract", function () {
   // TODO: rename back to minimal api once execution switched over
   useEphemeralIgnitionProject("minimal-new-api");
 

--- a/packages/hardhat-plugin/test/execution/multiple-batch-contract-deploy.ts
+++ b/packages/hardhat-plugin/test/execution/multiple-batch-contract-deploy.ts
@@ -12,8 +12,6 @@ import { sleep } from "./helpers";
  * The intent here is to test batching.
  */
 describe("execution - multiple batch contract deploy", function () {
-  this.timeout(60000);
-
   // TODO: rename back to minimal api once execution switched over
   useEphemeralIgnitionProject("minimal-new-api");
 


### PR DESCRIPTION
Pre-artifact loading for the passed Ignition module should use the artifact resolved for named contracts, but read the artifacts from the passed future for user provided cases.

Two integration tests have been added that cover the bug.