### PR TITLE
refactor: move views out of execution

### DIFF
--- a/packages/core/src/internal/execution/execution-engine.ts
+++ b/packages/core/src/internal/execution/execution-engine.ts
@@ -12,6 +12,8 @@ import {
 } from "../../types/module";
 import { DeploymentLoader } from "../deployment-loader/types";
 import { getFuturesFromModule } from "../utils/get-futures-from-module";
+import { getPendingNonceAndSender } from "../views/execution-state/get-pending-nonce-and-sender";
+import { hasExecutionFailed } from "../views/has-execution-failed";
 
 import { applyNewMessage } from "./deployment-state-helpers";
 import { FutureProcessor } from "./future-processor/future-processor";
@@ -24,8 +26,6 @@ import {
 import { TransactionTrackingTimer } from "./transaction-tracking-timer";
 import { DeploymentState } from "./types/deployment-state";
 import { ExecutionStrategy } from "./types/execution-strategy";
-import { getPendingNonceAndSender } from "./views/execution-state/get-pending-nonce-and-sender";
-import { hasExecutionFailed } from "./views/has-execution-failed";
 
 /**
  * This class is used to execute a module to completion, returning the new

--- a/packages/core/src/internal/execution/future-processor/future-processor.ts
+++ b/packages/core/src/internal/execution/future-processor/future-processor.ts
@@ -3,6 +3,7 @@ import { DeploymentParameters } from "../../../types/deploy";
 import { Future } from "../../../types/module";
 import { DeploymentLoader } from "../../deployment-loader/types";
 import { assertIgnitionInvariant } from "../../utils/assertions";
+import { isExecutionStateComplete } from "../../views/is-execution-state-complete";
 import { applyNewMessage } from "../deployment-state-helpers";
 import { JsonRpcClient } from "../jsonrpc-client";
 import { NonceManager } from "../nonce-management";
@@ -18,7 +19,6 @@ import {
 } from "../types/execution-state";
 import { ExecutionStrategy } from "../types/execution-strategy";
 import { JournalMessage, JournalMessageType } from "../types/messages";
-import { isExecutionStateComplete } from "../views/is-execution-state-complete";
 
 import { monitorOnchainInteraction } from "./handlers/monitor-onchain-interaction";
 import { queryStaticCall } from "./handlers/query-static-call";

--- a/packages/core/src/internal/execution/future-processor/helpers/future-resolvers.ts
+++ b/packages/core/src/internal/execution/future-processor/helpers/future-resolvers.ts
@@ -15,12 +15,12 @@ import { DeploymentLoader } from "../../../deployment-loader/types";
 import { assertIgnitionInvariant } from "../../../utils/assertions";
 import { replaceWithinArg } from "../../../utils/replace-within-arg";
 import { resolveModuleParameter } from "../../../utils/resolve-module-parameter";
+import { findAddressForContractFuture } from "../../../views/find-address-for-contract-future-by-id";
+import { findConfirmedTransactionByFutureId } from "../../../views/find-confirmed-transaction-by-future-id";
+import { findResultForFutureById } from "../../../views/find-result-for-future-by-id";
 import { getEventArgumentFromReceipt } from "../../abi";
 import { DeploymentState } from "../../types/deployment-state";
 import { convertEvmValueToSolidityParam } from "../../utils/convert-evm-tuple-to-solidity-param";
-import { findAddressForContractFuture } from "../../views/find-address-for-contract-future-by-id";
-import { findConfirmedTransactionByFutureId } from "../../views/find-confirmed-transaction-by-future-id";
-import { findResultForFutureById } from "../../views/find-result-for-future-by-id";
 
 /**
  * Resolve a futures value to a bigint.

--- a/packages/core/src/internal/execution/nonce-management.ts
+++ b/packages/core/src/internal/execution/nonce-management.ts
@@ -1,4 +1,6 @@
 import { IgnitionError } from "../../errors";
+import { getPendingNonceAndSender } from "../views/execution-state/get-pending-nonce-and-sender";
+import { getPendingOnchainInteraction } from "../views/execution-state/get-pending-onchain-interaction";
 
 import { JsonRpcClient } from "./jsonrpc-client";
 import { DeploymentState } from "./types/deployment-state";
@@ -8,8 +10,6 @@ import {
   OnchainInteractionDroppedMessage,
   OnchainInteractionReplacedByUserMessage,
 } from "./types/messages";
-import { getPendingNonceAndSender } from "./views/execution-state/get-pending-nonce-and-sender";
-import { getPendingOnchainInteraction } from "./views/execution-state/get-pending-onchain-interaction";
 
 /**
  * This function is meant to be used to sync the local state's nonces

--- a/packages/core/src/internal/execution/reducers/helpers/network-interaction-helpers.ts
+++ b/packages/core/src/internal/execution/reducers/helpers/network-interaction-helpers.ts
@@ -1,6 +1,9 @@
 import { produce } from "immer";
 
 import { assertIgnitionInvariant } from "../../../utils/assertions";
+import { findOnchainInteractionBy } from "../../../views/execution-state/find-onchain-interaction-by";
+import { findStaticCallBy } from "../../../views/execution-state/find-static-call-by";
+import { findTransactionBy } from "../../../views/execution-state/find-transaction-by";
 import {
   CallExecutionState,
   DeploymentExecutionState,
@@ -20,9 +23,6 @@ import {
   TransactionSendMessage,
 } from "../../types/messages";
 import { NetworkInteractionType } from "../../types/network-interaction";
-import { findOnchainInteractionBy } from "../../views/execution-state/find-onchain-interaction-by";
-import { findStaticCallBy } from "../../views/execution-state/find-static-call-by";
-import { findTransactionBy } from "../../views/execution-state/find-transaction-by";
 
 /**
  * Add a new network interaction to the execution state.

--- a/packages/core/src/internal/views/execution-state/find-onchain-interaction-by.ts
+++ b/packages/core/src/internal/views/execution-state/find-onchain-interaction-by.ts
@@ -1,14 +1,14 @@
-import { assertIgnitionInvariant } from "../../../utils/assertions";
 import {
   CallExecutionState,
   DeploymentExecutionState,
   SendDataExecutionState,
   StaticCallExecutionState,
-} from "../../types/execution-state";
+} from "../../execution/types/execution-state";
 import {
   NetworkInteractionType,
   OnchainInteraction,
-} from "../../types/network-interaction";
+} from "../../execution/types/network-interaction";
+import { assertIgnitionInvariant } from "../../utils/assertions";
 
 export function findOnchainInteractionBy(
   executionState:

--- a/packages/core/src/internal/views/execution-state/find-static-call-by.ts
+++ b/packages/core/src/internal/views/execution-state/find-static-call-by.ts
@@ -1,14 +1,14 @@
-import { assertIgnitionInvariant } from "../../../utils/assertions";
 import {
   CallExecutionState,
   DeploymentExecutionState,
   SendDataExecutionState,
   StaticCallExecutionState,
-} from "../../types/execution-state";
+} from "../../execution/types/execution-state";
 import {
   NetworkInteractionType,
   StaticCall,
-} from "../../types/network-interaction";
+} from "../../execution/types/network-interaction";
+import { assertIgnitionInvariant } from "../../utils/assertions";
 
 export function findStaticCallBy(
   executionState:

--- a/packages/core/src/internal/views/execution-state/find-transaction-by.ts
+++ b/packages/core/src/internal/views/execution-state/find-transaction-by.ts
@@ -1,11 +1,11 @@
-import { assertIgnitionInvariant } from "../../../utils/assertions";
 import {
   CallExecutionState,
   DeploymentExecutionState,
   SendDataExecutionState,
   StaticCallExecutionState,
-} from "../../types/execution-state";
-import { Transaction } from "../../types/jsonrpc";
+} from "../../execution/types/execution-state";
+import { Transaction } from "../../execution/types/jsonrpc";
+import { assertIgnitionInvariant } from "../../utils/assertions";
 
 import { findOnchainInteractionBy } from "./find-onchain-interaction-by";
 

--- a/packages/core/src/internal/views/execution-state/get-pending-nonce-and-sender.ts
+++ b/packages/core/src/internal/views/execution-state/get-pending-nonce-and-sender.ts
@@ -1,4 +1,7 @@
-import { ExecutionSateType, ExecutionState } from "../../types/execution-state";
+import {
+  ExecutionSateType,
+  ExecutionState,
+} from "../../execution/types/execution-state";
 
 import { getPendingOnchainInteraction } from "./get-pending-onchain-interaction";
 

--- a/packages/core/src/internal/views/execution-state/get-pending-onchain-interaction.ts
+++ b/packages/core/src/internal/views/execution-state/get-pending-onchain-interaction.ts
@@ -1,9 +1,12 @@
-import { assertIgnitionInvariant } from "../../../utils/assertions";
-import { ExecutionSateType, ExecutionState } from "../../types/execution-state";
+import {
+  ExecutionSateType,
+  ExecutionState,
+} from "../../execution/types/execution-state";
 import {
   NetworkInteractionType,
   OnchainInteraction,
-} from "../../types/network-interaction";
+} from "../../execution/types/network-interaction";
+import { assertIgnitionInvariant } from "../../utils/assertions";
 
 /**
  * Returns the last NetworkInteraction if there's one and it's an

--- a/packages/core/src/internal/views/find-address-for-contract-future-by-id.ts
+++ b/packages/core/src/internal/views/find-address-for-contract-future-by-id.ts
@@ -1,7 +1,7 @@
-import { assertIgnitionInvariant } from "../../utils/assertions";
-import { DeploymentState } from "../types/deployment-state";
-import { ExecutionResultType } from "../types/execution-result";
-import { ExecutionSateType } from "../types/execution-state";
+import { DeploymentState } from "../execution/types/deployment-state";
+import { ExecutionResultType } from "../execution/types/execution-result";
+import { ExecutionSateType } from "../execution/types/execution-state";
+import { assertIgnitionInvariant } from "../utils/assertions";
 
 /**
  * Find the address for the future by its id. Only works for ContractAt, NamedLibrary,

--- a/packages/core/src/internal/views/find-confirmed-transaction-by-future-id.ts
+++ b/packages/core/src/internal/views/find-confirmed-transaction-by-future-id.ts
@@ -1,8 +1,8 @@
-import { assertIgnitionInvariant } from "../../utils/assertions";
-import { DeploymentState } from "../types/deployment-state";
-import { ExecutionSateType } from "../types/execution-state";
-import { Transaction, TransactionReceipt } from "../types/jsonrpc";
-import { NetworkInteractionType } from "../types/network-interaction";
+import { DeploymentState } from "../execution/types/deployment-state";
+import { ExecutionSateType } from "../execution/types/execution-state";
+import { Transaction, TransactionReceipt } from "../execution/types/jsonrpc";
+import { NetworkInteractionType } from "../execution/types/network-interaction";
+import { assertIgnitionInvariant } from "../utils/assertions";
 
 export function findConfirmedTransactionByFutureId(
   deploymentState: DeploymentState,

--- a/packages/core/src/internal/views/find-deployed-contracts.ts
+++ b/packages/core/src/internal/views/find-deployed-contracts.ts
@@ -1,12 +1,12 @@
-import { assertIgnitionInvariant } from "../../utils/assertions";
-import { DeploymentState } from "../types/deployment-state";
-import { ExecutionResultType } from "../types/execution-result";
+import { DeploymentState } from "../execution/types/deployment-state";
+import { ExecutionResultType } from "../execution/types/execution-result";
 import {
   ContractAtExecutionState,
   DeploymentExecutionState,
   ExecutionSateType,
   ExecutionStatus,
-} from "../types/execution-state";
+} from "../execution/types/execution-state";
+import { assertIgnitionInvariant } from "../utils/assertions";
 
 interface DeployedContract {
   futureId: string;

--- a/packages/core/src/internal/views/find-execution-state-by-id.ts
+++ b/packages/core/src/internal/views/find-execution-state-by-id.ts
@@ -1,7 +1,7 @@
-import { assertIgnitionInvariant } from "../../utils/assertions";
-import { MapExStateTypeToExState } from "../type-helpers";
-import { DeploymentState } from "../types/deployment-state";
-import { ExecutionSateType } from "../types/execution-state";
+import { MapExStateTypeToExState } from "../execution/type-helpers";
+import { DeploymentState } from "../execution/types/deployment-state";
+import { ExecutionSateType } from "../execution/types/execution-state";
+import { assertIgnitionInvariant } from "../utils/assertions";
 
 export function findExecutionStateById<ExStateT extends ExecutionSateType>(
   exStateType: ExStateT,

--- a/packages/core/src/internal/views/find-result-for-future-by-id.ts
+++ b/packages/core/src/internal/views/find-result-for-future-by-id.ts
@@ -1,8 +1,8 @@
-import { SolidityParameterType } from "../../../types/module";
-import { assertIgnitionInvariant } from "../../utils/assertions";
-import { DeploymentState } from "../types/deployment-state";
-import { ExecutionResultType } from "../types/execution-result";
-import { ExecutionSateType } from "../types/execution-state";
+import { SolidityParameterType } from "../../types/module";
+import { DeploymentState } from "../execution/types/deployment-state";
+import { ExecutionResultType } from "../execution/types/execution-result";
+import { ExecutionSateType } from "../execution/types/execution-state";
+import { assertIgnitionInvariant } from "../utils/assertions";
 
 export function findResultForFutureById(
   deploymentState: DeploymentState,

--- a/packages/core/src/internal/views/has-execution-failed.ts
+++ b/packages/core/src/internal/views/has-execution-failed.ts
@@ -1,6 +1,6 @@
-import { Future } from "../../../types/module";
-import { DeploymentState } from "../types/deployment-state";
-import { ExecutionStatus } from "../types/execution-state";
+import { Future } from "../../types/module";
+import { DeploymentState } from "../execution/types/deployment-state";
+import { ExecutionStatus } from "../execution/types/execution-state";
 
 /**
  * Returns true if the execution of the given future has failed.

--- a/packages/core/src/internal/views/is-execution-state-complete.ts
+++ b/packages/core/src/internal/views/is-execution-state-complete.ts
@@ -1,4 +1,7 @@
-import { ExecutionState, ExecutionStatus } from "../types/execution-state";
+import {
+  ExecutionState,
+  ExecutionStatus,
+} from "../execution/types/execution-state";
 
 /**
  * Determine if an execution state has reached completion, either

--- a/packages/core/test/execution/reducers/running-a-call.ts
+++ b/packages/core/test/execution/reducers/running-a-call.ts
@@ -18,10 +18,10 @@ import {
   TransactionSendMessage,
 } from "../../../src/internal/execution/types/messages";
 import { NetworkInteractionType } from "../../../src/internal/execution/types/network-interaction";
-import { findOnchainInteractionBy } from "../../../src/internal/execution/views/execution-state/find-onchain-interaction-by";
-import { findTransactionBy } from "../../../src/internal/execution/views/execution-state/find-transaction-by";
-import { findExecutionStateById } from "../../../src/internal/execution/views/find-execution-state-by-id";
 import { assertIgnitionInvariant } from "../../../src/internal/utils/assertions";
+import { findOnchainInteractionBy } from "../../../src/internal/views/execution-state/find-onchain-interaction-by";
+import { findTransactionBy } from "../../../src/internal/views/execution-state/find-transaction-by";
+import { findExecutionStateById } from "../../../src/internal/views/find-execution-state-by-id";
 
 import { applyMessages } from "./utils";
 

--- a/packages/core/test/execution/reducers/running-a-named-contract-deploy.ts
+++ b/packages/core/test/execution/reducers/running-a-named-contract-deploy.ts
@@ -18,10 +18,10 @@ import {
   TransactionSendMessage,
 } from "../../../src/internal/execution/types/messages";
 import { NetworkInteractionType } from "../../../src/internal/execution/types/network-interaction";
-import { findOnchainInteractionBy } from "../../../src/internal/execution/views/execution-state/find-onchain-interaction-by";
-import { findTransactionBy } from "../../../src/internal/execution/views/execution-state/find-transaction-by";
-import { findExecutionStateById } from "../../../src/internal/execution/views/find-execution-state-by-id";
 import { assertIgnitionInvariant } from "../../../src/internal/utils/assertions";
+import { findOnchainInteractionBy } from "../../../src/internal/views/execution-state/find-onchain-interaction-by";
+import { findTransactionBy } from "../../../src/internal/views/execution-state/find-transaction-by";
+import { findExecutionStateById } from "../../../src/internal/views/find-execution-state-by-id";
 import { FutureType } from "../../../src/types/module";
 
 import { applyMessages } from "./utils";

--- a/packages/core/test/execution/reducers/running-a-named-library-deploy.ts
+++ b/packages/core/test/execution/reducers/running-a-named-library-deploy.ts
@@ -17,7 +17,7 @@ import {
   TransactionSendMessage,
 } from "../../../src/internal/execution/types/messages";
 import { NetworkInteractionType } from "../../../src/internal/execution/types/network-interaction";
-import { findExecutionStateById } from "../../../src/internal/execution/views/find-execution-state-by-id";
+import { findExecutionStateById } from "../../../src/internal/views/find-execution-state-by-id";
 import { FutureType } from "../../../src/types/module";
 
 import { applyMessages } from "./utils";

--- a/packages/core/test/execution/reducers/running-a-read-event-arg.ts
+++ b/packages/core/test/execution/reducers/running-a-read-event-arg.ts
@@ -10,7 +10,7 @@ import {
   JournalMessageType,
   ReadEventArgExecutionStateInitializeMessage,
 } from "../../../src/internal/execution/types/messages";
-import { findExecutionStateById } from "../../../src/internal/execution/views/find-execution-state-by-id";
+import { findExecutionStateById } from "../../../src/internal/views/find-execution-state-by-id";
 
 import { applyMessages } from "./utils";
 

--- a/packages/core/test/execution/reducers/running-a-static-call.ts
+++ b/packages/core/test/execution/reducers/running-a-static-call.ts
@@ -16,7 +16,7 @@ import {
   StaticCallExecutionStateInitializeMessage,
 } from "../../../src/internal/execution/types/messages";
 import { NetworkInteractionType } from "../../../src/internal/execution/types/network-interaction";
-import { findExecutionStateById } from "../../../src/internal/execution/views/find-execution-state-by-id";
+import { findExecutionStateById } from "../../../src/internal/views/find-execution-state-by-id";
 
 import { applyMessages } from "./utils";
 

--- a/packages/core/test/execution/reducers/running-contract-at.ts
+++ b/packages/core/test/execution/reducers/running-contract-at.ts
@@ -10,7 +10,7 @@ import {
   ContractAtExecutionStateInitializeMessage,
   JournalMessageType,
 } from "../../../src/internal/execution/types/messages";
-import { findExecutionStateById } from "../../../src/internal/execution/views/find-execution-state-by-id";
+import { findExecutionStateById } from "../../../src/internal/views/find-execution-state-by-id";
 import { FutureType } from "../../../src/types/module";
 
 import { applyMessages } from "./utils";

--- a/packages/core/test/execution/reducers/running-send-data.ts
+++ b/packages/core/test/execution/reducers/running-send-data.ts
@@ -18,10 +18,10 @@ import {
   TransactionSendMessage,
 } from "../../../src/internal/execution/types/messages";
 import { NetworkInteractionType } from "../../../src/internal/execution/types/network-interaction";
-import { findOnchainInteractionBy } from "../../../src/internal/execution/views/execution-state/find-onchain-interaction-by";
-import { findTransactionBy } from "../../../src/internal/execution/views/execution-state/find-transaction-by";
-import { findExecutionStateById } from "../../../src/internal/execution/views/find-execution-state-by-id";
 import { assertIgnitionInvariant } from "../../../src/internal/utils/assertions";
+import { findOnchainInteractionBy } from "../../../src/internal/views/execution-state/find-onchain-interaction-by";
+import { findTransactionBy } from "../../../src/internal/views/execution-state/find-transaction-by";
+import { findExecutionStateById } from "../../../src/internal/views/find-execution-state-by-id";
 
 import { applyMessages } from "./utils";
 

--- a/packages/core/test/execution/views/find-result-for-future-by-id.ts
+++ b/packages/core/test/execution/views/find-result-for-future-by-id.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 
 import { ExecutionResultType } from "../../../src/internal/execution/types/execution-result";
 import { ExecutionSateType } from "../../../src/internal/execution/types/execution-state";
-import { findResultForFutureById } from "../../../src/internal/execution/views/find-result-for-future-by-id";
+import { findResultForFutureById } from "../../../src/internal/views/find-result-for-future-by-id";
 
 describe("find result by future by", () => {
   const futureId = "MyFuture";


### PR DESCRIPTION
Views are used for execution state and more generally than just the execution phase.