### PR TITLE
refactor: clean up chain-dispatcher (PR 1)

### DIFF
--- a/packages/core/src/new-api/internal/execution/chain-dispatcher.ts
+++ b/packages/core/src/new-api/internal/execution/chain-dispatcher.ts
@@ -124,10 +124,9 @@ export class ChainDispatcherImpl implements ChainDispatcher {
       txToReadFrom
     );
 
-    // TODO: should this really return an error result
     assertIgnitionInvariant(
       receipt !== undefined && receipt !== null,
-      `Receipt must be available: ${txToReadFrom}`
+      `Failed to find receipt when reading event for transaction: ${txToReadFrom}`
     );
 
     const { logs } = receipt;
@@ -139,11 +138,10 @@ export class ChainDispatcherImpl implements ChainDispatcher {
     );
 
     // sanity check to ensure the eventIndex isn't out of range
-    if (events.length > 1 && eventIndex >= events.length) {
-      throw new Error(
-        `Given eventIndex '${eventIndex}' exceeds number of events emitted '${events.length}'`
-      );
-    }
+    assertIgnitionInvariant(
+      events.length <= 1 || eventIndex < events.length,
+      `Given eventIndex '${eventIndex}' exceeds number of events emitted '${events.length}'`
+    );
 
     // this works in combination with the check above
     // because we default eventIndex to 0 if not set by user

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -26,6 +26,7 @@ import {
   NamedContractAtFuture,
   NamedContractDeploymentFuture,
   NamedLibraryDeploymentFuture,
+  SolidityParameterType,
 } from "../../types/module";
 import { DeploymentLoader } from "../deployment-loader/types";
 import {
@@ -1017,9 +1018,9 @@ export class ExecutionEngine {
       accounts: string[];
       executionStateMap: ExecutionStateMap;
     }
-  ) {
+  ): SolidityParameterType[] {
     const replace = (arg: ArgumentType) =>
-      replaceWithinArg<ArgumentType>(arg, {
+      replaceWithinArg<SolidityParameterType>(arg, {
         bigint: identity,
         future: (f) => {
           return resolveFutureToValue(f, context);

--- a/packages/core/src/new-api/internal/execution/onchain-state-transitions.ts
+++ b/packages/core/src/new-api/internal/execution/onchain-state-transitions.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 
 import { IgnitionError } from "../../../errors";
-import { ArgumentType } from "../../types/module";
+import { SolidityParameterType } from "../../types/module";
 import {
   DeploymentExecutionState,
   ExecutionEngineState,
@@ -477,7 +477,7 @@ async function _convertRequestToCallFunctionTransaction(
   const contractAddress: string = request.contractAddress;
   const abi = artifact.abi;
   const functionName: string = request.functionName;
-  const args: ArgumentType[] = request.args;
+  const args: SolidityParameterType[] = request.args;
   const value: bigint = BigInt(request.value);
   const from: string = request.from;
 

--- a/packages/core/src/new-api/internal/execution/types.ts
+++ b/packages/core/src/new-api/internal/execution/types.ts
@@ -3,7 +3,6 @@ import { ethers } from "ethers";
 import { ArtifactResolver } from "../../types/artifact";
 import { DeployConfig, DeploymentParameters } from "../../types/deployer";
 import {
-  ArgumentType,
   FutureType,
   IgnitionModule,
   IgnitionModuleResult,
@@ -62,7 +61,7 @@ export interface DeploymentExecutionState
   > {
   artifactFutureId: string; // As stored in the deployment directory.
   contractName: string;
-  constructorArgs: ArgumentType[];
+  constructorArgs: SolidityParameterType[];
   libraries: Record<string, string>; // TODO: Do we need to store their future ids for the reconciliation process?
   value: bigint;
   from: string | undefined;
@@ -75,7 +74,7 @@ export interface CallExecutionState
   artifactFutureId: string;
   contractAddress: string;
   functionName: string;
-  args: ArgumentType[];
+  args: SolidityParameterType[];
   value: bigint;
   from: string | undefined;
   txId?: string;
@@ -86,7 +85,7 @@ export interface StaticCallExecutionState
   artifactFutureId: string;
   contractAddress: string;
   functionName: string;
-  args: ArgumentType[];
+  args: SolidityParameterType[];
   from: string | undefined;
   result?: SolidityParameterType;
 }
@@ -200,7 +199,7 @@ export interface ChainDispatcher {
   constructDeployTransaction(
     byteCode: string,
     abi: any[],
-    args: ArgumentType[],
+    args: SolidityParameterType[],
     value: bigint,
     from: string
   ): Promise<ethers.providers.TransactionRequest>;
@@ -209,7 +208,7 @@ export interface ChainDispatcher {
     contractAddress: string,
     abi: any[],
     functionName: string,
-    args: ArgumentType[],
+    args: SolidityParameterType[],
     value: bigint,
     from: string
   ): Promise<ethers.providers.TransactionRequest>;
@@ -223,9 +222,9 @@ export interface ChainDispatcher {
     contractAddress: string,
     abi: any[],
     functionName: string,
-    args: ArgumentType[],
+    args: SolidityParameterType[],
     from: string
-  ): Promise<any>;
+  ): Promise<SolidityParameterType>;
 
   getTransaction(
     txHash: string
@@ -242,7 +241,7 @@ export interface ChainDispatcher {
     eventIndex: number,
     emitterAddress: string,
     abi: any[]
-  ): Promise<any>;
+  ): Promise<SolidityParameterType>;
 }
 
 export interface ExecutionEngineState {

--- a/packages/core/src/new-api/internal/journal/types/future-level-journal-message/future-start-message.ts
+++ b/packages/core/src/new-api/internal/journal/types/future-level-journal-message/future-start-message.ts
@@ -1,4 +1,4 @@
-import { ArgumentType, FutureType } from "../../../../types/module";
+import { FutureType, SolidityParameterType } from "../../../../types/module";
 import { JournalMessageType } from "../journal";
 
 /**
@@ -31,7 +31,7 @@ export interface DeployContractStartMessage {
   dependencies: string[];
   artifactFutureId: string;
   contractName: string;
-  constructorArgs: ArgumentType[];
+  constructorArgs: SolidityParameterType[];
   libraries: { [key: string]: string };
   value: string;
   from: string | undefined;
@@ -48,7 +48,7 @@ export interface CallFunctionStartMessage {
   futureType: FutureType.NAMED_CONTRACT_CALL;
   strategy: string;
   dependencies: string[];
-  args: ArgumentType[];
+  args: SolidityParameterType[];
   functionName: string;
   value: string;
   contractAddress: string;
@@ -67,7 +67,7 @@ export interface StaticCallStartMessage {
   futureType: FutureType.NAMED_STATIC_CALL;
   strategy: string;
   dependencies: string[];
-  args: ArgumentType[];
+  args: SolidityParameterType[];
   functionName: string;
   contractAddress: string;
   artifactFutureId: string;

--- a/packages/core/src/new-api/internal/journal/types/transaction-level-journal-message/onchain-interaction-message.ts
+++ b/packages/core/src/new-api/internal/journal/types/transaction-level-journal-message/onchain-interaction-message.ts
@@ -1,4 +1,4 @@
-import { ArgumentType } from "../../../../types/module";
+import { SolidityParameterType } from "../../../../types/module";
 import { JournalMessageType } from "../journal";
 
 /**
@@ -24,7 +24,7 @@ export interface DeployContractInteractionMessage {
   subtype: "deploy-contract";
   futureId: string;
   executionId: number;
-  args: ArgumentType[];
+  args: SolidityParameterType[];
   contractName: string;
   artifactFutureId: string;
   value: string;
@@ -42,7 +42,7 @@ export interface CallFunctionInteractionMessage {
   subtype: "call-function";
   futureId: string;
   executionId: number;
-  args: ArgumentType[];
+  args: SolidityParameterType[];
   functionName: string;
   value: string;
   contractAddress: string;
@@ -60,7 +60,7 @@ export interface StaticCallInteractionMessage {
   subtype: "static-call";
   futureId: string;
   executionId: number;
-  args: ArgumentType[];
+  args: SolidityParameterType[];
   functionName: string;
   contractAddress: string;
   artifactFutureId: string;


### PR DESCRIPTION
The main change here is switching to SolidityParameterType for args, this implied pushing that change through the messages and execution state. By the time an execution state is initialized the args should be resolved.

Fixes #380.