### PR TITLE
Remove temp fix for static call function names (PR 2)

### DIFF
--- a/packages/core/src/new-api/internal/execution/chain-dispatcher.ts
+++ b/packages/core/src/new-api/internal/execution/chain-dispatcher.ts
@@ -172,25 +172,7 @@ export class ChainDispatcherImpl implements ChainDispatcher {
 
     const contractInstance = new Contract(contractAddress, abi, signer);
 
-    // todo: temp fix
-    // if user provided a function name with parenthesis, assume they know what they're doing
-    // if not, add the open parenthesis for the regex test
-    const userFnOrNormalized = functionName.endsWith(")")
-      ? functionName.replace("(", "\\(").replace(")", "\\)")
-      : `${functionName}\\(`;
-
-    const matchingFunctions = Object.keys(contractInstance).filter((key) =>
-      new RegExp(userFnOrNormalized).test(key)
-    );
-
-    assertIgnitionInvariant(
-      matchingFunctions.length === 1,
-      "Ignition does not yet support overloaded static calls"
-    );
-
-    const [validFunctionName] = matchingFunctions;
-
-    const result = await contractInstance[validFunctionName](...args, {
+    const result = await contractInstance[functionName](...args, {
       from,
     });
 


### PR DESCRIPTION
The ticket originally was for writing a more comprehensive solution for static call function names with args, but this is handled in validation now so this issue was largely resolved already. Just removing the temp fix now.

fixes #372 