### PR TITLE
Update `package.json`s

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
   "typesVersions": {
     "*": {
       "ui-helpers": [
-        "./dist/src/ui-helpers"
+        "./dist/src/ui-helpers.d.ts"
       ]
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,9 +15,6 @@
     "solidity",
     "deployment"
   ],
-  "engines": {
-    "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
-  },
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "exports": {

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -15,9 +15,6 @@
     "solidity",
     "deployment"
   ],
-  "engines": {
-    "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
-  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This PR makes sure that the subpath exports are properly set so that the different versions of TS can resolve them. This was based on [this repository I built](https://github.com/alcuadrado/nodejs-exports-and-typescript).

This PR also removes the `engines` fields, to be consistent with Hardhat's packages.