### PR TITLE
Deployment Loader Cleanup (PR 7)

### DIFF
--- a/packages/core/src/new-api/internal/deployer.ts
+++ b/packages/core/src/new-api/internal/deployer.ts
@@ -18,7 +18,6 @@ import {
 import { Artifact, ArtifactResolver } from "../types/artifact";
 import { DeployConfig, DeploymentResult } from "../types/deployer";
 import { DeploymentLoader } from "../types/deployment-loader";
-import { Journal } from "../types/journal";
 
 import { Batcher } from "./batcher";
 import { ExecutionEngine } from "./execution/execution-engine";
@@ -36,6 +35,7 @@ import {
   DeploymentExecutionState,
   ExecutionStateMap,
 } from "./types/execution-state";
+import { Journal } from "./types/journal";
 import { TransactionLookupTimer } from "./types/transaction-timer";
 import { assertIgnitionInvariant } from "./utils/assertions";
 import { getFuturesFromModule } from "./utils/get-futures-from-module";

--- a/packages/core/src/new-api/internal/deployer.ts
+++ b/packages/core/src/new-api/internal/deployer.ts
@@ -17,7 +17,6 @@ import {
 } from "../type-guards";
 import { Artifact, ArtifactResolver } from "../types/artifact";
 import { DeployConfig, DeploymentResult } from "../types/deployer";
-import { DeploymentLoader } from "../types/deployment-loader";
 
 import { Batcher } from "./batcher";
 import { ExecutionEngine } from "./execution/execution-engine";
@@ -29,6 +28,7 @@ import { Reconciler } from "./reconciliation/reconciler";
 import { ArtifactMap } from "./reconciliation/types";
 import { isContractExecutionStateArray } from "./type-guards";
 import { ChainDispatcher } from "./types/chain-dispatcher";
+import { DeploymentLoader } from "./types/deployment-loader";
 import { ExecutionStrategy } from "./types/execution-engine";
 import {
   ContractAtExecutionState,

--- a/packages/core/src/new-api/internal/deployment-loader/ephemeral-deployment-loader.ts
+++ b/packages/core/src/new-api/internal/deployment-loader/ephemeral-deployment-loader.ts
@@ -1,7 +1,7 @@
 import { Artifact, ArtifactResolver, BuildInfo } from "../../types/artifact";
 import { DeploymentLoader } from "../../types/deployment-loader";
-import { Journal } from "../../types/journal";
 import { MemoryJournal } from "../journal/memory-journal";
+import { Journal } from "../types/journal";
 import { assertIgnitionInvariant } from "../utils/assertions";
 
 /**

--- a/packages/core/src/new-api/internal/deployment-loader/ephemeral-deployment-loader.ts
+++ b/packages/core/src/new-api/internal/deployment-loader/ephemeral-deployment-loader.ts
@@ -1,6 +1,6 @@
 import { Artifact, ArtifactResolver, BuildInfo } from "../../types/artifact";
-import { DeploymentLoader } from "../../types/deployment-loader";
 import { MemoryJournal } from "../journal/memory-journal";
+import { DeploymentLoader } from "../types/deployment-loader";
 import { Journal } from "../types/journal";
 import { assertIgnitionInvariant } from "../utils/assertions";
 

--- a/packages/core/src/new-api/internal/deployment-loader/file-deployment-loader.ts
+++ b/packages/core/src/new-api/internal/deployment-loader/file-deployment-loader.ts
@@ -3,8 +3,8 @@ import path from "path";
 
 import { Artifact, BuildInfo } from "../../types/artifact";
 import { DeploymentLoader } from "../../types/deployment-loader";
-import { Journal } from "../../types/journal";
 import { FileJournal } from "../journal/file-journal";
+import { Journal } from "../types/journal";
 
 export class FileDeploymentLoader implements DeploymentLoader {
   public journal: Journal;

--- a/packages/core/src/new-api/internal/deployment-loader/file-deployment-loader.ts
+++ b/packages/core/src/new-api/internal/deployment-loader/file-deployment-loader.ts
@@ -2,8 +2,8 @@ import { ensureDir, pathExists, readFile, writeFile } from "fs-extra";
 import path from "path";
 
 import { Artifact, BuildInfo } from "../../types/artifact";
-import { DeploymentLoader } from "../../types/deployment-loader";
 import { FileJournal } from "../journal/file-journal";
+import { DeploymentLoader } from "../types/deployment-loader";
 import { Journal } from "../types/journal";
 
 export class FileDeploymentLoader implements DeploymentLoader {

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -17,15 +17,6 @@ import {
 } from "../../types/deployer";
 import { DeploymentLoader } from "../../types/deployment-loader";
 import {
-  ExecutionResultMessage,
-  ExecutionTimeout,
-  FutureStartMessage,
-  JournalableMessage,
-  OnchainTransactionReset,
-  StartRunMessage,
-  TransactionMessage,
-} from "../../types/journal";
-import {
   AccountRuntimeValue,
   ArgumentType,
   ContractFuture,
@@ -53,6 +44,15 @@ import {
   ExecutionStateMap,
   ExecutionStatus,
 } from "../types/execution-state";
+import {
+  ExecutionResultMessage,
+  ExecutionTimeout,
+  FutureStartMessage,
+  JournalableMessage,
+  OnchainTransactionReset,
+  StartRunMessage,
+  TransactionMessage,
+} from "../types/journal";
 import { assertIgnitionInvariant } from "../utils/assertions";
 import { getFuturesFromModule } from "../utils/get-futures-from-module";
 import { replaceWithinArg } from "../utils/replace-within-arg";

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -15,7 +15,6 @@ import {
   DeploymentResultContract,
   DeploymentResultContracts,
 } from "../../types/deployer";
-import { DeploymentLoader } from "../../types/deployment-loader";
 import {
   AccountRuntimeValue,
   ArgumentType,
@@ -34,6 +33,7 @@ import {
   isSendDataExecutionState,
   isStaticCallExecutionState,
 } from "../type-guards";
+import { DeploymentLoader } from "../types/deployment-loader";
 import {
   ExecutionEngineState,
   ExecutionStrategyContext,

--- a/packages/core/src/new-api/internal/execution/execution-state-reducer.ts
+++ b/packages/core/src/new-api/internal/execution/execution-state-reducer.ts
@@ -1,5 +1,4 @@
 import { IgnitionError } from "../../../errors";
-import { FutureStartMessage, JournalableMessage } from "../../types/journal";
 import {
   isCallFunctionStartMessage,
   isContractAtStartMessage,
@@ -24,6 +23,7 @@ import {
   SendDataExecutionState,
   StaticCallExecutionState,
 } from "../types/execution-state";
+import { FutureStartMessage, JournalableMessage } from "../types/journal";
 import { assertIgnitionInvariant } from "../utils/assertions";
 
 import {

--- a/packages/core/src/new-api/internal/execution/execution-strategy-cycler.ts
+++ b/packages/core/src/new-api/internal/execution/execution-strategy-cycler.ts
@@ -1,12 +1,11 @@
+import { isOnChainResultMessage } from "../journal/type-guards";
+import { ExecutionState } from "../types/execution-state";
 import {
   ExecutionSuccess,
   OnchainInteractionMessage,
   OnchainResultMessage,
   TransactionMessage,
-} from "../../types/journal";
-import { isOnChainResultMessage } from "../journal/type-guards";
-import { ExecutionState } from "../types/execution-state";
-
+} from "../types/journal";
 export class ExecutionStategyCycler {
   /**
    * Given a execution strategy and history of on chain transactions

--- a/packages/core/src/new-api/internal/execution/execution-strategy.ts
+++ b/packages/core/src/new-api/internal/execution/execution-strategy.ts
@@ -1,5 +1,23 @@
 import { IgnitionError } from "../../../errors";
 import {
+  isCallExecutionState,
+  isContractAtExecutionState,
+  isDeploymentExecutionState,
+  isReadEventArgumentExecutionState,
+  isSendDataExecutionState,
+  isStaticCallExecutionState,
+} from "../type-guards";
+import { ExecutionStrategy } from "../types/execution-engine";
+import {
+  CallExecutionState,
+  ContractAtExecutionState,
+  DeploymentExecutionState,
+  ExecutionState,
+  ReadEventArgumentExecutionState,
+  SendDataExecutionState,
+  StaticCallExecutionState,
+} from "../types/execution-state";
+import {
   CallFunctionInteractionMessage,
   CalledFunctionExecutionSuccess,
   ContractAtExecutionSuccess,
@@ -21,25 +39,7 @@ import {
   SendDataInteractionMessage,
   StaticCallExecutionSuccess,
   StaticCallInteractionMessage,
-} from "../../types/journal";
-import {
-  isCallExecutionState,
-  isContractAtExecutionState,
-  isDeploymentExecutionState,
-  isReadEventArgumentExecutionState,
-  isSendDataExecutionState,
-  isStaticCallExecutionState,
-} from "../type-guards";
-import { ExecutionStrategy } from "../types/execution-engine";
-import {
-  CallExecutionState,
-  ContractAtExecutionState,
-  DeploymentExecutionState,
-  ExecutionState,
-  ReadEventArgumentExecutionState,
-  SendDataExecutionState,
-  StaticCallExecutionState,
-} from "../types/execution-state";
+} from "../types/journal";
 import { assertIgnitionInvariant } from "../utils/assertions";
 
 export class BasicExecutionStrategy implements ExecutionStrategy {

--- a/packages/core/src/new-api/internal/execution/guards.ts
+++ b/packages/core/src/new-api/internal/execution/guards.ts
@@ -18,7 +18,7 @@ import {
   SendDataInteractionMessage,
   StaticCallExecutionSuccess,
   StaticCallInteractionMessage,
-} from "../../types/journal";
+} from "../types/journal";
 
 export function isExecutionResultMessage(
   potential: JournalableMessage

--- a/packages/core/src/new-api/internal/execution/onchain-action-reducer.ts
+++ b/packages/core/src/new-api/internal/execution/onchain-action-reducer.ts
@@ -1,5 +1,4 @@
 import { IgnitionError } from "../../../errors";
-import { TransactionMessage } from "../../types/journal";
 import {
   isOnchainCallFunctionSuccessMessage,
   isOnchainContractAtSuccessMessage,
@@ -14,6 +13,7 @@ import {
 } from "../journal/type-guards";
 import { serializeReplacer } from "../journal/utils/serialize-replacer";
 import { OnchainState, OnchainStatuses } from "../types/execution-state";
+import { TransactionMessage } from "../types/journal";
 import { assertIgnitionInvariant } from "../utils/assertions";
 
 import {

--- a/packages/core/src/new-api/internal/execution/onchain-state-transitions.ts
+++ b/packages/core/src/new-api/internal/execution/onchain-state-transitions.ts
@@ -22,7 +22,7 @@ import {
   SendDataInteractionMessage,
   StaticCallInteractionMessage,
   TransactionMessage,
-} from "../../types/journal";
+} from "../../internal/types/journal";
 import { ArgumentType } from "../../types/module";
 import {
   isOnChainResultMessage,

--- a/packages/core/src/new-api/internal/journal/file-journal.ts
+++ b/packages/core/src/new-api/internal/journal/file-journal.ts
@@ -2,7 +2,7 @@
 import fs, { closeSync, constants, openSync, writeFileSync } from "fs";
 import { parse } from "ndjson";
 
-import { Journal, JournalableMessage } from "../../types/journal";
+import { Journal, JournalableMessage } from "../types/journal";
 
 import { deserializeReplacer } from "./utils/deserialize-replacer";
 import { logJournalableMessage } from "./utils/log";

--- a/packages/core/src/new-api/internal/journal/memory-journal.ts
+++ b/packages/core/src/new-api/internal/journal/memory-journal.ts
@@ -1,4 +1,4 @@
-import { Journal, JournalableMessage } from "../../types/journal";
+import { Journal, JournalableMessage } from "../types/journal";
 
 import { deserializeReplacer } from "./utils/deserialize-replacer";
 import { logJournalableMessage } from "./utils/log";

--- a/packages/core/src/new-api/internal/journal/type-guards.ts
+++ b/packages/core/src/new-api/internal/journal/type-guards.ts
@@ -1,3 +1,5 @@
+import { FutureType } from "../../types/module";
+import { isOnchainInteractionMessage } from "../execution/guards";
 import {
   CallFunctionStartMessage,
   ContractAtStartMessage,
@@ -22,9 +24,7 @@ import {
   StaticCallStartMessage,
   TransactionMessage,
   WipeMessage,
-} from "../../types/journal";
-import { FutureType } from "../../types/module";
-import { isOnchainInteractionMessage } from "../execution/guards";
+} from "../types/journal";
 
 /**
  * Determines if potential is a StartRunMessage.

--- a/packages/core/src/new-api/internal/journal/utils/log.ts
+++ b/packages/core/src/new-api/internal/journal/utils/log.ts
@@ -1,4 +1,3 @@
-import { JournalableMessage } from "../../../types/journal";
 import { SolidityParameterType } from "../../../types/module";
 import {
   isCallFunctionInteraction,
@@ -17,6 +16,7 @@ import {
   isStaticCallExecutionSuccess,
   isStaticCallInteraction,
 } from "../../execution/guards";
+import { JournalableMessage } from "../../types/journal";
 import {
   isCallFunctionStartMessage,
   isContractAtStartMessage,

--- a/packages/core/src/new-api/internal/types/deployment-loader.ts
+++ b/packages/core/src/new-api/internal/types/deployment-loader.ts
@@ -1,6 +1,6 @@
-import { Journal } from "../internal/types/journal";
+import { Artifact, BuildInfo } from "../../types/artifact";
 
-import { Artifact, BuildInfo } from "./artifact";
+import { Journal } from "./journal";
 
 /**
  * Read and write to the deployment storage.

--- a/packages/core/src/new-api/internal/types/execution-engine.ts
+++ b/packages/core/src/new-api/internal/types/execution-engine.ts
@@ -1,11 +1,6 @@
 import { ArtifactResolver } from "../../types/artifact";
 import { DeploymentLoader } from "../../types/deployment-loader";
 import {
-  ExecutionSuccess,
-  OnchainInteractionMessage,
-  OnchainResultMessage,
-} from "../../types/journal";
-import {
   IgnitionModule,
   IgnitionModuleResult,
   ModuleParameters,
@@ -13,6 +8,11 @@ import {
 
 import { ChainDispatcher } from "./chain-dispatcher";
 import { ExecutionState, ExecutionStateMap } from "./execution-state";
+import {
+  ExecutionSuccess,
+  OnchainInteractionMessage,
+  OnchainResultMessage,
+} from "./journal";
 import { TransactionLookupTimer } from "./transaction-timer";
 
 interface ExecutionConfig {

--- a/packages/core/src/new-api/internal/types/execution-engine.ts
+++ b/packages/core/src/new-api/internal/types/execution-engine.ts
@@ -1,5 +1,4 @@
 import { ArtifactResolver } from "../../types/artifact";
-import { DeploymentLoader } from "../../types/deployment-loader";
 import {
   IgnitionModule,
   IgnitionModuleResult,
@@ -7,6 +6,7 @@ import {
 } from "../../types/module";
 
 import { ChainDispatcher } from "./chain-dispatcher";
+import { DeploymentLoader } from "./deployment-loader";
 import { ExecutionState, ExecutionStateMap } from "./execution-state";
 import {
   ExecutionSuccess,

--- a/packages/core/src/new-api/internal/types/execution-state.ts
+++ b/packages/core/src/new-api/internal/types/execution-state.ts
@@ -1,9 +1,10 @@
-import { TransactionMessage } from "../../types/journal";
 import {
   ArgumentType,
   FutureType,
   SolidityParameterType,
 } from "../../types/module";
+
+import { TransactionMessage } from "./journal";
 
 /**
  * The execution history of a future is a sequence of onchain interactions.

--- a/packages/core/src/new-api/internal/types/journal.ts
+++ b/packages/core/src/new-api/internal/types/journal.ts
@@ -1,4 +1,8 @@
-import { ArgumentType, FutureType, SolidityParameterType } from "./module";
+import {
+  ArgumentType,
+  FutureType,
+  SolidityParameterType,
+} from "../../types/module";
 
 /**
  * Store a deployments execution state as a transaction log.

--- a/packages/core/src/new-api/internal/wiper.ts
+++ b/packages/core/src/new-api/internal/wiper.ts
@@ -1,8 +1,8 @@
 import { IgnitionError } from "../../errors";
-import { Journal, WipeMessage } from "../types/journal";
 
 import { executionStateReducer } from "./execution/execution-state-reducer";
 import { ExecutionStateMap } from "./types/execution-state";
+import { Journal, WipeMessage } from "./types/journal";
 
 export class Wiper {
   constructor(private _journal: Journal) {}

--- a/packages/core/src/new-api/type-guards.ts
+++ b/packages/core/src/new-api/type-guards.ts
@@ -1,4 +1,3 @@
-import { Adapters } from "./types/adapters";
 import { Artifact } from "./types/artifact";
 import {
   AccountRuntimeValue,
@@ -329,21 +328,5 @@ export function isModuleParameterRuntimeValue(
   return (
     isRuntimeValue(potential) &&
     potential.type === RuntimeValueType.MODULE_PARAMETER
-  );
-}
-
-/**
- * Returns true if potential is a set of adapters.
- *
- * @beta
- */
-export function isAdapters(potential: unknown): potential is Adapters {
-  return (
-    typeof potential === "object" &&
-    potential !== null &&
-    /* TODO: make this type safe */
-    "signer" in potential &&
-    "gas" in potential &&
-    "transactions" in potential
   );
 }

--- a/packages/core/src/new-api/types/deployment-loader.ts
+++ b/packages/core/src/new-api/types/deployment-loader.ts
@@ -1,5 +1,6 @@
+import { Journal } from "../internal/types/journal";
+
 import { Artifact, BuildInfo } from "./artifact";
-import { Journal } from "./journal";
 
 /**
  * Read and write to the deployment storage.

--- a/packages/core/test/new-api/helpers.ts
+++ b/packages/core/test/new-api/helpers.ts
@@ -7,6 +7,7 @@ import { Deployer } from "../../src/new-api/internal/deployer";
 import { AccountsState } from "../../src/new-api/internal/execution/execution-engine";
 import { MemoryJournal } from "../../src/new-api/internal/journal/memory-journal";
 import { ChainDispatcher } from "../../src/new-api/internal/types/chain-dispatcher";
+import { DeploymentLoader } from "../../src/new-api/internal/types/deployment-loader";
 import {
   OnchainState,
   OnchainStatuses,
@@ -20,7 +21,6 @@ import {
   DeploymentResultContract,
   DeploymentResultContracts,
 } from "../../src/new-api/types/deployer";
-import { DeploymentLoader } from "../../src/new-api/types/deployment-loader";
 
 export const exampleAccounts: string[] = [
   "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",

--- a/packages/core/test/new-api/helpers.ts
+++ b/packages/core/test/new-api/helpers.ts
@@ -12,12 +12,15 @@ import {
   OnchainStatuses,
 } from "../../src/new-api/internal/types/execution-state";
 import {
+  Journal,
+  JournalableMessage,
+} from "../../src/new-api/internal/types/journal";
+import {
   DeploymentResult,
   DeploymentResultContract,
   DeploymentResultContracts,
 } from "../../src/new-api/types/deployer";
 import { DeploymentLoader } from "../../src/new-api/types/deployment-loader";
-import { Journal, JournalableMessage } from "../../src/new-api/types/journal";
 
 export const exampleAccounts: string[] = [
   "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",

--- a/packages/core/test/new-api/types/deployment-loader.ts
+++ b/packages/core/test/new-api/types/deployment-loader.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 
 import { EphemeralDeploymentLoader } from "../../../src/new-api/internal/deployment-loader/ephemeral-deployment-loader";
 import { FileDeploymentLoader } from "../../../src/new-api/internal/deployment-loader/file-deployment-loader";
-import { DeploymentLoader } from "../../../src/new-api/types/deployment-loader";
+import { DeploymentLoader } from "../../../src/new-api/internal/types/deployment-loader";
 import { ExactInterface } from "../../helpers/exact-interface";
 import { setupMockArtifactResolver } from "../helpers";
 

--- a/packages/core/test/new-api/wipe.ts
+++ b/packages/core/test/new-api/wipe.ts
@@ -3,8 +3,8 @@ import { assert } from "chai";
 
 import { defineModule } from "../../src/new-api/define-module";
 import { MemoryJournal } from "../../src/new-api/internal/journal/memory-journal";
+import { Journal } from "../../src/new-api/internal/types/journal";
 import { Wiper } from "../../src/new-api/internal/wiper";
-import { Journal } from "../../src/new-api/types/journal";
 import { IgnitionModuleResult } from "../../src/new-api/types/module";
 import { IgnitionModuleDefinition } from "../../src/new-api/types/module-builder";
 


### PR DESCRIPTION
- [x] remove `isAdapters` type guard as it is not used
- [x] move `types/journals` to the internal types folder
- [x] `types/deployment-loader.ts#Deployer.journal` should be under the private types

fixes #315 