### PR TITLE
chore: re-enable samples

### DIFF
--- a/examples/complete/package.json
+++ b/examples/complete/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@ignored/hardhat-ignition": "^0.2.0",
-    "@nomicfoundation/hardhat-toolbox": "2.0.2",
+    "@nomicfoundation/hardhat-toolbox": "3.0.0",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"
   }

--- a/examples/complete/test/Complete.js
+++ b/examples/complete/test/Complete.js
@@ -1,8 +1,10 @@
-const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const {
+  loadFixture,
+} = require("@nomicfoundation/hardhat-toolbox/network-helpers");
 const { expect } = require("chai");
 const CompleteModule = require("../ignition/CompleteModule");
 
-describe.skip("Complete", function () {
+describe("Complete", function () {
   // We define a fixture to reuse the same setup in every test.
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
@@ -14,11 +16,7 @@ describe.skip("Complete", function () {
       withLib,
       duplicate,
       duplicateWithLib,
-    } = await ignition.deploy(CompleteModule, {
-      config: {
-        requiredConfirmations: 1,
-      },
-    });
+    } = await ignition.deploy(CompleteModule);
 
     return {
       basic,
@@ -33,7 +31,9 @@ describe.skip("Complete", function () {
   it("Should transfer funds to the BasicContract", async () => {
     const { basic } = await loadFixture(deployCompleteFixture);
 
-    expect(await ethers.provider.getBalance(basic.address)).to.equal(123n);
+    expect(await ethers.provider.getBalance(await basic.getAddress())).to.equal(
+      123n
+    );
   });
 
   it("Should add two to a given number", async () => {

--- a/examples/ens/package.json
+++ b/examples/ens/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@ignored/hardhat-ignition": "^0.2.0",
-    "@nomicfoundation/hardhat-toolbox": "2.0.2",
+    "@nomicfoundation/hardhat-toolbox": "3.0.0",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"
   },

--- a/examples/ens/test/sample-test.js
+++ b/examples/ens/test/sample-test.js
@@ -2,17 +2,15 @@ const { expect } = require("chai");
 const ENSModule = require("../ignition/test-registrar");
 const namehash = require("eth-ens-namehash");
 const labelhash = (label) =>
-  hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes(label));
+  hre.ethers.keccak256(hre.ethers.toUtf8Bytes(label));
 
-describe.skip("ENS", function () {
+describe("ENS", function () {
   it("should be able to create new subrecords", async function () {
     const [{ address: ACCOUNT_0 }, { address: ACCOUNT_1 }] =
       await hre.ethers.getSigners();
 
     // Arrange
-    const { ens, resolver } = await ignition.deploy(ENSModule, {
-      config: { requiredConfirmations: 1 },
-    });
+    const { ens, resolver } = await ignition.deploy(ENSModule);
 
     await ens.setSubnodeOwner(
       namehash.hash("test"),

--- a/examples/sample/hardhat.config.js
+++ b/examples/sample/hardhat.config.js
@@ -3,5 +3,5 @@ require("@ignored/hardhat-ignition");
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "0.8.17",
+  solidity: "0.8.19",
 };

--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@ignored/hardhat-ignition": "^0.2.0",
-    "@nomicfoundation/hardhat-toolbox": "2.0.2",
+    "@nomicfoundation/hardhat-toolbox": "3.0.0",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"
   }

--- a/examples/sample/test/Lock.js
+++ b/examples/sample/test/Lock.js
@@ -1,12 +1,12 @@
 const {
   time,
   loadFixture,
-} = require("@nomicfoundation/hardhat-network-helpers");
+} = require("@nomicfoundation/hardhat-toolbox/network-helpers");
 const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 const { expect } = require("chai");
 const LockModule = require("../ignition/LockModule");
 
-describe.skip("Lock", function () {
+describe("Lock", function () {
   // We define a fixture to reuse the same setup in every test.
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
@@ -27,7 +27,6 @@ describe.skip("Lock", function () {
           lockedAmount,
         },
       },
-      config: { requiredConfirmations: 1 },
     });
 
     return { lock, unlockTime, lockedAmount, owner, otherAccount };
@@ -51,7 +50,7 @@ describe.skip("Lock", function () {
         deployOneYearLockFixture
       );
 
-      expect(await ethers.provider.getBalance(lock.address)).to.equal(
+      expect(await ethers.provider.getBalance(lock.target)).to.equal(
         lockedAmount
       );
     });

--- a/examples/ts-sample/package.json
+++ b/examples/ts-sample/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@ignored/hardhat-ignition": "^0.2.0",
-    "@nomicfoundation/hardhat-toolbox": "2.0.2",
+    "@nomicfoundation/hardhat-toolbox": "3.0.0",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"
   }

--- a/examples/ts-sample/test/Lock.ts
+++ b/examples/ts-sample/test/Lock.ts
@@ -1,11 +1,13 @@
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
-import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import {
+  loadFixture,
+  time,
+} from "@nomicfoundation/hardhat-toolbox/network-helpers";
 import { expect } from "chai";
 import { ethers, ignition } from "hardhat";
-
 import LockModule from "../ignition/LockModule";
 
-describe.skip("Lock", function () {
+describe("Lock", function () {
   // We define a fixture to reuse the same setup in every test.
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
@@ -26,7 +28,6 @@ describe.skip("Lock", function () {
           lockedAmount,
         },
       },
-      config: { requiredConfirmations: 1 },
     });
 
     return { lock, unlockTime, lockedAmount, owner, otherAccount };
@@ -50,7 +51,7 @@ describe.skip("Lock", function () {
         deployOneYearLockFixture
       );
 
-      expect(await ethers.provider.getBalance(lock.address)).to.equal(
+      expect(await ethers.provider.getBalance(lock.target)).to.equal(
         lockedAmount
       );
     });

--- a/examples/uniswap/package.json
+++ b/examples/uniswap/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@ignored/hardhat-ignition": "^0.2.0",
-    "@nomicfoundation/hardhat-toolbox": "2.0.2",
+    "@nomicfoundation/hardhat-toolbox": "3.0.0",
     "hardhat": "^2.14.0",
     "prettier-plugin-solidity": "1.1.3"
   },

--- a/examples/uniswap/test/helpers.js
+++ b/examples/uniswap/test/helpers.js
@@ -5,7 +5,7 @@ bn.config({ EXPONENTIAL_AT: 999999, DECIMAL_PLACES: 40 });
 
 // returns the sqrt price as a 64x96
 function encodePriceSqrt(reserve1, reserve0) {
-  return BigNumber.from(
+  return BigInt(
     new bn(reserve1.toString())
       .div(reserve0.toString())
       .sqrt()

--- a/examples/uniswap/test/simplified-test.js
+++ b/examples/uniswap/test/simplified-test.js
@@ -1,0 +1,31 @@
+const { assert } = require("chai");
+const UniswapModule = require("../ignition/Uniswap");
+
+describe("uniswap deploy", () => {
+  let nonfungibleTokenPositionManager, uniswapV3Factory, swapRouter02;
+
+  beforeEach(async () => {
+    const [sign1, sign2] = await hre.ethers.getSigners();
+    owner = sign1;
+    user1 = sign2;
+
+    // Deploy Uniswap
+    ({ nonfungibleTokenPositionManager, uniswapV3Factory, swapRouter02 } =
+      await ignition.deploy(UniswapModule));
+  });
+
+  it("should deploy uniswap", async () => {
+    assert.equal(
+      await nonfungibleTokenPositionManager.getAddress(),
+      "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+    );
+    assert.equal(
+      await uniswapV3Factory.getAddress(),
+      "0xdc64a140aa3e981100a9beca4e685f962f0cf6c9"
+    );
+    assert.equal(
+      await swapRouter02.getAddress(),
+      "0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0"
+    );
+  });
+});

--- a/examples/uniswap/test/uniswap-test.js
+++ b/examples/uniswap/test/uniswap-test.js
@@ -9,6 +9,8 @@ const {
   getPoolState,
 } = require("./helpers");
 
+// TODO: We need to decide if we are bringing back the full uniswap example
+// given it depends on ethers-v5.
 describe.skip("Uniswap", function () {
   const fee = 500;
   let owner, user1, solidus, florin;
@@ -22,9 +24,7 @@ describe.skip("Uniswap", function () {
 
     // Deploy Uniswap
     ({ nonfungibleTokenPositionManager, uniswapV3Factory, swapRouter02 } =
-      await ignition.deploy(UniswapModule, {
-        config: { requiredConfirmations: 1 },
-      }));
+      await ignition.deploy(UniswapModule));
 
     // Deploy example tokens Solidus and Florin
     const Solidus = await hre.ethers.getContractFactory("Solidus");
@@ -33,18 +33,21 @@ describe.skip("Uniswap", function () {
     const Florin = await hre.ethers.getContractFactory("Florin");
     florin = await Florin.deploy();
 
+    const solidusAddress = await solidus.getAddress();
+    const florinAddress = await florin.getAddress();
+
     // Create pool for solidus/florin
     await nonfungibleTokenPositionManager.createAndInitializePoolIfNecessary(
-      solidus.address,
-      florin.address,
+      solidusAddress,
+      florinAddress,
       fee,
       encodePriceSqrt(1, 1),
       { gasLimit: 5000000 }
     );
 
     const poolAddress = await uniswapV3Factory.getPool(
-      solidus.address,
-      florin.address,
+      solidusAddress,
+      florinAddress,
       fee
     );
 
@@ -53,21 +56,24 @@ describe.skip("Uniswap", function () {
       poolAddress
     );
 
+    const nonfungibleTokenPositionManagerAddress =
+      await nonfungibleTokenPositionManager.getAddress();
+
     // Add liquidity to pool
-    await solidus.mint(owner.address, hre.ethers.utils.parseUnits("1000", 18));
+    await solidus.mint(owner.address, hre.ethers.parseUnits("1000", 18));
     await solidus
       .connect(owner)
       .approve(
-        nonfungibleTokenPositionManager.address,
-        hre.ethers.utils.parseUnits("1000", 18)
+        nonfungibleTokenPositionManagerAddress,
+        hre.ethers.parseUnits("1000", 18)
       );
 
-    await florin.mint(owner.address, hre.ethers.utils.parseUnits("1000", 18));
+    await florin.mint(owner.address, hre.ethers.parseUnits("1000", 18));
     await florin
       .connect(owner)
       .approve(
-        nonfungibleTokenPositionManager.address,
-        hre.ethers.utils.parseUnits("1000", 18)
+        nonfungibleTokenPositionManagerAddress,
+        hre.ethers.parseUnits("1000", 18)
       );
 
     const [poolImmutables, poolState] = await Promise.all([
@@ -102,7 +108,7 @@ describe.skip("Uniswap", function () {
 
     const position = new Position({
       pool: poolFromSdk,
-      liquidity: hre.ethers.utils.parseUnits("1", 18),
+      liquidity: hre.ethers.parseUnits("1", 18),
       tickLower:
         nearestUsableTick(poolState.tick, poolImmutables.tickSpacing) -
         poolImmutables.tickSpacing * 2,
@@ -116,8 +122,8 @@ describe.skip("Uniswap", function () {
 
     await nonfungibleTokenPositionManager.connect(owner).mint(
       {
-        token0: solidus.address,
-        token1: florin.address,
+        token0: solidusAddress,
+        token1: florinAddress,
         fee: fee,
         tickLower:
           nearestUsableTick(poolState.tick, poolImmutables.tickSpacing) -
@@ -142,15 +148,15 @@ describe.skip("Uniswap", function () {
 
     // add that amount to the users florin's balance
     await florin.mint(user1.address, 100);
-    await florin.connect(user1).approve(swapRouter02.address, 100);
+    await florin.connect(user1).approve(await swapRouter02.getAddress(), 100);
 
     assert.equal(await florin.balanceOf(user1.address), 100);
     assert.equal(await solidus.balanceOf(user1.address), 0);
 
     // act
     await swapRouter02.connect(user1).exactInputSingle({
-      tokenIn: florin.address,
-      tokenOut: solidus.address,
+      tokenIn: florinAddress,
+      tokenOut: solidusAddress,
       fee,
       recipient: user1.address,
       deadline: Math.floor(Date.now() / 1000) + 60 * 10,

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,201 @@
       "version": "0.2.0",
       "devDependencies": {
         "@ignored/hardhat-ignition": "^0.2.0",
-        "@nomicfoundation/hardhat-toolbox": "2.0.2",
+        "@nomicfoundation/hardhat-toolbox": "3.0.0",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
+      }
+    },
+    "examples/complete/node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "examples/complete/node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.2.tgz",
+      "integrity": "sha512-9Wu9mRtkj0U9ohgXYFbB/RQDa+PcEdyBm2suyEtsJf3PqzZEEjLUZgWnMjlFhATMk/fp3BjmnYVPrwl+gr8oEw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.4"
+      }
+    },
+    "examples/complete/node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.4.tgz",
+      "integrity": "sha512-k9qbLoY7qn6C6Y1LI0gk2kyHXil2Tauj4kGzQ8pgxYXIGw8lWn8tuuL72E11CrlKaXRUvOgF0EXrv/msPI2SbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.1.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "examples/complete/node_modules/@nomicfoundation/hardhat-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-3.0.0.tgz",
+      "integrity": "sha512-MsteDXd0UagMksqm9KvcFG6gNKYNa3GGNCy73iQ6bEasEgg2v8Qjl6XA5hjs8o5UD5A3153B6W2BIVJ8SxYUtA==",
+      "dev": true,
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
+        "@nomicfoundation/hardhat-verify": "^1.0.0",
+        "@typechain/ethers-v6": "^0.4.0",
+        "@typechain/hardhat": "^8.0.0",
+        "@types/chai": "^4.2.0",
+        "@types/mocha": ">=9.1.0",
+        "@types/node": ">=12.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.4.0",
+        "hardhat": "^2.11.0",
+        "hardhat-gas-reporter": "^1.0.8",
+        "solidity-coverage": "^0.8.1",
+        "ts-node": ">=8.0.0",
+        "typechain": "^8.2.0",
+        "typescript": ">=4.5.0"
+      }
+    },
+    "examples/complete/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "examples/complete/node_modules/@typechain/hardhat": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-8.0.3.tgz",
+      "integrity": "sha512-MytSmJJn+gs7Mqrpt/gWkTCOpOQ6ZDfRrRT2gtZL0rfGe4QrU4x9ZdW15fFbVM/XTa+5EsKiOMYXhRABibNeng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "@typechain/ethers-v6": "^0.4.3",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.9",
+        "typechain": "^8.3.1"
+      }
+    },
+    "examples/complete/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/complete/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/complete/node_modules/ethers": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "examples/complete/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "examples/complete/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/complete/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "examples/create2": {
@@ -60,9 +252,201 @@
       },
       "devDependencies": {
         "@ignored/hardhat-ignition": "^0.2.0",
-        "@nomicfoundation/hardhat-toolbox": "2.0.2",
+        "@nomicfoundation/hardhat-toolbox": "3.0.0",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
+      }
+    },
+    "examples/ens/node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "examples/ens/node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.2.tgz",
+      "integrity": "sha512-9Wu9mRtkj0U9ohgXYFbB/RQDa+PcEdyBm2suyEtsJf3PqzZEEjLUZgWnMjlFhATMk/fp3BjmnYVPrwl+gr8oEw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.4"
+      }
+    },
+    "examples/ens/node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.4.tgz",
+      "integrity": "sha512-k9qbLoY7qn6C6Y1LI0gk2kyHXil2Tauj4kGzQ8pgxYXIGw8lWn8tuuL72E11CrlKaXRUvOgF0EXrv/msPI2SbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.1.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "examples/ens/node_modules/@nomicfoundation/hardhat-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-3.0.0.tgz",
+      "integrity": "sha512-MsteDXd0UagMksqm9KvcFG6gNKYNa3GGNCy73iQ6bEasEgg2v8Qjl6XA5hjs8o5UD5A3153B6W2BIVJ8SxYUtA==",
+      "dev": true,
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
+        "@nomicfoundation/hardhat-verify": "^1.0.0",
+        "@typechain/ethers-v6": "^0.4.0",
+        "@typechain/hardhat": "^8.0.0",
+        "@types/chai": "^4.2.0",
+        "@types/mocha": ">=9.1.0",
+        "@types/node": ">=12.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.4.0",
+        "hardhat": "^2.11.0",
+        "hardhat-gas-reporter": "^1.0.8",
+        "solidity-coverage": "^0.8.1",
+        "ts-node": ">=8.0.0",
+        "typechain": "^8.2.0",
+        "typescript": ">=4.5.0"
+      }
+    },
+    "examples/ens/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "examples/ens/node_modules/@typechain/hardhat": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-8.0.3.tgz",
+      "integrity": "sha512-MytSmJJn+gs7Mqrpt/gWkTCOpOQ6ZDfRrRT2gtZL0rfGe4QrU4x9ZdW15fFbVM/XTa+5EsKiOMYXhRABibNeng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "@typechain/ethers-v6": "^0.4.3",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.9",
+        "typechain": "^8.3.1"
+      }
+    },
+    "examples/ens/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/ens/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/ens/node_modules/ethers": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "examples/ens/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "examples/ens/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/ens/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "examples/multisig": {
@@ -84,9 +468,201 @@
       "version": "0.2.0",
       "devDependencies": {
         "@ignored/hardhat-ignition": "^0.2.0",
-        "@nomicfoundation/hardhat-toolbox": "2.0.2",
+        "@nomicfoundation/hardhat-toolbox": "3.0.0",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
+      }
+    },
+    "examples/sample/node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "examples/sample/node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.2.tgz",
+      "integrity": "sha512-9Wu9mRtkj0U9ohgXYFbB/RQDa+PcEdyBm2suyEtsJf3PqzZEEjLUZgWnMjlFhATMk/fp3BjmnYVPrwl+gr8oEw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.4"
+      }
+    },
+    "examples/sample/node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.4.tgz",
+      "integrity": "sha512-k9qbLoY7qn6C6Y1LI0gk2kyHXil2Tauj4kGzQ8pgxYXIGw8lWn8tuuL72E11CrlKaXRUvOgF0EXrv/msPI2SbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.1.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "examples/sample/node_modules/@nomicfoundation/hardhat-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-3.0.0.tgz",
+      "integrity": "sha512-MsteDXd0UagMksqm9KvcFG6gNKYNa3GGNCy73iQ6bEasEgg2v8Qjl6XA5hjs8o5UD5A3153B6W2BIVJ8SxYUtA==",
+      "dev": true,
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
+        "@nomicfoundation/hardhat-verify": "^1.0.0",
+        "@typechain/ethers-v6": "^0.4.0",
+        "@typechain/hardhat": "^8.0.0",
+        "@types/chai": "^4.2.0",
+        "@types/mocha": ">=9.1.0",
+        "@types/node": ">=12.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.4.0",
+        "hardhat": "^2.11.0",
+        "hardhat-gas-reporter": "^1.0.8",
+        "solidity-coverage": "^0.8.1",
+        "ts-node": ">=8.0.0",
+        "typechain": "^8.2.0",
+        "typescript": ">=4.5.0"
+      }
+    },
+    "examples/sample/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "examples/sample/node_modules/@typechain/hardhat": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-8.0.3.tgz",
+      "integrity": "sha512-MytSmJJn+gs7Mqrpt/gWkTCOpOQ6ZDfRrRT2gtZL0rfGe4QrU4x9ZdW15fFbVM/XTa+5EsKiOMYXhRABibNeng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "@typechain/ethers-v6": "^0.4.3",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.9",
+        "typechain": "^8.3.1"
+      }
+    },
+    "examples/sample/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/sample/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/sample/node_modules/ethers": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "examples/sample/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "examples/sample/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/sample/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "examples/ts-sample": {
@@ -94,9 +670,201 @@
       "version": "0.2.0",
       "devDependencies": {
         "@ignored/hardhat-ignition": "^0.2.0",
-        "@nomicfoundation/hardhat-toolbox": "2.0.2",
+        "@nomicfoundation/hardhat-toolbox": "3.0.0",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
+      }
+    },
+    "examples/ts-sample/node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "examples/ts-sample/node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.2.tgz",
+      "integrity": "sha512-9Wu9mRtkj0U9ohgXYFbB/RQDa+PcEdyBm2suyEtsJf3PqzZEEjLUZgWnMjlFhATMk/fp3BjmnYVPrwl+gr8oEw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.4"
+      }
+    },
+    "examples/ts-sample/node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.4.tgz",
+      "integrity": "sha512-k9qbLoY7qn6C6Y1LI0gk2kyHXil2Tauj4kGzQ8pgxYXIGw8lWn8tuuL72E11CrlKaXRUvOgF0EXrv/msPI2SbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.1.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "examples/ts-sample/node_modules/@nomicfoundation/hardhat-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-3.0.0.tgz",
+      "integrity": "sha512-MsteDXd0UagMksqm9KvcFG6gNKYNa3GGNCy73iQ6bEasEgg2v8Qjl6XA5hjs8o5UD5A3153B6W2BIVJ8SxYUtA==",
+      "dev": true,
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
+        "@nomicfoundation/hardhat-verify": "^1.0.0",
+        "@typechain/ethers-v6": "^0.4.0",
+        "@typechain/hardhat": "^8.0.0",
+        "@types/chai": "^4.2.0",
+        "@types/mocha": ">=9.1.0",
+        "@types/node": ">=12.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.4.0",
+        "hardhat": "^2.11.0",
+        "hardhat-gas-reporter": "^1.0.8",
+        "solidity-coverage": "^0.8.1",
+        "ts-node": ">=8.0.0",
+        "typechain": "^8.2.0",
+        "typescript": ">=4.5.0"
+      }
+    },
+    "examples/ts-sample/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "examples/ts-sample/node_modules/@typechain/hardhat": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-8.0.3.tgz",
+      "integrity": "sha512-MytSmJJn+gs7Mqrpt/gWkTCOpOQ6ZDfRrRT2gtZL0rfGe4QrU4x9ZdW15fFbVM/XTa+5EsKiOMYXhRABibNeng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "@typechain/ethers-v6": "^0.4.3",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.9",
+        "typechain": "^8.3.1"
+      }
+    },
+    "examples/ts-sample/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/ts-sample/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/ts-sample/node_modules/ethers": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "examples/ts-sample/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "examples/ts-sample/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/ts-sample/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "examples/uniswap": {
@@ -114,15 +882,207 @@
       },
       "devDependencies": {
         "@ignored/hardhat-ignition": "^0.2.0",
-        "@nomicfoundation/hardhat-toolbox": "2.0.2",
+        "@nomicfoundation/hardhat-toolbox": "3.0.0",
         "hardhat": "^2.14.0",
         "prettier-plugin-solidity": "1.1.3"
+      }
+    },
+    "examples/uniswap/node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "examples/uniswap/node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.2.tgz",
+      "integrity": "sha512-9Wu9mRtkj0U9ohgXYFbB/RQDa+PcEdyBm2suyEtsJf3PqzZEEjLUZgWnMjlFhATMk/fp3BjmnYVPrwl+gr8oEw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.4"
+      }
+    },
+    "examples/uniswap/node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.4.tgz",
+      "integrity": "sha512-k9qbLoY7qn6C6Y1LI0gk2kyHXil2Tauj4kGzQ8pgxYXIGw8lWn8tuuL72E11CrlKaXRUvOgF0EXrv/msPI2SbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.1.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "examples/uniswap/node_modules/@nomicfoundation/hardhat-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-3.0.0.tgz",
+      "integrity": "sha512-MsteDXd0UagMksqm9KvcFG6gNKYNa3GGNCy73iQ6bEasEgg2v8Qjl6XA5hjs8o5UD5A3153B6W2BIVJ8SxYUtA==",
+      "dev": true,
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
+        "@nomicfoundation/hardhat-verify": "^1.0.0",
+        "@typechain/ethers-v6": "^0.4.0",
+        "@typechain/hardhat": "^8.0.0",
+        "@types/chai": "^4.2.0",
+        "@types/mocha": ">=9.1.0",
+        "@types/node": ">=12.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.4.0",
+        "hardhat": "^2.11.0",
+        "hardhat-gas-reporter": "^1.0.8",
+        "solidity-coverage": "^0.8.1",
+        "ts-node": ">=8.0.0",
+        "typechain": "^8.2.0",
+        "typescript": ">=4.5.0"
       }
     },
     "examples/uniswap/node_modules/@openzeppelin/contracts": {
       "version": "3.4.2-solc-0.7",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz",
       "integrity": "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="
+    },
+    "examples/uniswap/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "examples/uniswap/node_modules/@typechain/hardhat": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-8.0.3.tgz",
+      "integrity": "sha512-MytSmJJn+gs7Mqrpt/gWkTCOpOQ6ZDfRrRT2gtZL0rfGe4QrU4x9ZdW15fFbVM/XTa+5EsKiOMYXhRABibNeng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "@typechain/ethers-v6": "^0.4.3",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.9",
+        "typechain": "^8.3.1"
+      }
+    },
+    "examples/uniswap/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/uniswap/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/uniswap/node_modules/ethers": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "examples/uniswap/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "examples/uniswap/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true,
+      "peer": true
+    },
+    "examples/uniswap/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.9.2",
@@ -3074,26 +4034,6 @@
         "setimmediate": "^1.0.5"
       }
     },
-    "node_modules/@nomicfoundation/hardhat-chai-matchers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.6.tgz",
-      "integrity": "sha512-f5ZMNmabZeZegEfuxn/0kW+mm7+yV7VNDxLpMOMGXWFJ2l/Ct3QShujzDRF9cOkK9Ui/hbDeOWGZqyQALDXVCQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.1.2",
-        "@types/chai-as-promised": "^7.1.3",
-        "chai-as-promised": "^7.1.1",
-        "deep-eql": "^4.0.1",
-        "ordinal": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@nomiclabs/hardhat-ethers": "^2.0.0",
-        "chai": "^4.2.0",
-        "ethers": "^5.0.0",
-        "hardhat": "^2.9.4"
-      }
-    },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.8.tgz",
@@ -3148,31 +4088,35 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@nomicfoundation/hardhat-toolbox": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-2.0.2.tgz",
-      "integrity": "sha512-vnN1AzxbvpSx9pfdRHbUzTRIXpMLPXnUlkW855VaDk6N1pwRaQ2gNzEmFAABk4lWf11E00PKwFd/q27HuwYrYg==",
+    "node_modules/@nomicfoundation/hardhat-verify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.1.1.tgz",
+      "integrity": "sha512-9QsTYD7pcZaQFEA3tBb/D/oCStYDiEVDN7Dxeo/4SCyHRSm86APypxxdOMEPlGmXsAvd+p1j/dTODcpxb8aztA==",
       "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^8.1.0",
+        "chalk": "^2.4.2",
+        "debug": "^4.1.1",
+        "lodash.clonedeep": "^4.5.0",
+        "semver": "^6.3.0",
+        "table": "^6.8.0",
+        "undici": "^5.14.0"
+      },
       "peerDependencies": {
-        "@ethersproject/abi": "^5.4.7",
-        "@ethersproject/providers": "^5.4.7",
-        "@nomicfoundation/hardhat-chai-matchers": "^1.0.0",
-        "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
-        "@nomiclabs/hardhat-ethers": "^2.0.0",
-        "@nomiclabs/hardhat-etherscan": "^3.0.0",
-        "@typechain/ethers-v5": "^10.1.0",
-        "@typechain/hardhat": "^6.1.2",
-        "@types/chai": "^4.2.0",
-        "@types/mocha": ">=9.1.0",
-        "@types/node": ">=12.0.0",
-        "chai": "^4.2.0",
-        "ethers": "^5.4.7",
-        "hardhat": "^2.11.0",
-        "hardhat-gas-reporter": "^1.0.8",
-        "solidity-coverage": "^0.8.1",
-        "ts-node": ">=8.0.0",
-        "typechain": "^8.1.0",
-        "typescript": ">=4.5.0"
+        "hardhat": "^2.0.4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@nomicfoundation/ignition-complete-example": {
@@ -3370,84 +4314,6 @@
       "resolved": "https://registry.npmjs.org/@nomiclabs/eslint-plugin-hardhat-internal-rules/-/eslint-plugin-hardhat-internal-rules-1.0.2.tgz",
       "integrity": "sha512-x0iaAQXCiDHZw+TEk2gnV7OdBI9OGBtAT5yYab3Bzpoiic4040TcUthEsysXLZTnIouSfZRh6PZh7tJV0dmo/A==",
       "dev": true
-    },
-    "node_modules/@nomiclabs/hardhat-ethers": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz",
-      "integrity": "sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "ethers": "^5.0.0",
-        "hardhat": "^2.0.0"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.7.tgz",
-      "integrity": "sha512-tZ3TvSgpvsQ6B6OGmo1/Au6u8BrAkvs1mIC/eURA3xgIfznUZBhmpne8hv7BXUzw9xNL3fXdpOYgOQlVMTcoHQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.1.2",
-        "@ethersproject/address": "^5.0.2",
-        "cbor": "^8.1.0",
-        "chalk": "^2.4.2",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "lodash": "^4.17.11",
-        "semver": "^6.3.0",
-        "table": "^6.8.0",
-        "undici": "^5.14.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.0.4"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "peer": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/@nomiclabs/hardhat-truffle5": {
       "version": "2.0.7",
@@ -4190,58 +5056,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "devOptional": true
-    },
-    "node_modules/@typechain/ethers-v5": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-10.2.1.tgz",
-      "integrity": "sha512-n3tQmCZjRE6IU4h6lqUGiQ1j866n5MTCBJreNEHHVWXa2u9GJTaeYyU1/k+1qLutkyw+sS6VAN+AbeiTqsxd/A==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.15",
-        "ts-essentials": "^7.0.1"
-      },
-      "peerDependencies": {
-        "@ethersproject/abi": "^5.0.0",
-        "@ethersproject/providers": "^5.0.0",
-        "ethers": "^5.1.3",
-        "typechain": "^8.1.1",
-        "typescript": ">=4.3.0"
-      }
-    },
-    "node_modules/@typechain/hardhat": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-6.1.6.tgz",
-      "integrity": "sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "fs-extra": "^9.1.0"
-      },
-      "peerDependencies": {
-        "@ethersproject/abi": "^5.4.7",
-        "@ethersproject/providers": "^5.4.7",
-        "@typechain/ethers-v5": "^10.2.1",
-        "ethers": "^5.4.7",
-        "hardhat": "^2.9.9",
-        "typechain": "^8.1.1"
-      }
-    },
-    "node_modules/@typechain/hardhat/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
@@ -13391,6 +14205,13 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -19348,9 +20169,9 @@
       }
     },
     "node_modules/typechain": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.2.0.tgz",
-      "integrity": "sha512-tZqhqjxJ9xAS/Lh32jccTjMkpx7sTdUVVHAy5Bf0TIer5QFNYXotiX74oCvoVYjyxUKDK3MXHtMFzMyD3kE+jg==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.3.1.tgz",
+      "integrity": "sha512-fA7clol2IP/56yq6vkMTR+4URF1nGjV82Wx6Rf09EsqD4tkzMAvEaqYxVFCavJm/1xaRga/oD55K+4FtuXwQOQ==",
       "dev": true,
       "peer": true,
       "dependencies": {

--- a/packages/core/src/new-api/internal/new-execution/basic-execution-strategy.ts
+++ b/packages/core/src/new-api/internal/new-execution/basic-execution-strategy.ts
@@ -128,7 +128,7 @@ export class BasicExecutionStrategy implements ExecutionStrategy {
       {
         id: 1,
         type: NetworkInteractionType.ONCHAIN_INTERACTION,
-        to: undefined,
+        to: executionState.to,
         data: executionState.data,
         value: executionState.value,
       }


### PR DESCRIPTION
Upgrade the samples to toolbox 3.0.0 so that ethers v6 is used throughout the monorepo.

This lets us bring back the samples, with the exception of the full uniswap test as the test depends on the uniswap sdk which is ethers v5 based. That test remains skipped but a simpler uniswap test has been added that asserts that the deploy has completed.

Includes a minor fix to the basic execution strategy to fix the `to` of send requests.

Resolves #421.