### PR TITLE
refactor/encapsulate-ethers-in-validation

### DIFF
--- a/packages/core/src/new-api/internal/new-execution/abi.ts
+++ b/packages/core/src/new-api/internal/new-execution/abi.ts
@@ -143,6 +143,31 @@ export function decodeArtifactFunctionCallResult(
 }
 
 /**
+ * Validate that the given args length matches the artifact's abi's args length.
+ *
+ * @param artifact - the artifact for the contract being validated
+ * @param contractName - the name of the contract for error messages
+ * @param args - the args to validate against
+ */
+export function validateContractConstructorArgsLength(
+  artifact: Artifact,
+  contractName: string,
+  args: ArgumentType[]
+): void {
+  const argsLength = args.length;
+
+  const { ethers } = require("ethers") as typeof import("ethers");
+  const iface = new ethers.Interface(artifact.abi);
+  const expectedArgsLength = iface.deploy.inputs.length;
+
+  if (argsLength !== expectedArgsLength) {
+    throw new IgnitionValidationError(
+      `The constructor of the contract '${contractName}' expects ${expectedArgsLength} arguments but ${argsLength} were given`
+    );
+  }
+}
+
+/**
  * Validates that a function is valid for the given artifact. That means:
  *  - It's a valid function name
  *    - The function name exists in the artifact's ABI

--- a/packages/core/src/new-api/internal/validation/stageOne/validateArtifactContractDeployment.ts
+++ b/packages/core/src/new-api/internal/validation/stageOne/validateArtifactContractDeployment.ts
@@ -1,8 +1,6 @@
-import { Interface } from "ethers";
-
-import { IgnitionValidationError } from "../../../../errors";
 import { ArtifactResolver } from "../../../types/artifact";
 import { ArtifactContractDeploymentFuture } from "../../../types/module";
+import { validateContractConstructorArgsLength } from "../../new-execution/abi";
 import { validateLibraryNames } from "../../new-execution/libraries";
 
 export async function validateArtifactContractDeployment(
@@ -13,14 +11,9 @@ export async function validateArtifactContractDeployment(
 
   validateLibraryNames(artifact, Object.keys(future.libraries));
 
-  const argsLength = future.constructorArgs.length;
-
-  const iface = new Interface(artifact.abi);
-  const expectedArgsLength = iface.deploy.inputs.length;
-
-  if (argsLength !== expectedArgsLength) {
-    throw new IgnitionValidationError(
-      `The constructor of the contract '${future.contractName}' expects ${expectedArgsLength} arguments but ${argsLength} were given`
-    );
-  }
+  validateContractConstructorArgsLength(
+    artifact,
+    future.contractName,
+    future.constructorArgs
+  );
 }

--- a/packages/core/src/new-api/internal/validation/stageOne/validateNamedContractDeployment.ts
+++ b/packages/core/src/new-api/internal/validation/stageOne/validateNamedContractDeployment.ts
@@ -1,9 +1,8 @@
-import { Interface } from "ethers";
-
 import { IgnitionValidationError } from "../../../../errors";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { NamedContractDeploymentFuture } from "../../../types/module";
+import { validateContractConstructorArgsLength } from "../../new-execution/abi";
 import { validateLibraryNames } from "../../new-execution/libraries";
 
 export async function validateNamedContractDeployment(
@@ -20,14 +19,9 @@ export async function validateNamedContractDeployment(
 
   validateLibraryNames(artifact, Object.keys(future.libraries));
 
-  const argsLength = future.constructorArgs.length;
-
-  const iface = new Interface(artifact.abi);
-  const expectedArgsLength = iface.deploy.inputs.length;
-
-  if (argsLength !== expectedArgsLength) {
-    throw new IgnitionValidationError(
-      `The constructor of the contract '${future.contractName}' expects ${expectedArgsLength} arguments but ${argsLength} were given`
-    );
-  }
+  validateContractConstructorArgsLength(
+    artifact,
+    future.contractName,
+    future.constructorArgs
+  );
 }


### PR DESCRIPTION
A new abi level function is leveraged in both artifact and named contract variants to check number of args matches the artifacts abi's number of args in the constructor.

This is the last usage of Ethers at the validation level.

Resolves #414.