### PR TITLE
fix: allow readEventArg as address in contractAt

### DIFF
--- a/packages/hardhat-plugin/test/events.ts
+++ b/packages/hardhat-plugin/test/events.ts
@@ -1,0 +1,61 @@
+/* eslint-disable import/no-unused-modules */
+import { defineModule } from "@ignored/ignition-core";
+import { assert } from "chai";
+
+import { useEphemeralIgnitionProject } from "./use-ignition-project";
+
+describe("events", () => {
+  useEphemeralIgnitionProject("minimal-new-api");
+
+  it("should be able to use the output of a readEvent in a contract at", async function () {
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account1 = m.getAccount(1);
+
+      const fooFactory = m.contract("FooFactory", [], { from: account1 });
+
+      const createCall = m.call(fooFactory, "create", []);
+
+      const newAddress = m.readEventArgument(
+        createCall,
+        "Deployed",
+        "fooAddress"
+      );
+
+      const foo = m.contractAt("Foo", newAddress);
+
+      return { fooFactory, foo };
+    });
+
+    const result = await this.deploy(moduleDefinition);
+
+    assert.equal(await result.fooFactory.isDeployed(), true);
+    assert.equal(await result.foo.x(), Number(1));
+  });
+
+  it("should be able to use the output of a readEvent in an artifact contract at", async function () {
+    const artifact = await this.hre.artifacts.readArtifact("Foo");
+
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account1 = m.getAccount(1);
+
+      const fooFactory = m.contract("FooFactory", [], { from: account1 });
+
+      const createCall = m.call(fooFactory, "create", []);
+
+      const newAddress = m.readEventArgument(
+        createCall,
+        "Deployed",
+        "fooAddress"
+      );
+
+      const foo = m.contractAtFromArtifact("Foo", newAddress, artifact);
+
+      return { fooFactory, foo };
+    });
+
+    const result = await this.deploy(moduleDefinition);
+
+    assert.equal(await result.fooFactory.isDeployed(), true);
+    assert.equal(await result.foo.x(), Number(1));
+  });
+});

--- a/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/Factory.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/Factory.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./Contracts.sol";
+
+contract FooFactory {
+  event Deployed(address indexed fooAddress);
+
+  function create() public {
+    Foo foo = new Foo();
+
+    emit Deployed(address(foo));
+  }
+
+  function isDeployed() public pure returns (bool output) {
+    return true;
+  }
+}


### PR DESCRIPTION
We were assuming either a deployment execution state or a contract at execution state when resolving the address of a contractAt future.

A check has been added to see if the address a readEventArg, and that it resolves to a valid address string.

Fixes #354.