### PR TITLE
fix/static-call-validation

### DIFF
--- a/packages/core/src/new-api/internal/new-execution/abi.ts
+++ b/packages/core/src/new-api/internal/new-execution/abi.ts
@@ -150,13 +150,16 @@ export function decodeArtifactFunctionCallResult(
  *    - If the function is overloaded, the function name is includes the argument types
  *      in parentheses.
  * - The function has the correct number of arguments
+ *
+ * Optionally checks further static call constraints:
  * - The function is has a pure or view state mutability
  */
 export function validateArtifactFunction(
   artifact: Artifact,
   contractName: string,
   functionName: string,
-  args: ArgumentType[]
+  args: ArgumentType[],
+  isStaticCall: boolean
 ) {
   validateOverloadedName(artifact, functionName, false);
 
@@ -171,8 +174,8 @@ export function validateArtifactFunction(
     );
   }
 
-  // CHeck that the function is pure or view, which is required for a static call
-  if (!fragment.constant) {
+  // Check that the function is pure or view, which is required for a static call
+  if (isStaticCall && !fragment.constant) {
     throw new IgnitionValidationError(
       `Function ${functionName} in contract ${contractName} is not 'pure' or 'view' and cannot be statically called`
     );

--- a/packages/core/src/new-api/internal/validation/stageOne/validateNamedContractCall.ts
+++ b/packages/core/src/new-api/internal/validation/stageOne/validateNamedContractCall.ts
@@ -1,10 +1,11 @@
-import { FunctionFragment, Interface } from "ethers";
-
 import { IgnitionValidationError } from "../../../../errors";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { NamedContractCallFuture } from "../../../types/module";
-import { validateArtifactFunctionName } from "../../new-execution/abi";
+import {
+  validateArtifactFunction,
+  validateArtifactFunctionName,
+} from "../../new-execution/abi";
 
 export async function validateNamedContractCall(
   future: NamedContractCallFuture<string, string>,
@@ -23,30 +24,11 @@ export async function validateNamedContractCall(
 
   validateArtifactFunctionName(artifact, future.functionName);
 
-  const argsLength = future.args.length;
-
-  const iface = new Interface(artifact.abi);
-
-  const funcs: FunctionFragment[] = [];
-  iface.forEachFunction((func) => {
-    if (func.name === future.functionName) {
-      funcs.push(func);
-    }
-  });
-
-  const matchingFunctionFragments = funcs.filter(
-    (f) => f.inputs.length === argsLength
+  validateArtifactFunction(
+    artifact,
+    future.contract.contractName,
+    future.functionName,
+    future.args,
+    false
   );
-
-  if (matchingFunctionFragments.length === 0) {
-    if (funcs.length === 1) {
-      throw new IgnitionValidationError(
-        `Function ${future.functionName} in contract ${future.contract.contractName} expects ${funcs[0].inputs.length} arguments but ${argsLength} were given`
-      );
-    } else {
-      throw new IgnitionValidationError(
-        `Function ${future.functionName} in contract ${future.contract.contractName} is overloaded, but no overload expects ${argsLength} arguments`
-      );
-    }
-  }
 }

--- a/packages/core/src/new-api/internal/validation/stageOne/validateNamedStaticCall.ts
+++ b/packages/core/src/new-api/internal/validation/stageOne/validateNamedStaticCall.ts
@@ -23,6 +23,7 @@ export async function validateNamedStaticCall(
     artifact,
     future.contract.contractName,
     future.functionName,
-    future.args
+    future.args,
+    true
   );
 }

--- a/packages/core/src/new-api/internal/validation/stageOne/validateNamedStaticCall.ts
+++ b/packages/core/src/new-api/internal/validation/stageOne/validateNamedStaticCall.ts
@@ -1,10 +1,8 @@
-import { FunctionFragment, Interface } from "ethers";
-
 import { IgnitionValidationError } from "../../../../errors";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { NamedStaticCallFuture } from "../../../types/module";
-import { validateArtifactFunctionName } from "../../new-execution/abi";
+import { validateArtifactFunction } from "../../new-execution/abi";
 
 export async function validateNamedStaticCall(
   future: NamedStaticCallFuture<string, string>,
@@ -21,40 +19,10 @@ export async function validateNamedStaticCall(
     );
   }
 
-  validateArtifactFunctionName(artifact, future.functionName);
-
-  const argsLength = future.args.length;
-
-  const iface = new Interface(artifact.abi);
-
-  const funcs: FunctionFragment[] = [];
-  iface.forEachFunction((func) => {
-    if (func.name === future.functionName) {
-      funcs.push(func);
-    }
-  });
-
-  const matchingFunctionFragments = funcs.filter(
-    (f) => f.inputs.length === argsLength
+  validateArtifactFunction(
+    artifact,
+    future.contract.contractName,
+    future.functionName,
+    future.args
   );
-
-  if (matchingFunctionFragments.length === 0) {
-    if (funcs.length === 1) {
-      throw new IgnitionValidationError(
-        `Function ${future.functionName} in contract ${future.contract.contractName} expects ${funcs[0].inputs.length} arguments but ${argsLength} were given`
-      );
-    } else {
-      throw new IgnitionValidationError(
-        `Function ${future.functionName} in contract ${future.contract.contractName} is overloaded, but no overload expects ${argsLength} arguments`
-      );
-    }
-  }
-
-  const funcFrag = matchingFunctionFragments[0] as FunctionFragment;
-
-  if (!funcFrag.constant) {
-    throw new IgnitionValidationError(
-      `Function ${future.functionName} in contract ${future.contract.contractName} is not 'pure' or 'view' and cannot be statically called`
-    );
-  }
 }

--- a/packages/core/test/new-api/call.ts
+++ b/packages/core/test/new-api/call.ts
@@ -616,7 +616,7 @@ describe("call", () => {
 
         await assert.isRejected(
           validateNamedContractCall(future as any, setupMockArtifactResolver()),
-          /Function inc\(bool,uint256\) in contract Another is overloaded, but no overload expects 3 arguments/
+          /Function inc\(bool,uint256\) in contract Another expects 2 arguments but 3 were given/
         );
       });
     });

--- a/packages/core/test/new-api/staticCall.ts
+++ b/packages/core/test/new-api/staticCall.ts
@@ -586,7 +586,7 @@ describe("static call", () => {
 
         await assert.isRejected(
           validateNamedStaticCall(future as any, setupMockArtifactResolver()),
-          /Function inc\(bool,uint256\) in contract Another is overloaded, but no overload expects 3 arguments/
+          /Function inc\(bool,uint256\) in contract Another expects 2 arguments but 3 were given/
         );
       });
 

--- a/packages/hardhat-plugin/test/static-calls.ts
+++ b/packages/hardhat-plugin/test/static-calls.ts
@@ -78,8 +78,7 @@ describe("static calls", () => {
     assert.equal(await result.foo.x(), Number(1));
   });
 
-  // TODO: this needs more investigation
-  it.skip("should be able to use the output of a static call function in a contract at (with function signature)", async function () {
+  it("should be able to use the output of a static call function in a contract at (with function signature)", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account1 = m.getAccount(1);
 


### PR DESCRIPTION
A few checks where relying on the previous version of ethers. The ethers code has been moved down into abi, so it is encapsulated.