### PR TITLE
Rework module loading

### DIFF
--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -1,4 +1,9 @@
-import { deploy, ModuleConstructor, wipe } from "@ignored/ignition-core";
+import {
+  deploy,
+  DeploymentParameters,
+  ModuleConstructor,
+  wipe,
+} from "@ignored/ignition-core";
 import "@nomiclabs/hardhat-ethers";
 import { BigNumber } from "ethers";
 import { existsSync, readdirSync, readJSONSync } from "fs-extra";
@@ -119,7 +124,7 @@ task("deploy")
 
       await hre.run("compile", { quiet: true });
 
-      const userModule: any | undefined = loadModule(
+      const userModule = loadModule(
         hre.config.paths.ignition,
         moduleNameOrPath
       );
@@ -129,10 +134,10 @@ task("deploy")
         process.exit(0);
       }
 
-      let parameters: any | undefined;
+      let parameters: DeploymentParameters | undefined;
       if (parametersInput === undefined) {
         parameters = resolveParametersFromModuleName(
-          userModule.name,
+          userModule.id,
           hre.config.paths.ignition
         );
       } else if (parametersInput.endsWith(".json")) {
@@ -160,9 +165,8 @@ task("deploy")
           adapters,
           artifactResolver,
           deploymentDir,
-          moduleDefinition: userModule as any,
-          // TODO: parameters needs properly typed with module
-          deploymentParameters: (parameters as any) ?? {},
+          moduleDefinition: userModule,
+          deploymentParameters: parameters ?? {},
           accounts,
           verbose: logs,
         });
@@ -226,8 +230,7 @@ task("plan")
     ) => {
       await hre.run("compile", { quiet: true });
 
-      // TODO: alter loadModule to return new-api modules at type level
-      const userModule: any = loadModule(
+      const userModule = loadModule(
         hre.config.paths.ignition,
         moduleNameOrPath
       );
@@ -348,7 +351,7 @@ task("wipe")
 function resolveParametersFromModuleName(
   moduleName: string,
   ignitionPath: string
-): any | undefined {
+): DeploymentParameters | undefined {
   const files = readdirSync(ignitionPath);
   const configFilename = `${moduleName}.config.json`;
 
@@ -357,13 +360,13 @@ function resolveParametersFromModuleName(
     : undefined;
 }
 
-function resolveParametersFromFileName(fileName: string): any {
+function resolveParametersFromFileName(fileName: string): DeploymentParameters {
   const filepath = path.resolve(process.cwd(), fileName);
 
   return resolveConfigPath(filepath);
 }
 
-function resolveConfigPath(filepath: string): any {
+function resolveConfigPath(filepath: string): DeploymentParameters {
   try {
     return require(filepath);
   } catch {
@@ -372,7 +375,7 @@ function resolveConfigPath(filepath: string): any {
   }
 }
 
-function resolveParametersString(paramString: string): any {
+function resolveParametersString(paramString: string): DeploymentParameters {
   try {
     return JSON.parse(paramString);
   } catch {

--- a/packages/hardhat-plugin/src/load-module.ts
+++ b/packages/hardhat-plugin/src/load-module.ts
@@ -1,4 +1,8 @@
-import { IgnitionError } from "@ignored/ignition-core";
+import {
+  IgnitionError,
+  IgnitionModuleDefinition,
+  IgnitionModuleResult,
+} from "@ignored/ignition-core";
 import setupDebug from "debug";
 import { existsSync, pathExistsSync } from "fs-extra";
 import path from "path";
@@ -8,7 +12,9 @@ const debug = setupDebug("hardhat-ignition:modules");
 export function loadModule(
   modulesDirectory: string,
   moduleNameOrPath: string
-): any | undefined {
+):
+  | IgnitionModuleDefinition<string, string, IgnitionModuleResult<string>>
+  | undefined {
   debug(`Loading user modules from '${modulesDirectory}'`);
 
   if (!existsSync(modulesDirectory)) {

--- a/packages/hardhat-plugin/test/fixture-projects/user-modules/ignition/TestModule.js
+++ b/packages/hardhat-plugin/test/fixture-projects/user-modules/ignition/TestModule.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-unused-modules
 module.exports = {
-  name: "testing123",
-  action: () => {},
+  id: "testing123",
+  moduleDefintionFunction: () => {},
 };

--- a/packages/hardhat-plugin/test/load-module.ts
+++ b/packages/hardhat-plugin/test/load-module.ts
@@ -12,7 +12,7 @@ describe.skip("loadModule", function () {
       assert.fail("Module was not loaded");
     }
 
-    assert.equal(module.name, "testing123");
+    // assert.equal(module.name, "testing123");
   });
 
   it("should return the module given the module name and extension", () => {
@@ -22,7 +22,7 @@ describe.skip("loadModule", function () {
       assert.fail("Module was not loaded");
     }
 
-    assert.equal(module.name, "testing123");
+    // assert.equal(module.name, "testing123");
   });
 
   it("should throw if the module name does not exist", () => {

--- a/packages/hardhat-plugin/test/load-module.ts
+++ b/packages/hardhat-plugin/test/load-module.ts
@@ -3,8 +3,11 @@ import { assert } from "chai";
 
 import { loadModule } from "../src/load-module";
 
-// TODO: convert over once old code paths are removed
-describe.skip("loadModule", function () {
+import { useEphemeralIgnitionProject } from "./use-ignition-project";
+
+describe("loadModule", function () {
+  useEphemeralIgnitionProject("user-modules");
+
   it("should return the module given the module name", () => {
     const module = loadModule("ignition", "TestModule");
 
@@ -12,7 +15,7 @@ describe.skip("loadModule", function () {
       assert.fail("Module was not loaded");
     }
 
-    // assert.equal(module.name, "testing123");
+    assert.equal(module.id, "testing123");
   });
 
   it("should return the module given the module name and extension", () => {
@@ -22,7 +25,7 @@ describe.skip("loadModule", function () {
       assert.fail("Module was not loaded");
     }
 
-    // assert.equal(module.name, "testing123");
+    assert.equal(module.id, "testing123");
   });
 
   it("should throw if the module name does not exist", () => {


### PR DESCRIPTION
- [x] Replace the use of `any` in the `hardhat-plugin/src/index.ts` around module loading and manipulation
- [x] Re-enable the module loading tests (review and determine what is still appropriate)

fixes #344