### PR TITLE
fix: reconcile send data when undefined

### DIFF
--- a/packages/core/src/new-api/internal/reconciliation/futures/reconcileSendData.ts
+++ b/packages/core/src/new-api/internal/reconciliation/futures/reconcileSendData.ts
@@ -2,6 +2,7 @@ import { SendDataFuture } from "../../../types/module";
 import { resolveAddressLike } from "../../new-execution/future-processor/helpers/future-resolvers";
 import { SendDataExecutionState } from "../../new-execution/types/execution-state";
 import { compare } from "../helpers/compare";
+import { reconcileData } from "../helpers/reconcile-data";
 import { reconcileFrom } from "../helpers/reconcile-from";
 import { reconcileValue } from "../helpers/reconcile-value";
 import { ReconciliationContext, ReconciliationFutureResult } from "../types";
@@ -37,7 +38,7 @@ export function reconcileSendData(
     return result;
   }
 
-  result = compare(future, "Data", executionState.data, future.data);
+  result = reconcileData(future, executionState, context);
   if (result !== undefined) {
     return result;
   }

--- a/packages/core/src/new-api/internal/reconciliation/helpers/reconcile-data.ts
+++ b/packages/core/src/new-api/internal/reconciliation/helpers/reconcile-data.ts
@@ -1,0 +1,16 @@
+import { SendDataFuture } from "../../../types/module";
+import { SendDataExecutionState } from "../../new-execution/types/execution-state";
+import {
+  ReconciliationContext,
+  ReconciliationFutureResultFailure,
+} from "../types";
+
+import { compare } from "./compare";
+
+export function reconcileData(
+  future: SendDataFuture,
+  exState: SendDataExecutionState,
+  _context: ReconciliationContext
+): ReconciliationFutureResultFailure | undefined {
+  return compare(future, "Data", exState.data, future.data ?? "0x");
+}

--- a/packages/core/test/new-api/reconciliation/futures/reconcileSendData.ts
+++ b/packages/core/test/new-api/reconciliation/futures/reconcileSendData.ts
@@ -56,6 +56,24 @@ describe("Reconciliation - send data", () => {
     );
   });
 
+  it("should reconcile between undefined and 0x for data", async () => {
+    const moduleDefinition = buildModule("Module", (m) => {
+      m.send("test_send", exampleAddress, 0n, undefined);
+
+      return {};
+    });
+
+    await assertSuccessReconciliation(
+      moduleDefinition,
+      createDeploymentState({
+        ...exampleSendState,
+        id: "Module:test_send",
+        status: ExecutionStatus.STARTED,
+        data: "0x",
+      })
+    );
+  });
+
   it("should find changes to the to address unreconciliable", async () => {
     const moduleDefinition = buildModule("Module", (m) => {
       m.send("test_send", differentAddress, 0n, "example_data");


### PR DESCRIPTION
Two runs where the send data is undefined now reconcile.

Fixes #420.