### PR TITLE
fix: allow staticCall as address in contractAt(FromArtifact)

### DIFF
--- a/packages/core/src/new-api/internal/execution/chain-dispatcher.ts
+++ b/packages/core/src/new-api/internal/execution/chain-dispatcher.ts
@@ -168,7 +168,11 @@ export class ChainDispatcherImpl implements ChainDispatcher {
 
     const contractInstance = new Contract(contractAddress, abi, signer);
 
-    const result = await contractInstance[functionName](...args, {
+    const validFunctionName = functionName.endsWith("()")
+      ? functionName
+      : `${functionName}()`;
+
+    const result = await contractInstance[validFunctionName](...args, {
       from,
     });
 

--- a/packages/core/src/new-api/internal/execution/chain-dispatcher.ts
+++ b/packages/core/src/new-api/internal/execution/chain-dispatcher.ts
@@ -168,9 +168,23 @@ export class ChainDispatcherImpl implements ChainDispatcher {
 
     const contractInstance = new Contract(contractAddress, abi, signer);
 
-    const validFunctionName = functionName.endsWith("()")
-      ? functionName
-      : `${functionName}()`;
+    // todo: temp fix
+    // if user provided a function name with parenthesis, assume they know what they're doing
+    // if not, add the open parenthesis for the regex test
+    const userFnOrNormalized = functionName.endsWith(")")
+      ? functionName.replace("(", "\\(").replace(")", "\\)")
+      : `${functionName}\\(`;
+
+    const matchingFunctions = Object.keys(contractInstance).filter((key) =>
+      new RegExp(userFnOrNormalized).test(key)
+    );
+
+    assertIgnitionInvariant(
+      matchingFunctions.length === 1,
+      "Ignition does not yet support overloaded static calls"
+    );
+
+    const [validFunctionName] = matchingFunctions;
 
     const result = await contractInstance[validFunctionName](...args, {
       from,

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -837,17 +837,20 @@ export class ExecutionEngine {
             );
 
             address = contractAddress;
-          } else if (isReadEventArgumentExecutionState(exState)) {
+          } else if (
+            isReadEventArgumentExecutionState(exState) ||
+            isStaticCallExecutionState(exState)
+          ) {
             const contractAddress = exState.result;
 
             assertIgnitionInvariant(
               contractAddress !== undefined,
-              `Internal error - dependency ReadEventArgument ${future.address.id} used before it's resolved`
+              `Internal error - dependency ${future.address.id} used before it's resolved`
             );
 
             assertIgnitionInvariant(
               typeof contractAddress === "string" && isAddress(contractAddress),
-              `Read event argument ${future.address.id} must be a valid address`
+              `Future '${future.address.id}' must be a valid address`
             );
 
             address = contractAddress;
@@ -902,17 +905,20 @@ export class ExecutionEngine {
             );
 
             address = contractAddress;
-          } else if (isReadEventArgumentExecutionState(exState)) {
+          } else if (
+            isReadEventArgumentExecutionState(exState) ||
+            isStaticCallExecutionState(exState)
+          ) {
             const contractAddress = exState.result;
 
             assertIgnitionInvariant(
               contractAddress !== undefined,
-              `Internal error - dependency ReadEventArgument ${future.address.id} used before it's resolved`
+              `Internal error - dependency ${future.address.id} used before it's resolved`
             );
 
             assertIgnitionInvariant(
               typeof contractAddress === "string" && isAddress(contractAddress),
-              `Read event argument ${future.address.id} must be a valid address`
+              `Future '${future.address.id}' must be a valid address`
             );
 
             address = contractAddress;

--- a/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/Factory.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/Factory.sol
@@ -7,8 +7,14 @@ import "./Contracts.sol";
 contract FooFactory {
   event Deployed(address indexed fooAddress);
 
+  address public deployed;
+
+  bool public nonAddressResult;
+
   function create() public {
     Foo foo = new Foo();
+
+    deployed = address(foo);
 
     emit Deployed(address(foo));
   }

--- a/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/Factory.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/Factory.sol
@@ -8,6 +8,7 @@ contract FooFactory {
   event Deployed(address indexed fooAddress);
 
   address public deployed;
+  address[] public allDeployed;
 
   bool public nonAddressResult;
 
@@ -15,6 +16,7 @@ contract FooFactory {
     Foo foo = new Foo();
 
     deployed = address(foo);
+    allDeployed.push(address(foo));
 
     emit Deployed(address(foo));
   }

--- a/packages/hardhat-plugin/test/static-calls.ts
+++ b/packages/hardhat-plugin/test/static-calls.ts
@@ -1,0 +1,105 @@
+/* eslint-disable import/no-unused-modules */
+import { defineModule } from "@ignored/ignition-core";
+import { assert } from "chai";
+
+import { useEphemeralIgnitionProject } from "./use-ignition-project";
+
+describe("static calls", () => {
+  useEphemeralIgnitionProject("minimal-new-api");
+
+  it("should be able to use the output of a static call in a contract at", async function () {
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account1 = m.getAccount(1);
+
+      const fooFactory = m.contract("FooFactory", [], { from: account1 });
+
+      const createCall = m.call(fooFactory, "create", []);
+
+      const newAddress = m.staticCall(fooFactory, "deployed", [], {
+        after: [createCall],
+      });
+
+      const foo = m.contractAt("Foo", newAddress);
+
+      return { fooFactory, foo };
+    });
+
+    const result = await this.deploy(moduleDefinition);
+
+    assert.equal(await result.fooFactory.isDeployed(), true);
+    assert.equal(await result.foo.x(), Number(1));
+  });
+
+  it("should be able to use the output of a static call in an artifact contract at", async function () {
+    const artifact = await this.hre.artifacts.readArtifact("Foo");
+
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account1 = m.getAccount(1);
+
+      const fooFactory = m.contract("FooFactory", [], { from: account1 });
+
+      const createCall = m.call(fooFactory, "create", []);
+
+      const newAddress = m.staticCall(fooFactory, "deployed", [], {
+        after: [createCall],
+      });
+
+      const foo = m.contractAtFromArtifact("Foo", newAddress, artifact);
+
+      return { fooFactory, foo };
+    });
+
+    const result = await this.deploy(moduleDefinition);
+
+    assert.equal(await result.fooFactory.isDeployed(), true);
+    assert.equal(await result.foo.x(), Number(1));
+  });
+
+  it("should not be able to use the output of a non-address static call in a contract at", async function () {
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account1 = m.getAccount(1);
+
+      const fooFactory = m.contract("FooFactory", [], { from: account1 });
+
+      const createCall = m.call(fooFactory, "create", []);
+
+      const nonAddress = m.staticCall(fooFactory, "nonAddressResult", [], {
+        after: [createCall],
+      });
+
+      const foo = m.contractAt("Foo", nonAddress);
+
+      return { fooFactory, foo };
+    });
+
+    await assert.isRejected(
+      this.deploy(moduleDefinition),
+      /Future 'FooModule:FooFactory#nonAddressResult' must be a valid address/
+    );
+  });
+
+  it("should not be able to use the output of a non-address static call in an artifact contract at", async function () {
+    const artifact = await this.hre.artifacts.readArtifact("Foo");
+
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account1 = m.getAccount(1);
+
+      const fooFactory = m.contract("FooFactory", [], { from: account1 });
+
+      const createCall = m.call(fooFactory, "create", []);
+
+      const nonAddress = m.staticCall(fooFactory, "nonAddressResult", [], {
+        after: [createCall],
+      });
+
+      const foo = m.contractAtFromArtifact("Foo", nonAddress, artifact);
+
+      return { fooFactory, foo };
+    });
+
+    await assert.isRejected(
+      this.deploy(moduleDefinition),
+      /Future 'FooModule:FooFactory#nonAddressResult' must be a valid address/
+    );
+  });
+});

--- a/packages/hardhat-plugin/test/static-calls.ts
+++ b/packages/hardhat-plugin/test/static-calls.ts
@@ -55,6 +55,52 @@ describe("static calls", () => {
     assert.equal(await result.foo.x(), Number(1));
   });
 
+  it("should be able to use the output of a static call function in a contract at (with arg)", async function () {
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account1 = m.getAccount(1);
+
+      const fooFactory = m.contract("FooFactory", [], { from: account1 });
+
+      const createCall = m.call(fooFactory, "create", []);
+
+      const newAddress = m.staticCall(fooFactory, "allDeployed", [0], {
+        after: [createCall],
+      });
+
+      const foo = m.contractAt("Foo", newAddress);
+
+      return { fooFactory, foo };
+    });
+
+    const result = await this.deploy(moduleDefinition);
+
+    assert.equal(await result.fooFactory.isDeployed(), true);
+    assert.equal(await result.foo.x(), Number(1));
+  });
+
+  it("should be able to use the output of a static call function in a contract at (with function signature)", async function () {
+    const moduleDefinition = defineModule("FooModule", (m) => {
+      const account1 = m.getAccount(1);
+
+      const fooFactory = m.contract("FooFactory", [], { from: account1 });
+
+      const createCall = m.call(fooFactory, "create", []);
+
+      const newAddress = m.staticCall(fooFactory, "allDeployed(uint256)", [0], {
+        after: [createCall],
+      });
+
+      const foo = m.contractAt("Foo", newAddress);
+
+      return { fooFactory, foo };
+    });
+
+    const result = await this.deploy(moduleDefinition);
+
+    assert.equal(await result.fooFactory.isDeployed(), true);
+    assert.equal(await result.foo.x(), Number(1));
+  });
+
   it("should not be able to use the output of a non-address static call in a contract at", async function () {
     const moduleDefinition = defineModule("FooModule", (m) => {
       const account1 = m.getAccount(1);


### PR DESCRIPTION
A check has been added to see if the address a staticCall, and that it resolves to a valid address string.

Also fixed a bug in the static call execution code.

Fixes #357.