### PR TITLE
restrict ReadEventArgumentFuture types for futureToReadFrom

### DIFF
--- a/packages/core/src/internal/module.ts
+++ b/packages/core/src/internal/module.ts
@@ -205,7 +205,10 @@ export class ReadEventArgumentFutureImplementation
   constructor(
     public readonly id: string,
     public readonly module: IgnitionModuleImplementation,
-    public readonly futureToReadFrom: Future,
+    public readonly futureToReadFrom:
+      | NamedContractDeploymentFuture<string>
+      | ArtifactContractDeploymentFuture
+      | NamedContractCallFuture<string, string>,
     public readonly eventName: string,
     public readonly argumentName: string,
     public readonly emitter: ContractFuture<string>,

--- a/packages/core/src/stored-deployment-serializer.ts
+++ b/packages/core/src/stored-deployment-serializer.ts
@@ -29,6 +29,7 @@ import {
   AccountRuntimeValue,
   AddressResolvableFuture,
   ArgumentType,
+  ArtifactContractDeploymentFuture,
   ContractFuture,
   Future,
   FutureType,
@@ -36,6 +37,8 @@ import {
   IgnitionModuleResult,
   ModuleParameterRuntimeValue,
   ModuleParameterType,
+  NamedContractCallFuture,
+  NamedContractDeploymentFuture,
   RuntimeValueType,
 } from "./types/module";
 import {
@@ -787,7 +790,10 @@ export class StoredDeploymentDeserializer {
           this._lookup(
             futuresLookup,
             serializedFuture.futureToReadFrom.futureId
-          ),
+          ) as
+            | NamedContractDeploymentFuture<string>
+            | ArtifactContractDeploymentFuture
+            | NamedContractCallFuture<string, string>,
           serializedFuture.eventName,
           serializedFuture.argumentName,
           this._lookup(

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -262,7 +262,10 @@ export interface ReadEventArgumentFuture {
   id: string;
   module: IgnitionModule;
   dependencies: Set<Future>;
-  futureToReadFrom: Future;
+  futureToReadFrom:
+    | NamedContractDeploymentFuture<string>
+    | ArtifactContractDeploymentFuture
+    | NamedContractCallFuture<string, string>;
   eventName: string;
   argumentName: string;
   emitter: ContractFuture<string>;


### PR DESCRIPTION
Note, the linked issue says we currently accept `SendData` futures as `futureToReadFrom`, but we do not. Extra consideration would be needed to add it as an accepted type, so I've added a new issue to capture that discussion in #459

fixes #395 