### PR TITLE
feat: add `Held` status to exState status

### DIFF
--- a/packages/core/src/internal/batcher.ts
+++ b/packages/core/src/internal/batcher.ts
@@ -74,6 +74,7 @@ export class Batcher {
         switch (executionState.status) {
           case ExecutionStatus.FAILED:
           case ExecutionStatus.TIMEOUT:
+          case ExecutionStatus.HELD:
           case ExecutionStatus.STARTED:
             return [f.id, VisitStatus.UNVISITED];
           case ExecutionStatus.SUCCESS:

--- a/packages/core/src/internal/execution/execution-engine.ts
+++ b/packages/core/src/internal/execution/execution-engine.ts
@@ -13,7 +13,7 @@ import {
 import { DeploymentLoader } from "../deployment-loader/types";
 import { getFuturesFromModule } from "../utils/get-futures-from-module";
 import { getPendingNonceAndSender } from "../views/execution-state/get-pending-nonce-and-sender";
-import { hasExecutionFailed } from "../views/has-execution-failed";
+import { hasExecutionSucceeded } from "../views/has-execution-succeeded";
 import { isBatchFinished } from "../views/is-batch-finished";
 
 import { applyNewMessage } from "./deployment-state-helpers";
@@ -108,7 +108,9 @@ export class ExecutionEngine {
         deploymentState
       );
 
-      if (executionBatch.some((f) => hasExecutionFailed(f, deploymentState))) {
+      if (
+        !executionBatch.every((f) => hasExecutionSucceeded(f, deploymentState))
+      ) {
         return deploymentState;
       }
     }

--- a/packages/core/src/internal/execution/reducers/helpers/complete-execution-state.ts
+++ b/packages/core/src/internal/execution/reducers/helpers/complete-execution-state.ts
@@ -72,5 +72,7 @@ function _mapResultTypeToStatus(
       return ExecutionStatus.FAILED;
     case ExecutionResultType.STRATEGY_ERROR:
       return ExecutionStatus.FAILED;
+    case ExecutionResultType.STRATEGY_HELD:
+      return ExecutionStatus.HELD;
   }
 }

--- a/packages/core/src/internal/execution/types/execution-result.ts
+++ b/packages/core/src/internal/execution/types/execution-result.ts
@@ -12,6 +12,7 @@ export enum ExecutionResultType {
   REVERTED_TRANSACTION = "REVERTED_TRANSACTION",
   STATIC_CALL_ERROR = "STATIC_CALL_ERROR",
   STRATEGY_ERROR = "STRATEGY_ERROR",
+  STRATEGY_HELD = "STRATEGY_HELD",
 }
 
 /**
@@ -60,6 +61,16 @@ export interface StrategyErrorExecutionResult {
 }
 
 /**
+ * The execution strategy returned a strategy-specific hold e.g.
+ * waiting for off-chain multi-sig confirmations.
+ */
+export interface StrategyHeldExecutionResult {
+  type: ExecutionResultType.STRATEGY_HELD;
+  heldId: number;
+  reason: string;
+}
+
+/**
  * A deployment was successfully executed.
  */
 export interface SuccessfulDeploymentExecutionResult {
@@ -77,7 +88,8 @@ export type DeploymentExecutionResult =
   | StrategySimulationErrorExecutionResult
   | RevertedTransactionExecutionResult
   | FailedStaticCallExecutionResult
-  | StrategyErrorExecutionResult;
+  | StrategyErrorExecutionResult
+  | StrategyHeldExecutionResult;
 
 /**
  * A call future was successfully executed.
@@ -95,7 +107,8 @@ export type CallExecutionResult =
   | StrategySimulationErrorExecutionResult
   | RevertedTransactionExecutionResult
   | FailedStaticCallExecutionResult
-  | StrategyErrorExecutionResult;
+  | StrategyErrorExecutionResult
+  | StrategyHeldExecutionResult;
 
 /**
  * A send data future was successfully executed.
@@ -113,7 +126,8 @@ export type SendDataExecutionResult =
   | StrategySimulationErrorExecutionResult
   | RevertedTransactionExecutionResult
   | FailedStaticCallExecutionResult
-  | StrategyErrorExecutionResult;
+  | StrategyErrorExecutionResult
+  | StrategyHeldExecutionResult;
 
 /**
  * A static call future was successfully executed.
@@ -129,4 +143,5 @@ export interface SuccessfulStaticCallExecutionResult {
 export type StaticCallExecutionResult =
   | SuccessfulStaticCallExecutionResult
   | FailedStaticCallExecutionResult
-  | StrategyErrorExecutionResult;
+  | StrategyErrorExecutionResult
+  | StrategyHeldExecutionResult;

--- a/packages/core/src/internal/execution/types/execution-state.ts
+++ b/packages/core/src/internal/execution/types/execution-state.ts
@@ -26,6 +26,7 @@ export enum ExecutionStatus {
   STARTED = "STARATED",
   TIMEOUT = "TIMEOUT",
   SUCCESS = "SUCCESS",
+  HELD = "HELD",
   FAILED = "FAILED",
 }
 

--- a/packages/core/src/internal/formatters.ts
+++ b/packages/core/src/internal/formatters.ts
@@ -31,19 +31,14 @@ export function formatExecutionError(
       return `Simulating the transaction failed with error: ${formatFailedEvmExecutionResult(
         result.error
       )}`;
-
     case ExecutionResultType.STRATEGY_SIMULATION_ERROR:
       return `Simulating the transaction failed with error: ${result.error}`;
-
-    case ExecutionResultType.REVERTED_TRANSACTION: {
+    case ExecutionResultType.REVERTED_TRANSACTION:
       return `Transaction ${result.txHash} reverted`;
-    }
-
     case ExecutionResultType.STATIC_CALL_ERROR:
       return `Static call failed with error: ${formatFailedEvmExecutionResult(
         result.error
       )}`;
-
     case ExecutionResultType.STRATEGY_ERROR:
       return `Execution failed with error: ${result.error}`;
   }

--- a/packages/core/src/internal/journal/utils/emitExecutionEvent.ts
+++ b/packages/core/src/internal/journal/utils/emitExecutionEvent.ts
@@ -1,9 +1,9 @@
 import {
   ExecutionEventListener,
-  ExecutionEventType,
+  ExecutionEventNetworkInteractionType,
   ExecutionEventResult,
   ExecutionEventResultType,
-  ExecutionEventNetworkInteractionType,
+  ExecutionEventType,
 } from "../../../types/execution-events";
 import { SolidityParameterType } from "../../../types/module";
 import {
@@ -217,6 +217,13 @@ function convertExecutionResultToEventResult(
         error: "Transaction reverted",
       };
     }
+    case ExecutionResultType.STRATEGY_HELD: {
+      return {
+        type: ExecutionEventResultType.HELD,
+        heldId: result.heldId,
+        reason: result.reason,
+      };
+    }
   }
 }
 
@@ -239,6 +246,13 @@ function convertStaticCallResultToExecutionEventResult(
       return {
         type: ExecutionEventResultType.ERROR,
         error: result.error,
+      };
+    }
+    case ExecutionResultType.STRATEGY_HELD: {
+      return {
+        type: ExecutionEventResultType.HELD,
+        heldId: result.heldId,
+        reason: result.reason,
       };
     }
   }

--- a/packages/core/src/internal/views/has-execution-succeeded.ts
+++ b/packages/core/src/internal/views/has-execution-succeeded.ts
@@ -3,23 +3,21 @@ import { DeploymentState } from "../execution/types/deployment-state";
 import { ExecutionStatus } from "../execution/types/execution-state";
 
 /**
- * Returns true if the execution of the given future has failed.
+ * Returns true if the execution of the given future has succeeded.
  *
  * @param future The future.
  * @param deploymentState The deployment state to check against.
- * @returns true if it failed.
+ * @returns true if it succeeded.
  */
-export function hasExecutionFailed(
+export function hasExecutionSucceeded(
   future: Future,
   deploymentState: DeploymentState
 ): boolean {
   const exState = deploymentState.executionStates[future.id];
+
   if (exState === undefined) {
     return false;
   }
 
-  return (
-    exState.status === ExecutionStatus.FAILED ||
-    exState.status === ExecutionStatus.TIMEOUT
-  );
+  return exState.status === ExecutionStatus.SUCCESS;
 }

--- a/packages/core/src/types/deploy.ts
+++ b/packages/core/src/types/deploy.ts
@@ -114,16 +114,22 @@ export interface ExecutionErrorDeploymentResult {
   type: DeploymentResultType.EXECUTION_ERROR;
 
   /**
-   * A list of all the future that have started executed but have not
+   * A list of all the futures that have started executing but have not
    * finished, neither successfully nor unsuccessfully.
    */
   started: string[];
 
   /**
-   * A list of all the future that have timed out, including details of the
+   * A list of all the futures that have timed out, including details of the
    * network interaction that timed out.
    */
   timedOut: Array<{ futureId: string; networkInteractionId: number }>;
+
+  /**
+   * A list of all the futures that are being Held as determined by the execution
+   * strategy, i.e. an off-chain process is not yet complete.
+   */
+  held: Array<{ futureId: string; heldId: number; reason: string }>;
 
   /**
    * A list of all the future that have failed, including the details of

--- a/packages/core/src/types/execution-events.ts
+++ b/packages/core/src/types/execution-events.ts
@@ -360,6 +360,7 @@ export enum ExecutionEventNetworkInteractionType {
 export enum ExecutionEventResultType {
   SUCCESS = "SUCCESS",
   ERROR = "ERROR",
+  HELD = "HELD",
 }
 
 /**
@@ -367,7 +368,10 @@ export enum ExecutionEventResultType {
  *
  * @beta
  */
-export type ExecutionEventResult = ExecutionEventSuccess | ExecutionEventError;
+export type ExecutionEventResult =
+  | ExecutionEventSuccess
+  | ExecutionEventError
+  | ExecutionEventHeld;
 
 /**
  * A successful result of a future's execution.
@@ -387,6 +391,17 @@ export interface ExecutionEventSuccess {
 export interface ExecutionEventError {
   type: ExecutionEventResultType.ERROR;
   error: string;
+}
+
+/**
+ * A hold result of a future's execution.
+ *
+ * @beta
+ */
+export interface ExecutionEventHeld {
+  type: ExecutionEventResultType.HELD;
+  heldId: number;
+  reason: string;
 }
 
 /**

--- a/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
+++ b/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
@@ -40,6 +40,7 @@ import {
   UiBatches,
   UiFuture,
   UiFutureErrored,
+  UiFutureHeld,
   UiFutureStatusType,
   UiFutureSuccess,
   UiState,
@@ -396,7 +397,7 @@ export class UiEventHandler implements ExecutionEventListener {
 
   private _getFutureStatusFromEventResult(
     result: ExecutionEventResult
-  ): UiFutureSuccess | UiFutureErrored {
+  ): UiFutureSuccess | UiFutureErrored | UiFutureHeld {
     switch (result.type) {
       case ExecutionEventResultType.SUCCESS: {
         return {
@@ -408,6 +409,13 @@ export class UiEventHandler implements ExecutionEventListener {
         return {
           type: UiFutureStatusType.ERRORED,
           message: result.error,
+        };
+      }
+      case ExecutionEventResultType.HELD: {
+        return {
+          type: UiFutureStatusType.HELD,
+          heldId: result.heldId,
+          reason: result.reason,
         };
       }
     }

--- a/packages/hardhat-plugin/src/ui/VerboseEventHandler.ts
+++ b/packages/hardhat-plugin/src/ui/VerboseEventHandler.ts
@@ -47,16 +47,24 @@ export class VerboseEventHandler implements ExecutionEventListener {
   public deploymentExecutionStateComplete(
     event: DeploymentExecutionStateCompleteEvent
   ): void {
-    if (event.result.type === ExecutionEventResultType.SUCCESS) {
-      console.log(
-        `Successfully completed the execution of deployment future ${
-          event.futureId
-        } with address ${event.result.result ?? "undefined"}`
-      );
-    } else {
-      console.log(
-        `Execution of future ${event.futureId} failed with reason: ${event.result.error}`
-      );
+    switch (event.result.type) {
+      case ExecutionEventResultType.SUCCESS: {
+        return console.log(
+          `Successfully completed the execution of deployment future ${
+            event.futureId
+          } with address ${event.result.result ?? "undefined"}`
+        );
+      }
+      case ExecutionEventResultType.ERROR: {
+        return console.log(
+          `Execution of future ${event.futureId} failed with reason: ${event.result.error}`
+        );
+      }
+      case ExecutionEventResultType.HELD: {
+        return console.log(
+          `Execution of future ${event.futureId}/${event.result.heldId} held with reason: ${event.result.reason}`
+        );
+      }
     }
   }
 
@@ -69,14 +77,22 @@ export class VerboseEventHandler implements ExecutionEventListener {
   public callExecutionStateComplete(
     event: CallExecutionStateCompleteEvent
   ): void {
-    if (event.result.type === ExecutionEventResultType.SUCCESS) {
-      console.log(
-        `Successfully completed the execution of call future ${event.futureId}`
-      );
-    } else {
-      console.log(
-        `Execution of future ${event.futureId} failed with reason: ${event.result.error}`
-      );
+    switch (event.result.type) {
+      case ExecutionEventResultType.SUCCESS: {
+        return console.log(
+          `Successfully completed the execution of call future ${event.futureId}`
+        );
+      }
+      case ExecutionEventResultType.ERROR: {
+        return console.log(
+          `Execution of call future ${event.futureId} failed with reason: ${event.result.error}`
+        );
+      }
+      case ExecutionEventResultType.HELD: {
+        return console.log(
+          `Execution of call future ${event.futureId}/${event.result.heldId} held with reason: ${event.result.reason}`
+        );
+      }
     }
   }
 
@@ -89,16 +105,24 @@ export class VerboseEventHandler implements ExecutionEventListener {
   public staticCallExecutionStateComplete(
     event: StaticCallExecutionStateCompleteEvent
   ): void {
-    if (event.result.type === ExecutionEventResultType.SUCCESS) {
-      console.log(
-        `Successfully completed the execution of static call future ${
-          event.futureId
-        } with result ${event.result.result ?? "undefined"}`
-      );
-    } else {
-      console.log(
-        `Execution of future ${event.futureId} failed with reason: ${event.result.error}`
-      );
+    switch (event.result.type) {
+      case ExecutionEventResultType.SUCCESS: {
+        return console.log(
+          `Successfully completed the execution of static call future ${
+            event.futureId
+          } with result ${event.result.result ?? "undefined"}`
+        );
+      }
+      case ExecutionEventResultType.ERROR: {
+        return console.log(
+          `Execution of static call future ${event.futureId} failed with reason: ${event.result.error}`
+        );
+      }
+      case ExecutionEventResultType.HELD: {
+        return console.log(
+          `Execution of static call future ${event.futureId}/${event.result.heldId} held with reason: ${event.result.reason}`
+        );
+      }
     }
   }
 
@@ -111,16 +135,24 @@ export class VerboseEventHandler implements ExecutionEventListener {
   public sendDataExecutionStateComplete(
     event: SendDataExecutionStateCompleteEvent
   ): void {
-    if (event.result.type === ExecutionEventResultType.SUCCESS) {
-      console.log(
-        `Successfully completed the execution of send data future ${
-          event.futureId
-        } in tx ${event.result.result ?? "undefined"}`
-      );
-    } else {
-      console.log(
-        `Execution of future ${event.futureId} failed with reason: ${event.result.error}`
-      );
+    switch (event.result.type) {
+      case ExecutionEventResultType.SUCCESS: {
+        return console.log(
+          `Successfully completed the execution of send data future ${
+            event.futureId
+          } in tx ${event.result.result ?? "undefined"}`
+        );
+      }
+      case ExecutionEventResultType.ERROR: {
+        return console.log(
+          `Execution of future ${event.futureId} failed with reason: ${event.result.error}`
+        );
+      }
+      case ExecutionEventResultType.HELD: {
+        return console.log(
+          `Execution of send future ${event.futureId}/${event.result.heldId} held with reason: ${event.result.reason}`
+        );
+      }
     }
   }
 

--- a/packages/hardhat-plugin/src/ui/components/execution/BatchExecution.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/BatchExecution.tsx
@@ -78,6 +78,9 @@ const StatusBadge = ({ future }: { future: UiFuture }) => {
     case UiFutureStatusType.ERRORED:
       badge = <Text>❌</Text>;
       break;
+    case UiFutureStatusType.HELD:
+      badge = <Text>🔶</Text>;
+      break;
   }
 
   return (
@@ -136,6 +139,12 @@ function resolveFutureColors(future: UiFuture): {
     case UiFutureStatusType.ERRORED:
       return {
         borderColor: "redBright",
+        borderStyle: "bold",
+        textColor: "white",
+      };
+    case UiFutureStatusType.HELD:
+      return {
+        borderColor: "yellow",
         borderStyle: "bold",
         textColor: "white",
       };

--- a/packages/hardhat-plugin/src/ui/types.ts
+++ b/packages/hardhat-plugin/src/ui/types.ts
@@ -5,6 +5,7 @@ export enum UiFutureStatusType {
   SUCCESS = "SUCCESS",
   PENDING = "PENDING",
   ERRORED = "ERRORED",
+  HELD = "HELD",
 }
 
 export enum UiStateDeploymentStatus {
@@ -31,11 +32,18 @@ export interface UiFutureErrored {
   message: string;
 }
 
+export interface UiFutureHeld {
+  type: UiFutureStatusType.HELD;
+  heldId: number;
+  reason: string;
+}
+
 export type UiFutureStatus =
   | UiFutureUnstarted
   | UiFutureSuccess
   | UiFuturePending
-  | UiFutureErrored;
+  | UiFutureErrored
+  | UiFutureHeld;
 
 export interface UiFuture {
   status: UiFutureStatus;

--- a/packages/hardhat-plugin/test/utils/error-deployment-result-to-exception-message.ts
+++ b/packages/hardhat-plugin/test/utils/error-deployment-result-to-exception-message.ts
@@ -66,6 +66,7 @@ describe("display error deployment result", () => {
           { futureId: "MyModule:MyContract", networkInteractionId: 1 },
           { futureId: "MyModule:AnotherContract", networkInteractionId: 3 },
         ],
+        held: [],
         failed: [],
         successful: [],
       };
@@ -81,11 +82,44 @@ Timed out:
       );
     });
 
+    it("should display an execution error with holds", () => {
+      const result: ExecutionErrorDeploymentResult = {
+        type: DeploymentResultType.EXECUTION_ERROR,
+        started: [],
+        timedOut: [],
+        held: [
+          {
+            futureId: "MyModule:MyContract",
+            heldId: 1,
+            reason: "Vote is not complete",
+          },
+          {
+            futureId: "MyModule:AnotherContract",
+            heldId: 3,
+            reason: "Server timed out",
+          },
+        ],
+        failed: [],
+        successful: [],
+      };
+
+      assert.equal(
+        errorDeploymentResultToExceptionMessage(result),
+        `The deployment wasn't successful, there were holds:
+
+Held:
+
+  * MyModule:MyContract/1: Vote is not complete
+  * MyModule:AnotherContract/3: Server timed out`
+      );
+    });
+
     it("should display an execution error with execution failures", () => {
       const result: ExecutionErrorDeploymentResult = {
         type: DeploymentResultType.EXECUTION_ERROR,
         started: [],
         timedOut: [],
+        held: [],
         failed: [
           {
             futureId: "MyModule:MyContract",
@@ -120,6 +154,7 @@ Failures:
           { futureId: "MyModule:FirstContract", networkInteractionId: 1 },
           { futureId: "MyModule:SecondContract", networkInteractionId: 3 },
         ],
+        held: [],
         failed: [
           {
             futureId: "MyModule:ThirdContract",


### PR DESCRIPTION
To support execution strategies returning `hold` status in the future,
we are adding it into the execution status of exStates.

Resolves https://github.com/NomicFoundation/ignition/issues/451

## TODO

- [x] Add the status
- [x] Update the return result
- [x] Do we need a strategy message now that can return an on hold result?
- [x] Do we need rerun rules? Or can they be deferred until we release execution strategies. 