### PR TITLE
refactor: rename wipe message

### DIFF
--- a/packages/core/src/internal/execution/reducers/deployment-state-reducer.ts
+++ b/packages/core/src/internal/execution/reducers/deployment-state-reducer.ts
@@ -33,7 +33,7 @@ export function deploymentStateReducer(
     };
   }
 
-  if (action.type === JournalMessageType.WIPE_EXECUTION_STATE) {
+  if (action.type === JournalMessageType.WIPE_APPLY) {
     return wipeExecutionState(state, action);
   }
 

--- a/packages/core/src/internal/execution/types/messages.ts
+++ b/packages/core/src/internal/execution/types/messages.ts
@@ -47,7 +47,7 @@ export type JournalMessage =
  */
 export enum JournalMessageType {
   RUN_START = "RUN_START",
-  WIPE_EXECUTION_STATE = "WIPE_EXECUTION_STATE",
+  WIPE_APPLY = "WIPE_APPLY",
   DEPLOYMENT_EXECUTION_STATE_INITIALIZE = "DEPLOYMENT_EXECUTION_STATE_INITIALIZE",
   DEPLOYMENT_EXECUTION_STATE_COMPLETE = "DEPLOYMENT_EXECUTION_STATE_COMPLETE",
   CALL_EXECUTION_STATE_INITIALIZE = "CALL_EXECUTION_STATE_INITIALIZE",
@@ -228,6 +228,6 @@ export interface OnchainInteractionTimeoutMessage {
 }
 
 export interface WipeExecutionStateMessage {
-  type: JournalMessageType.WIPE_EXECUTION_STATE;
+  type: JournalMessageType.WIPE_APPLY;
   futureId: string;
 }

--- a/packages/core/src/internal/journal/utils/emitExecutionEvent.ts
+++ b/packages/core/src/internal/journal/utils/emitExecutionEvent.ts
@@ -33,9 +33,9 @@ export function emitExecutionEvent(
       });
       break;
     }
-    case JournalMessageType.WIPE_EXECUTION_STATE: {
-      executionEventListener.wipeExecutionState({
-        type: ExecutionEventType.WIPE_EXECUTION_STATE,
+    case JournalMessageType.WIPE_APPLY: {
+      executionEventListener.wipeApply({
+        type: ExecutionEventType.WIPE_APPLY,
         futureId: message.futureId,
       });
       break;

--- a/packages/core/src/internal/journal/utils/log.ts
+++ b/packages/core/src/internal/journal/utils/log.ts
@@ -12,7 +12,7 @@ export function logJournalableMessage(message: JournalMessage): void {
       console.log(`Deployment started`);
       break;
 
-    case JournalMessageType.WIPE_EXECUTION_STATE: {
+    case JournalMessageType.WIPE_APPLY: {
       console.log(
         `Removing the execution of future ${message.futureId} from the journal`
       );

--- a/packages/core/src/internal/wiper.ts
+++ b/packages/core/src/internal/wiper.ts
@@ -43,7 +43,7 @@ export class Wiper {
     }
 
     const wipeMessage: WipeExecutionStateMessage = {
-      type: JournalMessageType.WIPE_EXECUTION_STATE,
+      type: JournalMessageType.WIPE_APPLY,
       futureId,
     };
 

--- a/packages/core/src/types/execution-events.ts
+++ b/packages/core/src/types/execution-events.ts
@@ -9,7 +9,7 @@ import { IgnitionModuleResult } from "./module";
  */
 export type ExecutionEvent =
   | RunStartEvent
-  | WipeExecutionStateEvent
+  | WipeApplyEvent
   | DeploymentExecutionStateInitializeEvent
   | DeploymentExecutionStateCompleteEvent
   | CallExecutionStateInitializeEvent
@@ -40,7 +40,7 @@ export type ExecutionEvent =
  */
 export enum ExecutionEventType {
   RUN_START = "RUN_START",
-  WIPE_EXECUTION_STATE = "WIPE_EXECUTION_STATE",
+  WIPE_APPLY = "WIPE_APPLY",
   DEPLOYMENT_EXECUTION_STATE_INITIALIZE = "DEPLOYMENT_EXECUTION_STATE_INITIALIZE",
   DEPLOYMENT_EXECUTION_STATE_COMPLETE = "DEPLOYMENT_EXECUTION_STATE_COMPLETE",
   CALL_EXECUTION_STATE_INITIALIZE = "CALL_EXECUTION_STATE_INITIALIZE",
@@ -238,8 +238,8 @@ export interface ReadEventArgExecutionStateInitializeEvent {
  *
  * @beta
  */
-export interface WipeExecutionStateEvent {
-  type: ExecutionEventType.WIPE_EXECUTION_STATE;
+export interface WipeApplyEvent {
+  type: ExecutionEventType.WIPE_APPLY;
   futureId: string;
 }
 
@@ -396,7 +396,7 @@ export interface ExecutionEventError {
  */
 export interface ExecutionEventTypeMap {
   [ExecutionEventType.RUN_START]: RunStartEvent;
-  [ExecutionEventType.WIPE_EXECUTION_STATE]: WipeExecutionStateEvent;
+  [ExecutionEventType.WIPE_APPLY]: WipeApplyEvent;
   [ExecutionEventType.DEPLOYMENT_EXECUTION_STATE_INITIALIZE]: DeploymentExecutionStateInitializeEvent;
   [ExecutionEventType.DEPLOYMENT_EXECUTION_STATE_COMPLETE]: DeploymentExecutionStateCompleteEvent;
   [ExecutionEventType.CALL_EXECUTION_STATE_INITIALIZE]: CallExecutionStateInitializeEvent;

--- a/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
+++ b/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
@@ -31,7 +31,7 @@ import {
   StaticCallExecutionStateInitializeEvent,
   TransactionConfirmEvent,
   TransactionSendEvent,
-  WipeExecutionStateEvent,
+  WipeApplyEvent,
 } from "@ignored/ignition-core";
 import { render } from "ink";
 
@@ -88,7 +88,7 @@ export class UiEventHandler implements ExecutionEventListener {
     };
   }
 
-  public wipeExecutionState(event: WipeExecutionStateEvent): void {
+  public wipeApply(event: WipeApplyEvent): void {
     const batches: UiBatches = [];
 
     for (const batch of this.state.batches) {

--- a/packages/hardhat-plugin/src/ui/VerboseEventHandler.ts
+++ b/packages/hardhat-plugin/src/ui/VerboseEventHandler.ts
@@ -26,7 +26,7 @@ import {
   StaticCallExecutionStateInitializeEvent,
   TransactionConfirmEvent,
   TransactionSendEvent,
-  WipeExecutionStateEvent,
+  WipeApplyEvent,
 } from "@ignored/ignition-core";
 
 export class VerboseEventHandler implements ExecutionEventListener {
@@ -34,7 +34,7 @@ export class VerboseEventHandler implements ExecutionEventListener {
     console.log(`Deployment started for chainId: ${event.chainId}`);
   }
 
-  public wipeExecutionState(event: WipeExecutionStateEvent): void {
+  public wipeApply(event: WipeApplyEvent): void {
     console.log(`Removing the execution of future ${event.futureId}`);
   }
 


### PR DESCRIPTION
Rename the `WIPE_EXECUTION_STATE` message to `WIPE_APPLY`. This is because all other message follow a `NOUN_VERB_MESSAGE` structure, so we should follow it for wipe as well.

The problem with mentioning execution state is it suggests that we are dealing with a execution state level message. In reality `WIPE` is its own world.