### PR TITLE
docs/update-config-section (PR 6)

### DIFF
--- a/docs/running-a-deployment.md
+++ b/docs/running-a-deployment.md
@@ -60,8 +60,9 @@ There are configurable options you can add to your Hardhat config file to adjust
 ```tsx
 export interface DeployConfig {
   blockPollingInterval: number;
-  transactionTimeoutInterval: number;
-  blockConfirmations: number;
+  timeBeforeBumpingFees: number;
+  maxFeeBumps: number;
+  requiredConfirmations: number;
 }
 ```
 
@@ -72,9 +73,10 @@ const { ethers } = require("ethers");
 
 module.exports = {
   ignition: {
-    blockPollingInterval: 200,
-    transactionTimeoutInterval: 3 * 60 * 1000,
-    blockConfirmations: 5,
+    blockPollingInterval: 1_000,
+    timeBeforeBumpingFees: 3 * 60 * 1_000,
+    maxFeeBumps: 4,
+    requiredConfirmations: 5,
   },
 };
 ```
@@ -87,15 +89,21 @@ The value of `blockPollingInterval` is the time in milliseconds between checks t
 
 ---
 
-#### `transactionTimeoutInterval`
+#### `timeBeforeBumpingFees`
 
-The value of `transactionTimeoutInterval` sets the time in milliseconds to wait for a transaction to be confirmed on-chain before setting it as timed out for this deployment run. The default is 3mins.
+The value of `timeBeforeBumpingFees` sets the time in milliseconds to wait for a transaction to be confirmed on-chain before bumping its fee. The default is 3mins.
 
 ---
 
-#### `blockConfirmations`
+#### `maxFeeBumps`
 
-The value of `blockConfirmations` is the number of blocks after a transaction has been confirmed to wait before Ignition will consider the transaction as complete. This provides control over block re-org risk. The default number of confirmations is five.
+The value of `maxFeeBumps` determines the number of times the transaction will have its fee bumped before Ignition fails it as a timeout. The default is four.
+
+---
+
+#### `requiredConfirmations`
+
+The value of `requiredConfirmations` is the number of blocks after a transaction has been confirmed to wait before Ignition will consider the transaction as complete. This provides control over block re-org risk. The default number of confirmations is five.
 
 ---
 

--- a/examples/complete/test/Complete.js
+++ b/examples/complete/test/Complete.js
@@ -16,7 +16,7 @@ describe.skip("Complete", function () {
       duplicateWithLib,
     } = await ignition.deploy(CompleteModule, {
       config: {
-        blockConfirmations: 1,
+        requiredConfirmations: 1,
       },
     });
 

--- a/examples/ens/test/sample-test.js
+++ b/examples/ens/test/sample-test.js
@@ -11,7 +11,7 @@ describe.skip("ENS", function () {
 
     // Arrange
     const { ens, resolver } = await ignition.deploy(ENSModule, {
-      config: { blockConfirmations: 1 },
+      config: { requiredConfirmations: 1 },
     });
 
     await ens.setSubnodeOwner(

--- a/examples/sample/test/Lock.js
+++ b/examples/sample/test/Lock.js
@@ -27,7 +27,7 @@ describe.skip("Lock", function () {
           lockedAmount,
         },
       },
-      config: { blockConfirmations: 1 },
+      config: { requiredConfirmations: 1 },
     });
 
     return { lock, unlockTime, lockedAmount, owner, otherAccount };

--- a/examples/ts-sample/test/Lock.ts
+++ b/examples/ts-sample/test/Lock.ts
@@ -26,7 +26,7 @@ describe.skip("Lock", function () {
           lockedAmount,
         },
       },
-      config: { blockConfirmations: 1 },
+      config: { requiredConfirmations: 1 },
     });
 
     return { lock, unlockTime, lockedAmount, owner, otherAccount };

--- a/examples/uniswap/test/uniswap-test.js
+++ b/examples/uniswap/test/uniswap-test.js
@@ -23,7 +23,7 @@ describe.skip("Uniswap", function () {
     // Deploy Uniswap
     ({ nonfungibleTokenPositionManager, uniswapV3Factory, swapRouter02 } =
       await ignition.deploy(UniswapModule, {
-        config: { blockConfirmations: 1 },
+        config: { requiredConfirmations: 1 },
       }));
 
     // Deploy example tokens Solidus and Florin

--- a/packages/core/src/new-api/deploy.ts
+++ b/packages/core/src/new-api/deploy.ts
@@ -74,10 +74,10 @@ export async function deploy({
 
   const resolvedConfig: DeployConfig = {
     ...defaultConfig,
-    ...config,
     requiredConfirmations: isAutominedNetwork
       ? DEFAULT_AUTOMINE_REQUIRED_CONFIRMATIONS
       : config.requiredConfirmations ?? defaultConfig.requiredConfirmations,
+    ...config,
   };
 
   const deployer = new Deployer(

--- a/packages/core/src/new-api/internal/deployer.ts
+++ b/packages/core/src/new-api/internal/deployer.ts
@@ -45,7 +45,7 @@ export class Deployer {
   ) {
     assertIgnitionInvariant(
       this._config.requiredConfirmations >= 1,
-      `Configured value 'blockConfirmations' cannot be less than 1. Value given: '${this._config.requiredConfirmations}'`
+      `Configured value 'requiredConfirmations' cannot be less than 1. Value given: '${this._config.requiredConfirmations}'`
     );
   }
 

--- a/packages/hardhat-plugin/test/config.ts
+++ b/packages/hardhat-plugin/test/config.ts
@@ -6,6 +6,7 @@ import { assert } from "chai";
 import { KeyListOf } from "./type-helper";
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
+// eslint-disable-next-line no-only-tests/no-only-tests
 describe.only("config", () => {
   describe("loading", () => {
     useEphemeralIgnitionProject("with-config");
@@ -47,7 +48,7 @@ describe.only("config", () => {
   describe("validating", () => {
     useEphemeralIgnitionProject("with-invalid-config");
 
-    it.skip("should throw when given a `requiredConfirmations` value less than 1", async function () {
+    it("should throw when given a `requiredConfirmations` value less than 1", async function () {
       const moduleDefinition = buildModule("FooModule", (m) => {
         const foo = m.contract("Foo");
 

--- a/packages/hardhat-plugin/test/config.ts
+++ b/packages/hardhat-plugin/test/config.ts
@@ -6,7 +6,7 @@ import { assert } from "chai";
 import { KeyListOf } from "./type-helper";
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
-describe("config", () => {
+describe.only("config", () => {
   describe("loading", () => {
     useEphemeralIgnitionProject("with-config");
 
@@ -16,7 +16,7 @@ describe("config", () => {
       loadedOptions = this.hre.config.ignition;
     });
 
-    it("should apply blockConfirmations", async function () {
+    it("should apply requiredConfirmations", async function () {
       assert.equal(loadedOptions.requiredConfirmations, 10);
     });
 
@@ -25,17 +25,17 @@ describe("config", () => {
     });
 
     it("should apply timeBeforeBumpingFees", async function () {
-      assert.equal(loadedOptions.timeBeforeBumpingFees, 3 * 60 * 1000);
+      assert.equal(loadedOptions.timeBeforeBumpingFees, 60 * 1000);
     });
 
     it("should apply maxFeeBumps", async function () {
-      assert.equal(loadedOptions.maxFeeBumps, 5);
+      assert.equal(loadedOptions.maxFeeBumps, 2);
     });
 
     it("should only have known config", () => {
       const configOptions: KeyListOf<DeployConfig> = [
-        "maxFeeBumps",
         "blockPollingInterval",
+        "maxFeeBumps",
         "requiredConfirmations",
         "timeBeforeBumpingFees",
       ];
@@ -47,7 +47,7 @@ describe("config", () => {
   describe("validating", () => {
     useEphemeralIgnitionProject("with-invalid-config");
 
-    it("should throw when given a `blockConfirmations` value less than 1", async function () {
+    it.skip("should throw when given a `requiredConfirmations` value less than 1", async function () {
       const moduleDefinition = buildModule("FooModule", (m) => {
         const foo = m.contract("Foo");
 
@@ -56,7 +56,7 @@ describe("config", () => {
 
       await assert.isRejected(
         this.deploy(moduleDefinition),
-        `Configured value 'blockConfirmations' cannot be less than 1. Value given: '0'`
+        `Configured value 'requiredConfirmations' cannot be less than 1. Value given: '0'`
       );
     });
   });

--- a/packages/hardhat-plugin/test/fixture-projects/with-config/hardhat.config.js
+++ b/packages/hardhat-plugin/test/fixture-projects/with-config/hardhat.config.js
@@ -9,8 +9,9 @@ module.exports = {
     },
   },
   ignition: {
-    blockConfirmations: 10,
+    requiredConfirmations: 10,
     blockPollingInterval: 100,
-    transactionTimeoutInterval: 60 * 1000,
+    timeBeforeBumpingFees: 60 * 1000,
+    maxFeeBumps: 2,
   },
 };

--- a/packages/hardhat-plugin/test/fixture-projects/with-invalid-config/hardhat.config.js
+++ b/packages/hardhat-plugin/test/fixture-projects/with-invalid-config/hardhat.config.js
@@ -9,8 +9,9 @@ module.exports = {
     },
   },
   ignition: {
-    blockConfirmations: 0,
+    requiredConfirmations: 0,
     blockPollingInterval: 100,
-    transactionTimeoutInterval: 60 * 1000,
+    timeBeforeBumpingFees: 60 * 1000,
+    maxFeeBumps: 2,
   },
 };

--- a/packages/hardhat-plugin/test/load-module.ts
+++ b/packages/hardhat-plugin/test/load-module.ts
@@ -6,7 +6,7 @@ import { loadModule } from "../src/load-module";
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
 // eslint-disable-next-line no-only-tests/no-only-tests
-describe.only("loadModule", function () {
+describe("loadModule", function () {
   useEphemeralIgnitionProject("user-modules");
 
   it("should return the module given the module name", () => {

--- a/packages/hardhat-plugin/test/load-module.ts
+++ b/packages/hardhat-plugin/test/load-module.ts
@@ -6,7 +6,7 @@ import { loadModule } from "../src/load-module";
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
 // eslint-disable-next-line no-only-tests/no-only-tests
-describe("loadModule", function () {
+describe.only("loadModule", function () {
   useEphemeralIgnitionProject("user-modules");
 
   it("should return the module given the module name", () => {

--- a/packages/hardhat-plugin/test/type-helper.ts
+++ b/packages/hardhat-plugin/test/type-helper.ts
@@ -7,9 +7,10 @@
  * Where ExpectedConfigOptions is the type level tuple:
  * ```
  * [
- *    "blockConfirmations",
  *    "blockPollingInterval",
- *    "transactionTimeoutInterval",
+ *    "maxFeeBumps",
+ *    "requiredConfirmations",
+ *    "timeBeforeBumpingFees"
  * ]
  * ```
  */


### PR DESCRIPTION
Bring the config section of the docs inline with the new config values and the defaults.

Fix an issue with config and automining. The user provided `requiredConfirmations` should take precedence even over the automining default.