### PR TITLE
chore: bump version to v0.1.1

### DIFF
--- a/examples/complete/package.json
+++ b/examples/complete/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-complete-example",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.1.1",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\" \"contracts/**/*.sol\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.1.0",
+    "@ignored/hardhat-ignition": "^0.1.1",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"

--- a/examples/ens/package.json
+++ b/examples/ens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-ens-example",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.1.1",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\" \"contracts/**/*.sol\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.1.0",
+    "@ignored/hardhat-ignition": "^0.1.1",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"

--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-sample-example",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.1.1",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\" \"contracts/**/*.sol\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.1.0",
+    "@ignored/hardhat-ignition": "^0.1.1",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"

--- a/examples/ts-sample/package.json
+++ b/examples/ts-sample/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-ts-sample-example",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.1.1",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,ts,md,json}\" \"ignition/*.{js,ts,md,json}\" \"test/*.{js,ts,md,json}\" \"contracts/**/*.sol\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.1.0",
+    "@ignored/hardhat-ignition": "^0.1.1",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"

--- a/examples/uniswap/package.json
+++ b/examples/uniswap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nomicfoundation/ignition-uniswap-example",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.1.1",
   "scripts": {
     "test": "hardhat test",
     "lint": "npm run prettier -- --check && npm run eslint",
@@ -10,7 +10,7 @@
     "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\" \"contracts/**/*.sol\""
   },
   "devDependencies": {
-    "@ignored/hardhat-ignition": "^0.1.0",
+    "@ignored/hardhat-ignition": "^0.1.1",
     "@nomicfoundation/hardhat-toolbox": "2.0.2",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,9 @@
     },
     "examples/complete": {
       "name": "@nomicfoundation/ignition-complete-example",
-      "version": "0.0.13",
+      "version": "0.1.1",
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.1.0",
+        "@ignored/hardhat-ignition": "^0.1.1",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
@@ -54,12 +54,12 @@
     },
     "examples/ens": {
       "name": "@nomicfoundation/ignition-ens-example",
-      "version": "0.0.13",
+      "version": "0.1.1",
       "dependencies": {
         "@ensdomains/ens-contracts": "0.0.11"
       },
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.1.0",
+        "@ignored/hardhat-ignition": "^0.1.1",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
@@ -81,9 +81,9 @@
     },
     "examples/sample": {
       "name": "@nomicfoundation/ignition-sample-example",
-      "version": "0.0.13",
+      "version": "0.1.1",
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.1.0",
+        "@ignored/hardhat-ignition": "^0.1.1",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
@@ -91,9 +91,9 @@
     },
     "examples/ts-sample": {
       "name": "@nomicfoundation/ignition-ts-sample-example",
-      "version": "0.0.13",
+      "version": "0.1.1",
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.1.0",
+        "@ignored/hardhat-ignition": "^0.1.1",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
@@ -101,7 +101,7 @@
     },
     "examples/uniswap": {
       "name": "@nomicfoundation/ignition-uniswap-example",
-      "version": "0.0.13",
+      "version": "0.1.1",
       "dependencies": {
         "@openzeppelin/contracts": "npm:@openzeppelin/contracts@3.4.2-solc-0.7",
         "@uniswap/swap-router-contracts": "1.1.0",
@@ -113,7 +113,7 @@
         "v3-periphery-1_3_0": "npm:@uniswap/v3-periphery@1.3.0"
       },
       "devDependencies": {
-        "@ignored/hardhat-ignition": "^0.1.0",
+        "@ignored/hardhat-ignition": "^0.1.1",
         "@nomicfoundation/hardhat-toolbox": "2.0.2",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
@@ -21011,7 +21011,7 @@
     },
     "packages/core": {
       "name": "@ignored/ignition-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "5.6.1",
@@ -21094,7 +21094,7 @@
     },
     "packages/hardhat-plugin": {
       "name": "@ignored/hardhat-ignition",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.2",
@@ -21108,8 +21108,8 @@
         "serialize-error": "8.1.0"
       },
       "devDependencies": {
-        "@ignored/ignition-core": "^0.1.0",
-        "@ignored/ignition-ui": "^0.1.0",
+        "@ignored/ignition-core": "^0.1.1",
+        "@ignored/ignition-ui": "^0.1.1",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@types/chai": "^4.2.22",
@@ -21151,8 +21151,8 @@
         "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
       },
       "peerDependencies": {
-        "@ignored/ignition-core": "^0.1.0",
-        "@ignored/ignition-ui": "^0.1.0",
+        "@ignored/ignition-core": "^0.1.1",
+        "@ignored/ignition-ui": "^0.1.1",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "hardhat": "^2.14.0"
       }
@@ -21302,9 +21302,9 @@
     },
     "packages/ui": {
       "name": "@ignored/ignition-ui",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
-        "@ignored/ignition-core": "^0.1.0",
+        "@ignored/ignition-core": "^0.1.1",
         "mermaid": "10.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.1.0 - 2023-07-30
+
+### Fixed
+
+- Fix validation error when using the result of a `readEventArgument` as the address of a `contractAt`/`contractAtFromArtifact` ([#354](https://github.com/NomicFoundation/ignition/issues/354))
+
 ## 0.1.0 - 2023-07-27
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/ignition-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.1.0 - 2023-07-30
+
+### Fixed
+
+- Fix validation error when using the result of a `readEventArgument` as the address of a `contractAt`/`contractAtFromArtifact` ([#354](https://github.com/NomicFoundation/ignition/issues/354))
+
 ## 0.1.0 - 2023-07-27
 
 ### Added

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/hardhat-ignition",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",
@@ -34,8 +34,8 @@
     "prepack": "npm run build"
   },
   "devDependencies": {
-    "@ignored/ignition-core": "^0.1.0",
-    "@ignored/ignition-ui": "^0.1.0",
+    "@ignored/ignition-core": "^0.1.1",
+    "@ignored/ignition-ui": "^0.1.1",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@types/chai": "^4.2.22",
@@ -74,8 +74,8 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@ignored/ignition-core": "^0.1.0",
-    "@ignored/ignition-ui": "^0.1.0",
+    "@ignored/ignition-core": "^0.1.1",
+    "@ignored/ignition-ui": "^0.1.1",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "hardhat": "^2.14.0"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ignored/ignition-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "predev": "npm run regenerate-deployment-example",
@@ -14,7 +14,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@ignored/ignition-core": "^0.1.0",
+    "@ignored/ignition-core": "^0.1.1",
     "mermaid": "10.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## 0.1.0 - 2023-07-30

### Fixed

- Fix validation error when using the result of a `readEventArgument` as the address of a `contractAt`/`contractAtFromArtifact` ([#354](https://github.com/NomicFoundation/ignition/issues/354))
