### PR TITLE
test/reenable-integration-tests

### DIFF
--- a/packages/core/src/new-api/internal/deployer.ts
+++ b/packages/core/src/new-api/internal/deployer.ts
@@ -149,7 +149,7 @@ export class Deployer {
       )
     ) {
       // TODO: deal with failure cases and error cases
-      throw new Error("TBD");
+      throw new Error("TBD: error result against future");
     }
 
     const deployedContracts: DeploymentResultContracts = {};

--- a/packages/core/src/new-api/internal/new-execution/basic-execution-strategy.ts
+++ b/packages/core/src/new-api/internal/new-execution/basic-execution-strategy.ts
@@ -90,7 +90,7 @@ export class BasicExecutionStrategy implements ExecutionStrategy {
       {
         id: 1,
         type: NetworkInteractionType.ONCHAIN_INTERACTION,
-        to: undefined,
+        to: executionState.contractAddress,
         data: encodeArtifactFunctionCall(
           artifact,
           executionState.functionName,

--- a/packages/hardhat-plugin/test/calls.ts
+++ b/packages/hardhat-plugin/test/calls.ts
@@ -4,8 +4,7 @@ import { assert } from "chai";
 
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
-// eslint-disable-next-line no-only-tests/no-only-tests
-describe.only("calls", () => {
+describe("calls", () => {
   useEphemeralIgnitionProject("minimal-new-api");
 
   it("should be able to call contracts", async function () {
@@ -173,6 +172,4 @@ describe.only("calls", () => {
       );
     });
   });
-
-  it("should note fail if call fails");
 });

--- a/packages/hardhat-plugin/test/calls.ts
+++ b/packages/hardhat-plugin/test/calls.ts
@@ -4,7 +4,8 @@ import { assert } from "chai";
 
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
-describe("calls", () => {
+// eslint-disable-next-line no-only-tests/no-only-tests
+describe.only("calls", () => {
   useEphemeralIgnitionProject("minimal-new-api");
 
   it("should be able to call contracts", async function () {
@@ -26,7 +27,10 @@ describe("calls", () => {
 
     const usedAddress = await result.usesContract.contractAddress();
 
-    assert.equal(usedAddress, result.bar.address);
+    assert.equal(
+      usedAddress.toLowerCase(),
+      (await result.bar.getAddress()).toLowerCase()
+    );
   });
 
   it("should be able to call contracts with array args", async function () {
@@ -112,7 +116,7 @@ describe("calls", () => {
         const passingValue = m.contract("PassingValue");
 
         m.call(passingValue, "deposit", [], {
-          value: BigInt(this.hre.ethers.utils.parseEther("1").toString()),
+          value: BigInt(this.hre.ethers.parseEther("1").toString()),
         });
 
         return { passingValue };
@@ -123,24 +127,23 @@ describe("calls", () => {
       assert.isDefined(result.passingValue);
 
       const actualInstanceBalance = await this.hre.ethers.provider.getBalance(
-        result.passingValue.address
+        await result.passingValue.getAddress()
       );
 
       assert.equal(
         actualInstanceBalance.toString(),
-        this.hre.ethers.utils.parseEther("1").toString()
+        this.hre.ethers.parseEther("1").toString()
       );
     });
 
     it("should be able to call a contract passing a value via a parameter", async function () {
       const submoduleDefinition = buildModule("Submodule", (m) => {
-        // const depositValue = m.getParameter("depositValue", 1000);
+        const depositValue = m.getParameter("depositValue", BigInt(1000));
 
         const passingValue = m.contract("PassingValue");
 
         m.call(passingValue, "deposit", [], {
-          // TODO: bring back passing this by parameter
-          value: BigInt(this.hre.ethers.utils.parseEther("1")),
+          value: depositValue,
         });
 
         return { passingValue };
@@ -153,20 +156,20 @@ describe("calls", () => {
       });
 
       const result = await this.deploy(moduleDefinition, {
-        Module: {
-          depositValue: BigInt(this.hre.ethers.utils.parseEther("1")),
+        Submodule: {
+          depositValue: BigInt(this.hre.ethers.parseEther("1")),
         },
       });
 
       assert.isDefined(result.passingValue);
 
       const actualInstanceBalance = await this.hre.ethers.provider.getBalance(
-        result.passingValue.address
+        await result.passingValue.getAddress()
       );
 
       assert.equal(
         actualInstanceBalance.toString(),
-        this.hre.ethers.utils.parseEther("1").toString()
+        this.hre.ethers.parseEther("1").toString()
       );
     });
   });

--- a/packages/hardhat-plugin/test/config.ts
+++ b/packages/hardhat-plugin/test/config.ts
@@ -6,8 +6,7 @@ import { assert } from "chai";
 import { KeyListOf } from "./type-helper";
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
-// eslint-disable-next-line no-only-tests/no-only-tests
-describe.only("config", () => {
+describe("config", () => {
   describe("loading", () => {
     useEphemeralIgnitionProject("with-config");
 

--- a/packages/hardhat-plugin/test/contracts.ts
+++ b/packages/hardhat-plugin/test/contracts.ts
@@ -4,8 +4,7 @@ import { assert } from "chai";
 
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
-// eslint-disable-next-line no-only-tests/no-only-tests
-describe.only("contract deploys", () => {
+describe("contract deploys", () => {
   useEphemeralIgnitionProject("minimal-new-api");
 
   it("should be able to deploy a contract", async function () {

--- a/packages/hardhat-plugin/test/events.ts
+++ b/packages/hardhat-plugin/test/events.ts
@@ -7,7 +7,7 @@ import { useEphemeralIgnitionProject } from "./use-ignition-project";
 describe("events", () => {
   useEphemeralIgnitionProject("minimal-new-api");
 
-  it("should be able to use the output of a readEvent in a contract at", async function () {
+  it.skip("should be able to use the output of a readEvent in a contract at", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account1 = m.getAccount(1);
 
@@ -32,7 +32,7 @@ describe("events", () => {
     assert.equal(await result.foo.x(), Number(1));
   });
 
-  it("should be able to use the output of a readEvent in an artifact contract at", async function () {
+  it.skip("should be able to use the output of a readEvent in an artifact contract at", async function () {
     const artifact = await this.hre.artifacts.readArtifact("Foo");
 
     const moduleDefinition = buildModule("FooModule", (m) => {

--- a/packages/hardhat-plugin/test/execution/deploy-contract-at-from-artifact.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract-at-from-artifact.ts
@@ -13,7 +13,7 @@ import {
  * First deploy a working contract, then reuse it from a subsequent module
  * with a passed in artifact.
  */
-describe("execution - deploy contractAt from artifact", function () {
+describe.skip("execution - deploy contractAt from artifact", function () {
   // TODO: rename back to minimal api once execution switched over
   useEphemeralIgnitionProject("minimal-new-api");
 

--- a/packages/hardhat-plugin/test/execution/deploy-contract-at.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract-at.ts
@@ -16,7 +16,7 @@ describe("execution - deploy contract at", function () {
   // TODO: rename back to minimal api once execution switched over
   useEphemeralIgnitionProject("minimal-new-api");
 
-  it("should deploy a contract that is callable", async function () {
+  it.skip("should deploy a contract that is callable", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const foo = m.contract("Foo");
 

--- a/packages/hardhat-plugin/test/execution/nonce-checks/error-on-pending-user-transactions.ts
+++ b/packages/hardhat-plugin/test/execution/nonce-checks/error-on-pending-user-transactions.ts
@@ -20,7 +20,7 @@ describe("execution - error on pending user transactions", () => {
     "error-on-rerun-with-replaced-pending-user-transaction"
   );
 
-  it("should error if a transaction is in flight for an account used in the deploy", async function () {
+  it.skip("should error if a transaction is in flight for an account used in the deploy", async function () {
     // Setup a module with a contract deploy on accounts[2]
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account2 = m.getAccount(2);

--- a/packages/hardhat-plugin/test/execution/nonce-checks/error-on-rerun-with-replaced-pending-user-transaction.ts
+++ b/packages/hardhat-plugin/test/execution/nonce-checks/error-on-rerun-with-replaced-pending-user-transaction.ts
@@ -19,7 +19,7 @@ describe("execution - error on rerun with replaced pending user transaction", ()
     "error-on-rerun-with-replaced-pending-user-transaction"
   );
 
-  it("should error on the second run", async function () {
+  it.skip("should error on the second run", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account2 = m.getAccount(2);
 
@@ -55,7 +55,7 @@ describe("execution - error on rerun with replaced pending user transaction", ()
     const [, , signer2] = await this.hre.ethers.getSigners();
     const FooFactory = await this.hre.ethers.getContractFactory("Foo");
     FooFactory.connect(signer2).deploy({
-      gasPrice: this.hre.ethers.utils.parseUnits("500", "gwei"),
+      gasPrice: this.hre.ethers.parseUnits("500", "gwei"),
       nonce: 2, // same nonce as foo3
     });
 

--- a/packages/hardhat-plugin/test/execution/nonce-checks/error-on-transaction-dropped.ts
+++ b/packages/hardhat-plugin/test/execution/nonce-checks/error-on-transaction-dropped.ts
@@ -14,7 +14,7 @@ import {
 describe("execution - error on transaction dropped", () => {
   useFileIgnitionProject("minimal-new-api", "error-on-transaction-dropped");
 
-  it("should error on the drop being detected", async function () {
+  it.skip("should error on the drop being detected", async function () {
     // Setup a module with two contract deploys (foo1 and foo2) over 2 batches
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account2 = m.getAccount(2);

--- a/packages/hardhat-plugin/test/execution/nonce-checks/error-on-user-transaction-sent.ts
+++ b/packages/hardhat-plugin/test/execution/nonce-checks/error-on-user-transaction-sent.ts
@@ -15,7 +15,7 @@ import {
 describe("execution - error on user transaction sent", () => {
   useFileIgnitionProject("minimal-new-api", "error-on-user-transaction-sent");
 
-  it("should error on the drop being detected", async function () {
+  it.skip("should error on the drop being detected", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account2 = m.getAccount(2);
 
@@ -50,7 +50,7 @@ describe("execution - error on user transaction sent", () => {
           const [, , signer2] = await this.hre.ethers.getSigners();
           const FooFactory = await this.hre.ethers.getContractFactory("Foo");
           FooFactory.connect(signer2).deploy({
-            gasPrice: this.hre.ethers.utils.parseUnits("500", "gwei"),
+            gasPrice: this.hre.ethers.parseUnits("500", "gwei"),
           });
 
           // Process block 1 with foo1

--- a/packages/hardhat-plugin/test/execution/nonce-checks/rerun-with-dropped-ignition-transaction.ts
+++ b/packages/hardhat-plugin/test/execution/nonce-checks/rerun-with-dropped-ignition-transaction.ts
@@ -19,7 +19,7 @@ describe("execution - rerun with dropped ignition transactions", () => {
     "rerun-with-dropped-ignition-transactions"
   );
 
-  it("should deploy successfully on second run", async function () {
+  it.skip("should deploy successfully on second run", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const foo = m.contract("Foo", []);
 

--- a/packages/hardhat-plugin/test/execution/nonce-checks/rerun-with-now-complete-ignition-transactions.ts
+++ b/packages/hardhat-plugin/test/execution/nonce-checks/rerun-with-now-complete-ignition-transactions.ts
@@ -19,7 +19,7 @@ describe("execution - rerun with now complete ignition transactions", () => {
     "rerun-with-now-complete-ignition-transactions"
   );
 
-  it("should complete the run on the second attempt", async function () {
+  it.skip("should complete the run on the second attempt", async function () {
     // Setup a module with 6 foo contracts deployed in pairs of 2 over 3 batches
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account2 = m.getAccount(2);

--- a/packages/hardhat-plugin/test/execution/nonce-checks/rerun-with-pending-ignition-transactions.ts
+++ b/packages/hardhat-plugin/test/execution/nonce-checks/rerun-with-pending-ignition-transactions.ts
@@ -18,7 +18,7 @@ describe("execution - rerun with pending ignition transactions", () => {
     "rerun-with-pending-ignition-transactions"
   );
 
-  it("should complete the run on the second attempt", async function () {
+  it.skip("should complete the run on the second attempt", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account2 = m.getAccount(2);
 

--- a/packages/hardhat-plugin/test/execution/nonce-checks/rerun-with-replaced-confirmed-user-transaction.ts
+++ b/packages/hardhat-plugin/test/execution/nonce-checks/rerun-with-replaced-confirmed-user-transaction.ts
@@ -21,7 +21,7 @@ describe("execution - rerun with replaced confirmed user transaction", () => {
     "rerun-with-replaced-confirmed-user-transaction"
   );
 
-  it("should deploy user interfered transaction on second run", async function () {
+  it.skip("should deploy user interfered transaction on second run", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account2 = m.getAccount(2);
 
@@ -50,7 +50,7 @@ describe("execution - rerun with replaced confirmed user transaction", () => {
     const [, , signer2] = await this.hre.ethers.getSigners();
     const FooFactory = await this.hre.ethers.getContractFactory("Foo");
     const userDeployedContractPromise = FooFactory.connect(signer2).deploy({
-      gasPrice: this.hre.ethers.utils.parseUnits("500", "gwei"),
+      gasPrice: this.hre.ethers.parseUnits("500", "gwei"),
       nonce: 2,
     });
 

--- a/packages/hardhat-plugin/test/existing-contract.ts
+++ b/packages/hardhat-plugin/test/existing-contract.ts
@@ -26,10 +26,9 @@ describe("existing contract", () => {
 
     const firstResult = await this.deploy(firstModuleDefinition);
 
-    assert.isDefined(firstResult.bar.address);
-    assert.isDefined(firstResult.usesContract.address);
-    const barAddress: string = firstResult.bar.address;
-    const usesContractAddress: string = firstResult.usesContract.address;
+    const barAddress: string = await firstResult.bar.getAddress();
+    const usesContractAddress: string =
+      await firstResult.usesContract.getAddress();
 
     const secondModuleDefinition = buildModule("SecondModule", (m) => {
       const bar = m.contractAt("Bar", barAddress, barArtifact);
@@ -51,6 +50,9 @@ describe("existing contract", () => {
 
     const usedAddress = await result.usesContract.contractAddress();
 
-    assert.equal(usedAddress, result.bar.address);
+    assert.equal(
+      usedAddress.toLowerCase(),
+      (await result.bar.getAddress()).toLowerCase()
+    );
   });
 });

--- a/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/Factory.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/minimal-new-api/contracts/Factory.sol
@@ -24,4 +24,12 @@ contract FooFactory {
   function isDeployed() public pure returns (bool output) {
     return true;
   }
+
+  function getDeployed() public view returns (address output) {
+    return allDeployed[0];
+  }
+
+  function getDeployed(uint256 value) public view returns (address output) {
+    return allDeployed[value];
+  }
 }

--- a/packages/hardhat-plugin/test/libraries.ts
+++ b/packages/hardhat-plugin/test/libraries.ts
@@ -4,7 +4,6 @@ import { assert } from "chai";
 
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
-// TODO: fix libraries in execution
 describe("libraries", () => {
   useEphemeralIgnitionProject("minimal-new-api");
 
@@ -75,11 +74,10 @@ describe("libraries", () => {
 
     const libDeployResult = await this.deploy(libraryModuleDefinition);
 
-    const libAddress = libDeployResult.rubbishMath.address;
-    const libAbi = libDeployResult.rubbishMath.abi;
+    const libAddress = await libDeployResult.rubbishMath.getAddress();
 
     const moduleDefinition = buildModule("ConsumingLibModule", (m) => {
-      const rubbishMath = m.contractAt("RubbishMath", libAddress, libAbi);
+      const rubbishMath = m.contractAt("RubbishMath", libAddress);
 
       const dependsOnLib = m.contract("DependsOnLib", [], {
         libraries: {

--- a/packages/hardhat-plugin/test/load-module.ts
+++ b/packages/hardhat-plugin/test/load-module.ts
@@ -5,8 +5,7 @@ import { loadModule } from "../src/load-module";
 
 import { useEphemeralIgnitionProject } from "./use-ignition-project";
 
-// eslint-disable-next-line no-only-tests/no-only-tests
-describe.only("loadModule", function () {
+describe("loadModule", function () {
   useEphemeralIgnitionProject("user-modules");
 
   it("should return the module given the module name", () => {

--- a/packages/hardhat-plugin/test/params.ts
+++ b/packages/hardhat-plugin/test/params.ts
@@ -80,8 +80,7 @@ describe("module parameters", () => {
   });
 });
 
-// TODO: bring back with parameter validation
-describe.skip("validation", () => {
+describe("params validation", () => {
   useEphemeralIgnitionProject("minimal-new-api");
 
   it("should throw if no parameters object provided", async function () {
@@ -101,7 +100,7 @@ describe.skip("validation", () => {
 
     await assert.isRejected(
       deployPromise,
-      'No parameters object provided to deploy options, but module requires parameter "MyNumber"'
+      "Module parameter 'MyNumber' requires a value but was given none"
     );
   });
 
@@ -128,7 +127,7 @@ describe.skip("validation", () => {
 
     await assert.isRejected(
       deployPromise,
-      'No parameter provided for "MyNumber"'
+      "Module parameter 'MyNumber' requires a value but was given none"
     );
   });
 });

--- a/packages/hardhat-plugin/test/plan/index.ts
+++ b/packages/hardhat-plugin/test/plan/index.ts
@@ -5,8 +5,7 @@ import path from "path";
 
 import { useEphemeralIgnitionProject } from "../use-ignition-project";
 
-// eslint-disable-next-line no-only-tests/no-only-tests
-describe.only("plan", () => {
+describe("plan", () => {
   // TODO: rename back to minimal api once execution switched over
   useEphemeralIgnitionProject("minimal-new-api");
 

--- a/packages/hardhat-plugin/test/static-calls.ts
+++ b/packages/hardhat-plugin/test/static-calls.ts
@@ -78,7 +78,8 @@ describe("static calls", () => {
     assert.equal(await result.foo.x(), Number(1));
   });
 
-  it("should be able to use the output of a static call function in a contract at (with function signature)", async function () {
+  // TODO: this needs more investigation
+  it.skip("should be able to use the output of a static call function in a contract at (with function signature)", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account1 = m.getAccount(1);
 
@@ -86,7 +87,7 @@ describe("static calls", () => {
 
       const createCall = m.call(fooFactory, "create", []);
 
-      const newAddress = m.staticCall(fooFactory, "allDeployed(uint256)", [0], {
+      const newAddress = m.staticCall(fooFactory, "getDeployed(uint256)", [0], {
         after: [createCall],
       });
 


### PR DESCRIPTION
The execution tests and some harder problems remain skipped but the broad basic integration tests are re-enabled including:

* calls
* library
* module params
* static calls
* useModule
* contract

There is a small bugfix for a missing id when passing a transaction for a call.