### PR TITLE
test: fix for complete test

### DIFF
--- a/examples/complete/test/Complete.js
+++ b/examples/complete/test/Complete.js
@@ -14,7 +14,11 @@ describe("Complete", function () {
       withLib,
       duplicate,
       duplicateWithLib,
-    } = await ignition.deploy(CompleteModule);
+    } = await ignition.deploy(CompleteModule, {
+      config: {
+        blockConfirmations: 1,
+      },
+    });
 
     return {
       basic,


### PR DESCRIPTION
We are not auto-detecting auto-mining chains, which means tests need an explicit override.

This will be cleaned up in a coming commit.