### PR TITLE
fix: support optional config/parameters in deploy

### DIFF
--- a/packages/hardhat-plugin/src/ignition-helper.ts
+++ b/packages/hardhat-plugin/src/ignition-helper.ts
@@ -51,10 +51,10 @@ export class IgnitionHelper {
     >,
     {
       parameters = {},
-      config: perDeployConfig,
+      config: perDeployConfig = {},
     }: {
-      parameters: DeploymentParameters;
-      config: Partial<DeployConfig>;
+      parameters?: DeploymentParameters;
+      config?: Partial<DeployConfig>;
     } = {
       parameters: {},
       config: {},

--- a/packages/hardhat-plugin/test/calls.ts
+++ b/packages/hardhat-plugin/test/calls.ts
@@ -160,7 +160,6 @@ describe("calls", () => {
             depositValue: BigInt(this.hre.ethers.parseEther("1")),
           },
         },
-        config: {},
       });
 
       assert.isDefined(result.passingValue);

--- a/packages/hardhat-plugin/test/config.ts
+++ b/packages/hardhat-plugin/test/config.ts
@@ -56,7 +56,6 @@ describe("config", () => {
 
       await assert.isRejected(
         this.deploy(moduleDefinition, {
-          parameters: {},
           config: {
             requiredConfirmations: 0,
           },

--- a/packages/hardhat-plugin/test/execution/multiple-batch-contract-deploy.ts
+++ b/packages/hardhat-plugin/test/execution/multiple-batch-contract-deploy.ts
@@ -48,10 +48,7 @@ describe("execution - multiple batch contract deploy", function () {
       };
     });
 
-    const deployPromise = this.deploy(moduleDefinition, {
-      parameters: {},
-      config: {},
-    });
+    const deployPromise = this.deploy(moduleDefinition);
 
     await sleep(300);
     await this.hre.network.provider.send("evm_mine");

--- a/packages/hardhat-plugin/test/params.ts
+++ b/packages/hardhat-plugin/test/params.ts
@@ -42,7 +42,6 @@ describe("module parameters", () => {
           MyNumber: 20,
         },
       },
-      config: {},
     });
 
     assert.equal(await result.foo.x(), Number(21));
@@ -79,7 +78,6 @@ describe("module parameters", () => {
           MyString: "NotExample",
         },
       },
-      config: {},
     });
 
     assert.equal(await result.greeter.getGreeting(), "NotExample");
@@ -129,7 +127,6 @@ describe("params validation", () => {
           NotMyNumber: 11,
         },
       },
-      config: {},
     });
 
     await assert.isRejected(

--- a/packages/hardhat-plugin/test/use-ignition-project.ts
+++ b/packages/hardhat-plugin/test/use-ignition-project.ts
@@ -126,7 +126,6 @@ async function runDeploy(
 
   try {
     const deployPromise = ignitionHelper.deploy(ignitionModule, {
-      parameters: {},
       config,
     });
 


### PR DESCRIPTION
The ignition-helper `deploy` function takes an options object, both config and parameters are now optional (providing one no longer requires the other).