### PR TITLE
Fix readEventArgument validation and decoding

### DIFF
--- a/packages/core/src/new-api/internal/new-execution/abi.ts
+++ b/packages/core/src/new-api/internal/new-execution/abi.ts
@@ -176,22 +176,25 @@ export function validateArtifactEventArgumentParams(
 
   const eventFragment = getEventFragment(iface, eventName);
 
-  if (typeof argument === "string") {
-    for (const input of eventFragment.inputs) {
-      if (input.name === argument) {
-        return;
-      }
+  const paramType = getEventArgumentParamType(
+    emitterArtifact.contractName,
+    eventName,
+    eventFragment,
+    argument
+  );
+
+  if (paramType.indexed === true) {
+    // We can't access the value of indexed arguments with dynamic size
+    if (
+      paramType.isArray() ||
+      paramType.isTuple() ||
+      paramType.type === "bytes" ||
+      paramType.type === "string"
+    ) {
+      throw new IgnitionValidationError(
+        `Indexed argument ${argument} of event ${eventName} of contract ${emitterArtifact.contractName} is not stored in the receipt, but its hash is, so you can't read it.`
+      );
     }
-
-    throw new IgnitionValidationError(
-      `Event ${eventName} of contract ${emitterArtifact.contractName} has no argument named ${argument}`
-    );
-  }
-
-  if (eventFragment.inputs.length <= argument) {
-    throw new IgnitionValidationError(
-      `Event ${eventName} of contract ${emitterArtifact.contractName} has only ${eventFragment.inputs.length} arguments, but argument ${argument} was requested`
-    );
   }
 }
 
@@ -227,7 +230,11 @@ export function getEventArgumentFromReceipt(
 
   const log = eventLogs[eventIndex];
 
-  const ethersResult = iface.decodeEventLog(eventFragment, log.data);
+  const ethersResult = iface.decodeEventLog(
+    eventFragment,
+    log.data,
+    log.topics
+  );
 
   const evmTuple = ethersResultIntoEvmTuple(ethersResult, eventFragment.inputs);
 
@@ -592,4 +599,38 @@ ${normalizedNameList}`
 ${normalizedNameList}`
     );
   }
+}
+
+/**
+ * Returns teh param type of an event argument, throwing a validation error if it's not found.
+ * @param eventFragment
+ * @param argument
+ */
+function getEventArgumentParamType(
+  contractName: string,
+  eventName: string,
+  eventFragment: EventFragment,
+  argument: string | number
+): ParamType {
+  if (typeof argument === "string") {
+    for (const input of eventFragment.inputs) {
+      if (input.name === argument) {
+        return input;
+      }
+    }
+
+    throw new IgnitionValidationError(
+      `Event ${eventName} of contract ${contractName} has no argument named ${argument}`
+    );
+  }
+
+  const paramType = eventFragment.inputs[argument];
+
+  if (paramType === undefined) {
+    throw new IgnitionValidationError(
+      `Event ${eventName} of contract ${contractName} has only ${eventFragment.inputs.length} arguments, but argument ${argument} was requested`
+    );
+  }
+
+  return paramType;
 }

--- a/packages/core/src/new-api/internal/new-execution/abi.ts
+++ b/packages/core/src/new-api/internal/new-execution/abi.ts
@@ -185,12 +185,9 @@ export function validateArtifactEventArgumentParams(
 
   if (paramType.indexed === true) {
     // We can't access the value of indexed arguments with dynamic size
-    if (
-      paramType.isArray() ||
-      paramType.isTuple() ||
-      paramType.type === "bytes" ||
-      paramType.type === "string"
-    ) {
+    // as their hash is stored in a topic, and its actual value isn't stored
+    // anywhere
+    if (hasDynamicSize(paramType)) {
       throw new IgnitionValidationError(
         `Indexed argument ${argument} of event ${eventName} of contract ${emitterArtifact.contractName} is not stored in the receipt, but its hash is, so you can't read it.`
       );
@@ -633,4 +630,16 @@ function getEventArgumentParamType(
   }
 
   return paramType;
+}
+
+/**
+ * Returns true if the given param type has a dynamic size.
+ */
+function hasDynamicSize(paramType: ParamType): boolean {
+  return (
+    paramType.isArray() ||
+    paramType.isTuple() ||
+    paramType.type === "bytes" ||
+    paramType.type === "string"
+  );
 }

--- a/packages/core/test/new-api/new-execution/abi.ts
+++ b/packages/core/test/new-api/new-execution/abi.ts
@@ -471,151 +471,6 @@ describe("abi", () => {
     });
   });
 
-  describe("validateArtifactFunctionName", () => {
-    it("Should throw if the function name is not valid", () => {
-      assert.throws(
-        () =>
-          validateArtifactFunctionName(
-            callEncodingFixtures.FunctionNameValidation,
-            "12"
-          ),
-        `Invalid function name "12"`
-      );
-
-      assert.throws(
-        () =>
-          validateArtifactFunctionName(
-            callEncodingFixtures.FunctionNameValidation,
-            "asd(123, asd"
-          ),
-        `Invalid function name "asd(123, asd"`
-      );
-    });
-
-    it("Should throw if the function name is not found", () => {
-      assert.throws(
-        () =>
-          validateArtifactFunctionName(
-            callEncodingFixtures.FunctionNameValidation,
-            "nonExistentFunction"
-          ),
-        `Function "nonExistentFunction" not found in contract FunctionNameValidation`
-      );
-
-      assert.throws(
-        () =>
-          validateArtifactFunctionName(
-            callEncodingFixtures.FunctionNameValidation,
-            "nonExistentFunction2(uint,bytes32)"
-          ),
-        `Function "nonExistentFunction2(uint,bytes32)" not found in contract FunctionNameValidation`
-      );
-    });
-
-    describe("Not overlaoded functions", () => {
-      it("Should not throw if the bare function name is used and the function exists", () => {
-        validateArtifactFunctionName(
-          callEncodingFixtures.FunctionNameValidation,
-          "noOverloads"
-        );
-
-        validateArtifactFunctionName(
-          callEncodingFixtures.FunctionNameValidation,
-          "_$_weirdName"
-        );
-
-        validateArtifactFunctionName(
-          callEncodingFixtures.FunctionNameValidation,
-          "$_weirdName2"
-        );
-      });
-
-      it("Should not throw if the function name with types is used", () => {
-        assert.throws(() => {
-          validateArtifactFunctionName(
-            callEncodingFixtures.FunctionNameValidation,
-            "noOverloads()"
-          );
-        }, `Function name "noOverloads()" used for contract FunctionNameValidation, but it's not overloaded. Use "noOverloads" instead`);
-      });
-    });
-
-    describe("Overloaded functions", () => {
-      it("Should throw if the bare function name is used", () => {
-        assert.throws(
-          () => {
-            validateArtifactFunctionName(
-              callEncodingFixtures.FunctionNameValidation,
-              "withTypeBasedOverloads"
-            );
-          },
-          `Function "withTypeBasedOverloads" is overloaded in contract FunctionNameValidation. Please use one of these names instead:
-
-* withTypeBasedOverloads(uint256)
-* withTypeBasedOverloads(int256)`
-        );
-
-        assert.throws(
-          () => {
-            validateArtifactFunctionName(
-              callEncodingFixtures.FunctionNameValidation,
-              "withParamCountOverloads"
-            );
-          },
-          `Function "withParamCountOverloads" is overloaded in contract FunctionNameValidation. Please use one of these names instead:
-
-* withParamCountOverloads()
-* withParamCountOverloads(int256)`
-        );
-      });
-
-      it("Should throw if the overload described by the function name doesn't exist", () => {
-        assert.throws(
-          () => {
-            validateArtifactFunctionName(
-              callEncodingFixtures.FunctionNameValidation,
-              "withTypeBasedOverloads(bool)"
-            );
-          },
-          `Function "withTypeBasedOverloads(bool)" is not a valid overload of "withTypeBasedOverloads" in contract FunctionNameValidation. Please use one of these names instead:
-
-* withTypeBasedOverloads(uint256)
-* withTypeBasedOverloads(int256)`
-        );
-
-        assert.throws(
-          () => {
-            validateArtifactFunctionName(
-              callEncodingFixtures.FunctionNameValidation,
-              "withParamCountOverloads(bool)"
-            );
-          },
-          `Function "withParamCountOverloads(bool)" is not a valid overload of "withParamCountOverloads" in contract FunctionNameValidation. Please use one of these names instead:
-
-* withParamCountOverloads()
-* withParamCountOverloads(int256)`
-        );
-      });
-
-      it("Should not throw if the overload described by the function name exists", () => {
-        validateArtifactFunctionName(
-          callEncodingFixtures.FunctionNameValidation,
-          "withTypeBasedOverloads(uint256)"
-        );
-
-        validateArtifactFunctionName(
-          callEncodingFixtures.FunctionNameValidation,
-          "withParamCountOverloads(int256)"
-        );
-
-        validateArtifactFunctionName(
-          callEncodingFixtures.FunctionNameValidation,
-          "complexTypeOverload((uint256,uint32,string)[])"
-        );
-      });
-    });
-  });
-
   describe("Error decoding", () => {
     function decode(
       contractName: keyof typeof staticCallResultFixtures,
@@ -783,6 +638,181 @@ describe("abi", () => {
             });
           });
         });
+      });
+    });
+  });
+
+  describe("validations", () => {
+    describe("validateArtifactFunctionName", () => {
+      it("Should throw if the function name is not valid", () => {
+        assert.throws(
+          () =>
+            validateArtifactFunctionName(
+              callEncodingFixtures.FunctionNameValidation,
+              "12"
+            ),
+          `Invalid function name "12"`
+        );
+
+        assert.throws(
+          () =>
+            validateArtifactFunctionName(
+              callEncodingFixtures.FunctionNameValidation,
+              "asd(123, asd"
+            ),
+          `Invalid function name "asd(123, asd"`
+        );
+      });
+
+      it("Should throw if the function name is not found", () => {
+        assert.throws(
+          () =>
+            validateArtifactFunctionName(
+              callEncodingFixtures.FunctionNameValidation,
+              "nonExistentFunction"
+            ),
+          `Function "nonExistentFunction" not found in contract FunctionNameValidation`
+        );
+
+        assert.throws(
+          () =>
+            validateArtifactFunctionName(
+              callEncodingFixtures.FunctionNameValidation,
+              "nonExistentFunction2(uint,bytes32)"
+            ),
+          `Function "nonExistentFunction2(uint,bytes32)" not found in contract FunctionNameValidation`
+        );
+      });
+
+      describe("Not overlaoded functions", () => {
+        it("Should not throw if the bare function name is used and the function exists", () => {
+          validateArtifactFunctionName(
+            callEncodingFixtures.FunctionNameValidation,
+            "noOverloads"
+          );
+
+          validateArtifactFunctionName(
+            callEncodingFixtures.FunctionNameValidation,
+            "_$_weirdName"
+          );
+
+          validateArtifactFunctionName(
+            callEncodingFixtures.FunctionNameValidation,
+            "$_weirdName2"
+          );
+        });
+
+        it("Should not throw if the function name with types is used", () => {
+          assert.throws(() => {
+            validateArtifactFunctionName(
+              callEncodingFixtures.FunctionNameValidation,
+              "noOverloads()"
+            );
+          }, `Function name "noOverloads()" used for contract FunctionNameValidation, but it's not overloaded. Use "noOverloads" instead`);
+        });
+      });
+
+      describe("Overloaded functions", () => {
+        it("Should throw if the bare function name is used", () => {
+          assert.throws(
+            () => {
+              validateArtifactFunctionName(
+                callEncodingFixtures.FunctionNameValidation,
+                "withTypeBasedOverloads"
+              );
+            },
+            `Function "withTypeBasedOverloads" is overloaded in contract FunctionNameValidation. Please use one of these names instead:
+
+* withTypeBasedOverloads(uint256)
+* withTypeBasedOverloads(int256)`
+          );
+
+          assert.throws(
+            () => {
+              validateArtifactFunctionName(
+                callEncodingFixtures.FunctionNameValidation,
+                "withParamCountOverloads"
+              );
+            },
+            `Function "withParamCountOverloads" is overloaded in contract FunctionNameValidation. Please use one of these names instead:
+
+* withParamCountOverloads()
+* withParamCountOverloads(int256)`
+          );
+        });
+
+        it("Should throw if the overload described by the function name doesn't exist", () => {
+          assert.throws(
+            () => {
+              validateArtifactFunctionName(
+                callEncodingFixtures.FunctionNameValidation,
+                "withTypeBasedOverloads(bool)"
+              );
+            },
+            `Function "withTypeBasedOverloads(bool)" is not a valid overload of "withTypeBasedOverloads" in contract FunctionNameValidation. Please use one of these names instead:
+
+* withTypeBasedOverloads(uint256)
+* withTypeBasedOverloads(int256)`
+          );
+
+          assert.throws(
+            () => {
+              validateArtifactFunctionName(
+                callEncodingFixtures.FunctionNameValidation,
+                "withParamCountOverloads(bool)"
+              );
+            },
+            `Function "withParamCountOverloads(bool)" is not a valid overload of "withParamCountOverloads" in contract FunctionNameValidation. Please use one of these names instead:
+
+* withParamCountOverloads()
+* withParamCountOverloads(int256)`
+          );
+        });
+
+        it("Should not throw if the overload described by the function name exists", () => {
+          validateArtifactFunctionName(
+            callEncodingFixtures.FunctionNameValidation,
+            "withTypeBasedOverloads(uint256)"
+          );
+
+          validateArtifactFunctionName(
+            callEncodingFixtures.FunctionNameValidation,
+            "withParamCountOverloads(int256)"
+          );
+
+          validateArtifactFunctionName(
+            callEncodingFixtures.FunctionNameValidation,
+            "complexTypeOverload((uint256,uint32,string)[])"
+          );
+        });
+      });
+    });
+
+    describe("validateArtifactEventArgumentParams", () => {
+      describe("Overloaded event names", () => {
+        // This tests should match those of validateArtifactFunctionName
+      });
+
+      describe("Param existance validation", () => {
+        it("Should throw if the named param doesn't exist", () => {});
+
+        it("Should throw if the positional param doesn't exist", () => {});
+
+        it("Should not throw if the named/positional param doesn't exist", () => {});
+      });
+
+      describe("Indexed params", () => {
+        it("Should throw when trying to read an indexed string", () => {});
+
+        it("Should throw when trying to read an indexed array", () => {});
+
+        it("Should throw when trying to read an indexed struct", () => {});
+
+        it("Should throw when trying to read an indexed bytes", () => {});
+
+        it("Should not throw when trying to read an indexed address", () => {});
+
+        it("Should not throw when trying to read an indexed uint", () => {});
       });
     });
   });

--- a/packages/hardhat-plugin/test/events.ts
+++ b/packages/hardhat-plugin/test/events.ts
@@ -7,7 +7,7 @@ import { useEphemeralIgnitionProject } from "./use-ignition-project";
 describe("events", () => {
   useEphemeralIgnitionProject("minimal-new-api");
 
-  it.skip("should be able to use the output of a readEvent in a contract at", async function () {
+  it("should be able to use the output of a readEvent in a contract at", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const account1 = m.getAccount(1);
 
@@ -32,7 +32,7 @@ describe("events", () => {
     assert.equal(await result.foo.x(), Number(1));
   });
 
-  it.skip("should be able to use the output of a readEvent in an artifact contract at", async function () {
+  it("should be able to use the output of a readEvent in an artifact contract at", async function () {
     const artifact = await this.hre.artifacts.readArtifact("Foo");
 
     const moduleDefinition = buildModule("FooModule", (m) => {


### PR DESCRIPTION
This PR forbids using arguments with dynamic types as their values are hashed and used as topics, not stored.

It also fixes how the arguments are decoded, by providing ethers the topics and not just the data of the log.

It also re-enables the argument-related integration tests.