### PR TITLE
Module builder refactor: overload `contract`, `contractAt`, and `library`.

### DIFF
--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -92,13 +92,13 @@ const b = m.contract("B", [], {
 
 ### Deploying from an artifact
 
-To allow you to use your own mechanism for getting the contract artifact, `contractFromArtifact` supports passing an `Artifact` as the second parameter:
+To allow you to use your own mechanism for getting the contract artifact, `contract` supports passing an `Artifact` as the second parameter:
 
 ```javascript
 const artifact = hre.artifacts.readArtifactSync("Foo");
 
 const userModule = buildModule("MyModule", (m) => {
-  m.contractFromArtifact("Foo", artifact, [0]);
+  m.contract("Foo", artifact, [0]);
 });
 ```
 
@@ -107,7 +107,7 @@ const userModule = buildModule("MyModule", (m) => {
 A user might need to execute a method in a contract that wasn't deployed by Ignition. An existing contract can be leveraged by passing an address and artifact:
 
 ```tsx
-const uniswap = m.contractAtFromArtifact("UniswapRouter", "0x0...", artifact);
+const uniswap = m.contractAt("UniswapRouter", "0x0...", artifact);
 
 m.call(uniswap, "swap", [
   /*...*/

--- a/examples/complete/ignition/CompleteModule.js
+++ b/examples/complete/ignition/CompleteModule.js
@@ -7,17 +7,12 @@ const libArtifact = require("../libArtifacts/BasicLibrary.json");
 module.exports = buildModule("CompleteModule", (m) => {
   const basic = m.contract("BasicContract");
   const library = m.library("BasicLibrary");
-  const libFromArtifact = m.libraryFromArtifact("BasicLibrary", libArtifact, {
+  const libFromArtifact = m.library("BasicLibrary", libArtifact, {
     id: "BasicLibrary2",
   });
-  const withLib = m.contractFromArtifact(
-    "ContractWithLibrary",
-    withLibArtifact,
-    [],
-    {
-      libraries: { BasicLibrary: library },
-    }
-  );
+  const withLib = m.contract("ContractWithLibrary", withLibArtifact, [], {
+    libraries: { BasicLibrary: library },
+  });
 
   const call = m.call(basic, "basicFunction", [40]);
   const eventArg = m.readEventArgument(call, "BasicEvent", "eventArg");
@@ -26,7 +21,7 @@ module.exports = buildModule("CompleteModule", (m) => {
   const duplicate = m.contractAt("BasicContract", basic, {
     id: "BasicContract2",
   });
-  const duplicateWithLib = m.contractAtFromArtifact(
+  const duplicateWithLib = m.contractAt(
     "ContractWithLibrary",
     withLib,
     withLibArtifact,

--- a/examples/uniswap/ignition/Uniswap.js
+++ b/examples/uniswap/ignition/Uniswap.js
@@ -49,10 +49,7 @@ module.exports = buildModule("Uniswap", (m) => {
   const weth9 = m.contract("WETH9");
 
   // DEPLOY_V3_CORE_FACTORY
-  const uniswapV3Factory = m.contractFromArtifact(
-    "UniswapV3Factory",
-    UniswapV3Factory
-  );
+  const uniswapV3Factory = m.contract("UniswapV3Factory", UniswapV3Factory);
 
   // 1 - add-1bp-fee-tier
   m.call(uniswapV3Factory, "enableFeeAmount", [
@@ -61,22 +58,19 @@ module.exports = buildModule("Uniswap", (m) => {
   ]);
 
   // 2 - deploy-multicall2
-  const multicall2Address = m.contractFromArtifact(
-    "Multicall2",
-    UniswapInterfaceMulticall
-  );
+  const multicall2Address = m.contract("Multicall2", UniswapInterfaceMulticall);
 
   // DEPLOY_PROXY_ADMIN
-  const proxyAdmin = m.contractFromArtifact("ProxyAdmin", ProxyAdmin);
+  const proxyAdmin = m.contract("ProxyAdmin", ProxyAdmin);
 
   // DEPLOY_TICK_LENS
-  const tickLens = m.contractFromArtifact("TickLens", TickLens);
+  const tickLens = m.contract("TickLens", TickLens);
 
   // DEPLOY_NFT_DESCRIPTOR_LIBRARY_V1_3_0
-  const nftDescriptor = m.contractFromArtifact("NFTDescriptor", NFTDescriptor);
+  const nftDescriptor = m.contract("NFTDescriptor", NFTDescriptor);
 
   // DEPLOY_NFT_POSITION_DESCRIPTOR_V1_3_0
-  const nonfungibleTokenPositionDescriptor = m.contractFromArtifact(
+  const nonfungibleTokenPositionDescriptor = m.contract(
     "nonfungibleTokenPositionDescriptorAddressV1_3_0",
     NonfungibleTokenPositionDescriptor,
     [weth9, asciiStringToBytes32(NATIVE_CURRENCY_LABEL)],
@@ -88,21 +82,21 @@ module.exports = buildModule("Uniswap", (m) => {
   );
 
   // DEPLOY_TRANSPARENT_PROXY_DESCRIPTOR
-  const descriptorProxy = m.contractFromArtifact(
+  const descriptorProxy = m.contract(
     "TransparentUpgradeableProxy",
     TransparentUpgradeableProxy,
     [nonfungibleTokenPositionDescriptor, proxyAdmin, "0x"]
   );
 
   // DEPLOY_NONFUNGIBLE_POSITION_MANAGER
-  const nonfungibleTokenPositionManager = m.contractFromArtifact(
+  const nonfungibleTokenPositionManager = m.contract(
     "NonfungibleTokenPositionManager",
     NonfungiblePositionManager,
     [uniswapV3Factory, weth9, descriptorProxy]
   );
 
   // DEPLOY_V3_MIGRATOR
-  const v3Migrator = m.contractFromArtifact("V3Migrator", V3Migrator, [
+  const v3Migrator = m.contract("V3Migrator", V3Migrator, [
     uniswapV3Factory,
     weth9,
     nonfungibleTokenPositionManager,
@@ -114,7 +108,7 @@ module.exports = buildModule("Uniswap", (m) => {
   });
 
   // DEPLOY_V3_STAKER
-  const v3Staker = m.contractFromArtifact("UniswapV3Staker", UniswapV3Staker, [
+  const v3Staker = m.contract("UniswapV3Staker", UniswapV3Staker, [
     uniswapV3Factory,
     nonfungibleTokenPositionManager,
     MAX_INCENTIVE_START_LEAD_TIME,
@@ -122,13 +116,10 @@ module.exports = buildModule("Uniswap", (m) => {
   ]);
 
   // DEPLOY_QUOTER_V2
-  const quoterV2 = m.contractFromArtifact("QuoterV2", QuoterV2, [
-    uniswapV3Factory,
-    weth9,
-  ]);
+  const quoterV2 = m.contract("QuoterV2", QuoterV2, [uniswapV3Factory, weth9]);
 
   // DEPLOY_V3_SWAP_ROUTER_02
-  const swapRouter02 = m.contractFromArtifact("SwapRouter02", SwapRouter02, [
+  const swapRouter02 = m.contract("SwapRouter02", SwapRouter02, [
     v2CoreFactoryAddress,
     uniswapV3Factory,
     nonfungibleTokenPositionManager,

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -290,8 +290,8 @@ class IgnitionModuleBuilderImplementation<
     options.value ??= BigInt(0);
 
     /* validation start */
-    this._assertValidId(options.id, this.contractFromArtifact);
-    this._assertValidContractName(contractName, this.contractFromArtifact);
+    this._assertValidId(options.id, this.contract);
+    this._assertValidContractName(contractName, this.contract);
     this._assertUniqueArtifactContractId(futureId);
     this._assertValidLibraries(options.libraries, this.contract);
     this._assertValidValue(options.value, this.contract);
@@ -404,8 +404,8 @@ class IgnitionModuleBuilderImplementation<
     options.libraries ??= {};
 
     /* validation start */
-    this._assertValidId(options.id, this.libraryFromArtifact);
-    this._assertValidContractName(libraryName, this.libraryFromArtifact);
+    this._assertValidId(options.id, this.library);
+    this._assertValidContractName(libraryName, this.library);
     this._assertUniqueArtifactLibraryId(futureId);
     this._assertValidLibraries(options.libraries, this.library);
     this._assertValidFrom(options.from, this.library);
@@ -630,7 +630,7 @@ class IgnitionModuleBuilderImplementation<
     );
 
     /* validation start */
-    this._assertValidId(options.id, this.contractAtFromArtifact);
+    this._assertValidId(options.id, this.contractAt);
     this._assertValidContractName(contractName, this.contractAt);
     this._assertUniqueContractAtFromArtifactId(futureId);
     this._assertValidAddress(address, this.contractAt);

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -38,10 +38,8 @@ import {
 import {
   CallOptions,
   ContractAtOptions,
-  ContractFromArtifactOptions,
   ContractOptions,
   IgnitionModuleBuilder,
-  LibraryFromArtifactOptions,
   LibraryOptions,
   ReadEventArgumentOptions,
   SendDataOptions,
@@ -180,6 +178,40 @@ class IgnitionModuleBuilderImplementation<
 
   public contract<ContractNameT extends string>(
     contractName: ContractNameT,
+    args?: ArgumentType[],
+    options?: ContractOptions
+  ): NamedContractDeploymentFuture<ContractNameT>;
+  public contract(
+    contractName: string,
+    artifact: Artifact,
+    args?: ArgumentType[],
+    options?: ContractOptions
+  ): ArtifactContractDeploymentFuture;
+  public contract<ContractNameT extends string>(
+    contractName: ContractNameT,
+    artifactOrArgs?: Artifact | ArgumentType[],
+    argsorOptions?: ArgumentType[] | ContractAtOptions,
+    maybeOptions?: ContractOptions
+  ):
+    | NamedContractDeploymentFuture<ContractNameT>
+    | ArtifactContractDeploymentFuture {
+    if (isArtifactType(artifactOrArgs)) {
+      return this._contractFromArtifact(
+        contractName,
+        artifactOrArgs,
+        argsorOptions as ArgumentType[], // TODO: Validate instead of cast
+        maybeOptions
+      );
+    }
+
+    const args = artifactOrArgs;
+    const options = argsorOptions as ContractOptions; // TODO: Validate instead of cast
+
+    return this._namedArtifactContract(contractName, args, options);
+  }
+
+  private _namedArtifactContract<ContractNameT extends string>(
+    contractName: ContractNameT,
     args: ArgumentType[] = [],
     options: ContractOptions = {}
   ): NamedContractDeploymentFuture<ContractNameT> {
@@ -228,11 +260,11 @@ class IgnitionModuleBuilderImplementation<
     return future;
   }
 
-  public contractFromArtifact(
+  private _contractFromArtifact(
     contractName: string,
     artifact: Artifact,
     args: ArgumentType[] = [],
-    options: ContractFromArtifactOptions = {}
+    options: ContractOptions = {}
   ): ArtifactContractDeploymentFuture {
     const futureId = toDeploymentFutureId(
       this._module.id,
@@ -246,10 +278,10 @@ class IgnitionModuleBuilderImplementation<
     this._assertValidId(options.id, this.contractFromArtifact);
     this._assertValidContractName(contractName, this.contractFromArtifact);
     this._assertUniqueArtifactContractId(futureId);
-    this._assertValidLibraries(options.libraries, this.contractFromArtifact);
-    this._assertValidValue(options.value, this.contractFromArtifact);
-    this._assertValidFrom(options.from, this.contractFromArtifact);
-    this._assertValidArtifact(artifact, this.contractFromArtifact);
+    this._assertValidLibraries(options.libraries, this.contract);
+    this._assertValidValue(options.value, this.contract);
+    this._assertValidFrom(options.from, this.contract);
+    this._assertValidArtifact(artifact, this.contract);
     /* validation end */
 
     const future = new ArtifactContractDeploymentFutureImplementation(
@@ -283,6 +315,27 @@ class IgnitionModuleBuilderImplementation<
   }
 
   public library<LibraryNameT extends string>(
+    libraryName: LibraryNameT,
+    options?: LibraryOptions
+  ): NamedLibraryDeploymentFuture<LibraryNameT>;
+  public library(
+    libraryName: string,
+    artifact: Artifact,
+    options?: LibraryOptions
+  ): ArtifactLibraryDeploymentFuture;
+  public library<LibraryNameT extends string>(
+    libraryName: LibraryNameT,
+    artifactOrOptions?: Artifact | LibraryOptions,
+    options?: LibraryOptions
+  ) {
+    if (isArtifactType(artifactOrOptions)) {
+      return this._libraryFromArtifact(libraryName, artifactOrOptions, options);
+    }
+
+    return this._namedArtifactLibrary(libraryName, artifactOrOptions);
+  }
+
+  private _namedArtifactLibrary<LibraryNameT extends string>(
     libraryName: LibraryNameT,
     options: LibraryOptions = {}
   ): NamedLibraryDeploymentFuture<LibraryNameT> {
@@ -323,10 +376,10 @@ class IgnitionModuleBuilderImplementation<
     return future;
   }
 
-  public libraryFromArtifact(
+  private _libraryFromArtifact(
     libraryName: string,
     artifact: Artifact,
-    options: LibraryFromArtifactOptions = {}
+    options: LibraryOptions = {}
   ): ArtifactLibraryDeploymentFuture {
     const futureId = toDeploymentFutureId(
       this._module.id,
@@ -339,9 +392,9 @@ class IgnitionModuleBuilderImplementation<
     this._assertValidId(options.id, this.libraryFromArtifact);
     this._assertValidContractName(libraryName, this.libraryFromArtifact);
     this._assertUniqueArtifactLibraryId(futureId);
-    this._assertValidLibraries(options.libraries, this.libraryFromArtifact);
-    this._assertValidFrom(options.from, this.libraryFromArtifact);
-    this._assertValidArtifact(artifact, this.libraryFromArtifact);
+    this._assertValidLibraries(options.libraries, this.library);
+    this._assertValidFrom(options.from, this.library);
+    this._assertValidArtifact(artifact, this.library);
     /* validation end */
 
     const future = new ArtifactLibraryDeploymentFutureImplementation(
@@ -469,6 +522,48 @@ class IgnitionModuleBuilderImplementation<
       | string
       | AddressResolvableFuture
       | ModuleParameterRuntimeValue<string>,
+    options?: ContractAtOptions
+  ): NamedContractAtFuture<ContractNameT>;
+  public contractAt(
+    contractName: string,
+    address:
+      | string
+      | AddressResolvableFuture
+      | ModuleParameterRuntimeValue<string>,
+    artifact: Artifact,
+    options?: ContractAtOptions
+  ): ArtifactContractAtFuture;
+  public contractAt<ContractNameT extends string>(
+    contractName: ContractNameT,
+    address:
+      | string
+      | AddressResolvableFuture
+      | ModuleParameterRuntimeValue<string>,
+    artifactOrOptions?: Artifact | ContractAtOptions,
+    options?: ContractAtOptions
+  ) {
+    if (isArtifactType(artifactOrOptions)) {
+      return this._contractAtFromArtifact(
+        contractName,
+        address,
+        artifactOrOptions,
+        options
+      );
+    }
+
+    return this._namedArtifactContractAt(
+      contractName,
+      address,
+      artifactOrOptions
+    );
+  }
+
+  private _namedArtifactContractAt<ContractNameT extends string>(
+    contractName: ContractNameT,
+    address:
+      | string
+      | AddressResolvableFuture
+      | ModuleParameterRuntimeValue<string>,
     options: ContractAtOptions = {}
   ): NamedContractAtFuture<ContractNameT> {
     const futureId = toDeploymentFutureId(
@@ -504,7 +599,7 @@ class IgnitionModuleBuilderImplementation<
     return future;
   }
 
-  public contractAtFromArtifact(
+  private _contractAtFromArtifact(
     contractName: string,
     address:
       | string
@@ -523,8 +618,8 @@ class IgnitionModuleBuilderImplementation<
     this._assertValidId(options.id, this.contractAtFromArtifact);
     this._assertValidContractName(contractName, this.contractAt);
     this._assertUniqueContractAtFromArtifactId(futureId);
-    this._assertValidAddress(address, this.contractAtFromArtifact);
-    this._assertValidArtifact(artifact, this.contractAtFromArtifact);
+    this._assertValidAddress(address, this.contractAt);
+    this._assertValidArtifact(artifact, this.contractAt);
     /* validation end */
 
     const future = new ArtifactContractAtFutureImplementation(
@@ -773,7 +868,7 @@ class IgnitionModuleBuilderImplementation<
     return this._assertUniqueFutureId(
       futureId,
       `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contractFromArtifact("MyContract", artifact, [], { id: "MyId"})\``,
-      this.contractFromArtifact
+      this.contract
     );
   }
 
@@ -789,7 +884,7 @@ class IgnitionModuleBuilderImplementation<
     return this._assertUniqueFutureId(
       futureId,
       `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.libraryFromArtifact("MyLibrary", artifact, { id: "MyId"})\``,
-      this.libraryFromArtifact
+      this.library
     );
   }
 
@@ -821,7 +916,7 @@ class IgnitionModuleBuilderImplementation<
     return this._assertUniqueFutureId(
       futureId,
       `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contractAtFromArtifact("MyContract", "0x123...", { id: "MyId"})\``,
-      this.contractAtFromArtifact
+      this.contractAt
     );
   }
 

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -867,7 +867,7 @@ class IgnitionModuleBuilderImplementation<
   private _assertUniqueArtifactContractId(futureId: string) {
     return this._assertUniqueFutureId(
       futureId,
-      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contractFromArtifact("MyContract", artifact, [], { id: "MyId"})\``,
+      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contract("MyContract", artifact, [], { id: "MyId"})\``,
       this.contract
     );
   }
@@ -883,7 +883,7 @@ class IgnitionModuleBuilderImplementation<
   private _assertUniqueArtifactLibraryId(futureId: string) {
     return this._assertUniqueFutureId(
       futureId,
-      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.libraryFromArtifact("MyLibrary", artifact, { id: "MyId"})\``,
+      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.library("MyLibrary", artifact, { id: "MyId"})\``,
       this.library
     );
   }
@@ -915,7 +915,7 @@ class IgnitionModuleBuilderImplementation<
   private _assertUniqueContractAtFromArtifactId(futureId: string) {
     return this._assertUniqueFutureId(
       futureId,
-      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contractAtFromArtifact("MyContract", "0x123...", { id: "MyId"})\``,
+      `Duplicated id ${futureId} found in module ${this._module.id}, ensure the id passed is unique \`m.contractAt("MyContract", "0x123...", { id: "MyId"})\``,
       this.contractAt
     );
   }

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -195,19 +195,34 @@ class IgnitionModuleBuilderImplementation<
   ):
     | NamedContractDeploymentFuture<ContractNameT>
     | ArtifactContractDeploymentFuture {
-    if (isArtifactType(artifactOrArgs)) {
-      return this._contractFromArtifact(
+    if (artifactOrArgs === undefined || Array.isArray(artifactOrArgs)) {
+      if (Array.isArray(argsorOptions)) {
+        this._throwErrorWithStackTrace(
+          `Invalid parameter "options" provided to contract "${contractName}" in module "${this._module.id}"`,
+          this.contract
+        );
+      }
+
+      return this._namedArtifactContract(
         contractName,
         artifactOrArgs,
-        argsorOptions as ArgumentType[], // TODO: Validate instead of cast
-        maybeOptions
+        argsorOptions
       );
     }
 
-    const args = artifactOrArgs;
-    const options = argsorOptions as ContractOptions; // TODO: Validate instead of cast
+    if (argsorOptions !== undefined && !Array.isArray(argsorOptions)) {
+      this._throwErrorWithStackTrace(
+        `Invalid parameter "args" provided to contract "${contractName}" in module "${this._module.id}"`,
+        this.contract
+      );
+    }
 
-    return this._namedArtifactContract(contractName, args, options);
+    return this._contractFromArtifact(
+      contractName,
+      artifactOrArgs,
+      argsorOptions,
+      maybeOptions
+    );
   }
 
   private _namedArtifactContract<ContractNameT extends string>(

--- a/packages/core/src/types/module-builder.ts
+++ b/packages/core/src/types/module-builder.ts
@@ -23,24 +23,11 @@ import {
 } from "./module";
 
 /**
- * The options for a `ContractOptions` call.
+ * The options for a `contract` call.
  *
  * @beta
  */
 export interface ContractOptions {
-  id?: string;
-  after?: Future[];
-  libraries?: Record<string, ContractFuture<string>>;
-  value?: bigint | ModuleParameterRuntimeValue<bigint>;
-  from?: string | AccountRuntimeValue;
-}
-
-/**
- * The options for a `contractFromArtifact` call.
- *
- * @beta
- */
-export interface ContractFromArtifactOptions {
   id?: string;
   after?: Future[];
   libraries?: Record<string, ContractFuture<string>>;
@@ -54,18 +41,6 @@ export interface ContractFromArtifactOptions {
  * @beta
  */
 export interface LibraryOptions {
-  id?: string;
-  after?: Future[];
-  libraries?: Record<string, ContractFuture<string>>;
-  from?: string | AccountRuntimeValue;
-}
-
-/**
- * The options for a `libraryFromArtifact` call.
- *
- * @beta
- */
-export interface LibraryFromArtifactOptions {
   id?: string;
   after?: Future[];
   libraries?: Record<string, ContractFuture<string>>;
@@ -158,11 +133,11 @@ export interface IgnitionModuleBuilder {
     options?: ContractOptions
   ): NamedContractDeploymentFuture<ContractNameT>;
 
-  contractFromArtifact(
+  contract(
     contractName: string,
     artifact: Artifact,
     args?: ArgumentType[],
-    options?: ContractFromArtifactOptions
+    options?: ContractOptions
   ): ArtifactContractDeploymentFuture;
 
   library<LibraryNameT extends string>(
@@ -170,10 +145,10 @@ export interface IgnitionModuleBuilder {
     options?: LibraryOptions
   ): NamedLibraryDeploymentFuture<LibraryNameT>;
 
-  libraryFromArtifact(
+  library(
     libraryName: string,
     artifact: Artifact,
-    options?: LibraryFromArtifactOptions
+    options?: LibraryOptions
   ): ArtifactLibraryDeploymentFuture;
 
   call<ContractNameT extends string, FunctionNameT extends string>(
@@ -200,7 +175,7 @@ export interface IgnitionModuleBuilder {
     options?: ContractAtOptions
   ): NamedContractAtFuture<ContractNameT>;
 
-  contractAtFromArtifact(
+  contractAt(
     contractName: string,
     address:
       | string

--- a/packages/core/test/call.ts
+++ b/packages/core/test/call.ts
@@ -522,7 +522,7 @@ describe("call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "test");
 
           return { another };
@@ -561,7 +561,7 @@ describe("call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "inc", [1, 2]);
 
           return { another };
@@ -618,7 +618,7 @@ describe("call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "inc(bool,uint256)", [1, 2, 3]);
 
           return { another };
@@ -658,7 +658,7 @@ describe("call", () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p");
 
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "test", [p]);
 
           return { another };
@@ -690,7 +690,7 @@ describe("call", () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", false as unknown as bigint);
 
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "test", [], { value: p });
 
           return { another };
@@ -730,7 +730,7 @@ describe("call", () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", 42n);
 
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "test", [], { value: p });
 
           return { another };
@@ -775,7 +775,7 @@ describe("call", () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", true);
 
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "test", [p]);
 
           return { another };
@@ -806,7 +806,7 @@ describe("call", () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p");
 
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "test", [
             [123, { really: { deeply: { nested: [p] } } }],
           ]);
@@ -854,7 +854,7 @@ describe("call", () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", true);
 
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.call(another, "test", [
             [123, { really: { deeply: { nested: [p] } } }],
           ]);
@@ -899,7 +899,7 @@ describe("call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           const account = m.getAccount(-1);
           m.call(another, "inc", [1], { from: account });
 
@@ -944,7 +944,7 @@ describe("call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           const account = m.getAccount(1);
           m.call(another, "inc", [1], { from: account });
 

--- a/packages/core/test/contractAtFromArtifact.ts
+++ b/packages/core/test/contractAtFromArtifact.ts
@@ -213,18 +213,6 @@ describe("contractAtFromArtifact", () => {
           /Invalid address given/
         );
       });
-
-      it("should not validate an invalid artifact", () => {
-        assert.throws(
-          () =>
-            buildModule("Module1", (m) => {
-              const another = m.contractAt("Another", "", {} as Artifact);
-
-              return { another };
-            }),
-          /Invalid artifact given/
-        );
-      });
     });
 
     describe("stage two", () => {

--- a/packages/core/test/contractAtFromArtifact.ts
+++ b/packages/core/test/contractAtFromArtifact.ts
@@ -18,11 +18,7 @@ describe("contractAtFromArtifact", () => {
 
   it("should be able to setup a contract at a given address", () => {
     const moduleWithContractFromArtifact = buildModule("Module1", (m) => {
-      const contract1 = m.contractAtFromArtifact(
-        "Contract1",
-        "0xtest",
-        fakeArtifact
-      );
+      const contract1 = m.contractAt("Contract1", "0xtest", fakeArtifact);
 
       return { contract1 };
     });
@@ -52,14 +48,9 @@ describe("contractAtFromArtifact", () => {
   it("should be able to pass an after dependency", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.contract("Example");
-      const another = m.contractAtFromArtifact(
-        "Another",
-        "0xtest",
-        fakeArtifact,
-        {
-          after: [example],
-        }
-      );
+      const another = m.contractAt("Another", "0xtest", fakeArtifact, {
+        after: [example],
+      });
 
       return { example, another };
     });
@@ -78,7 +69,7 @@ describe("contractAtFromArtifact", () => {
       const example = m.contract("Example");
       const call = m.staticCall(example, "getAddress");
 
-      const another = m.contractAtFromArtifact("Another", call, fakeArtifact);
+      const another = m.contractAt("Another", call, fakeArtifact);
 
       return { example, another };
     });
@@ -100,12 +91,8 @@ describe("contractAtFromArtifact", () => {
       const paramWithDefault = m.getParameter("addressWithDefault", "0x000000");
       const paramWithoutDefault = m.getParameter("addressWithoutDefault");
 
-      const withDefault = m.contractAtFromArtifact(
-        "C",
-        paramWithDefault,
-        fakeArtifact
-      );
-      const withoutDefault = m.contractAtFromArtifact(
+      const withDefault = m.contractAt("C", paramWithDefault, fakeArtifact);
+      const withoutDefault = m.contractAt(
         "C2",
         paramWithoutDefault,
         fakeArtifact
@@ -135,13 +122,13 @@ describe("contractAtFromArtifact", () => {
   describe("passing id", () => {
     it("should be able to deploy the same contract twice by passing an id", () => {
       const moduleWithSameContractTwice = buildModule("Module1", (m) => {
-        const sameContract1 = m.contractAtFromArtifact(
+        const sameContract1 = m.contractAt(
           "SameContract",
           "0x123",
           fakeArtifact,
           { id: "first" }
         );
-        const sameContract2 = m.contractAtFromArtifact(
+        const sameContract2 = m.contractAt(
           "SameContract",
           "0x123",
           fakeArtifact,
@@ -168,12 +155,12 @@ describe("contractAtFromArtifact", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            const sameContract1 = m.contractAtFromArtifact(
+            const sameContract1 = m.contractAt(
               "SameContract",
               "0x123",
               fakeArtifact
             );
-            const sameContract2 = m.contractAtFromArtifact(
+            const sameContract2 = m.contractAt(
               "SameContract",
               "0x123",
               fakeArtifact
@@ -189,7 +176,7 @@ describe("contractAtFromArtifact", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            const sameContract1 = m.contractAtFromArtifact(
+            const sameContract1 = m.contractAt(
               "SameContract",
               "0x123",
               fakeArtifact,
@@ -197,7 +184,7 @@ describe("contractAtFromArtifact", () => {
                 id: "same",
               }
             );
-            const sameContract2 = m.contractAtFromArtifact(
+            const sameContract2 = m.contractAt(
               "SameContract",
               "0x123",
               fakeArtifact,
@@ -219,11 +206,7 @@ describe("contractAtFromArtifact", () => {
         assert.throws(
           () =>
             buildModule("Module1", (m) => {
-              const another = m.contractAtFromArtifact(
-                "Another",
-                42 as any,
-                fakeArtifact
-              );
+              const another = m.contractAt("Another", 42 as any, fakeArtifact);
 
               return { another };
             }),
@@ -235,11 +218,7 @@ describe("contractAtFromArtifact", () => {
         assert.throws(
           () =>
             buildModule("Module1", (m) => {
-              const another = m.contractAtFromArtifact(
-                "Another",
-                "",
-                {} as Artifact
-              );
+              const another = m.contractAt("Another", "", {} as Artifact);
 
               return { another };
             }),
@@ -263,7 +242,7 @@ describe("contractAtFromArtifact", () => {
       it("should not validate a missing module parameter", async () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p");
-          const another = m.contractAtFromArtifact("Another", p, fakeArtifact);
+          const another = m.contractAt("Another", p, fakeArtifact);
 
           return { another };
         });
@@ -288,7 +267,7 @@ describe("contractAtFromArtifact", () => {
       it("should validate a missing module parameter if a default parameter is present", async () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", "0x1234");
-          const another = m.contractAtFromArtifact("Another", p, fakeArtifact);
+          const another = m.contractAt("Another", p, fakeArtifact);
 
           return { another };
         });
@@ -312,7 +291,7 @@ describe("contractAtFromArtifact", () => {
       it("should not validate a module parameter of the wrong type", async () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", 123 as unknown as string);
-          const another = m.contractAtFromArtifact("Another", p, fakeArtifact);
+          const another = m.contractAt("Another", p, fakeArtifact);
 
           return { another };
         });

--- a/packages/core/test/contractFromArtifact.ts
+++ b/packages/core/test/contractFromArtifact.ts
@@ -22,7 +22,7 @@ describe("contractFromArtifact", () => {
 
   it("should be able to deploy with a contract based on an artifact", () => {
     const moduleWithContractFromArtifact = buildModule("Module1", (m) => {
-      const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
+      const contract1 = m.contract("Contract1", fakeArtifact, [
         1,
         "a",
         BigInt("9007199254740991"),
@@ -56,9 +56,7 @@ describe("contractFromArtifact", () => {
   it("should be able to pass an arg dependency", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.contract("Example");
-      const another = m.contractFromArtifact("Another", fakeArtifact, [
-        example,
-      ]);
+      const another = m.contract("Another", fakeArtifact, [example]);
 
       return { example, another };
     });
@@ -75,7 +73,7 @@ describe("contractFromArtifact", () => {
   it("should be able to pass an after dependency", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.contract("Example");
-      const another = m.contractFromArtifact("Another", fakeArtifact, [], {
+      const another = m.contract("Another", fakeArtifact, [], {
         after: [example],
       });
 
@@ -94,7 +92,7 @@ describe("contractFromArtifact", () => {
   it("should be able to pass a library as a dependency of a contract", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.library("Example");
-      const another = m.contractFromArtifact("Another", fakeArtifact, [], {
+      const another = m.contract("Another", fakeArtifact, [], {
         libraries: { Example: example },
       });
 
@@ -124,7 +122,7 @@ describe("contractFromArtifact", () => {
 
   it("should be able to pass value as an option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      const another = m.contractFromArtifact("Another", fakeArtifact, [], {
+      const another = m.contract("Another", fakeArtifact, [], {
         value: BigInt(42),
       });
 
@@ -148,7 +146,7 @@ describe("contractFromArtifact", () => {
 
   it("Should be able to pass a ModuleParameterRuntimeValue as a value option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      const another = m.contractFromArtifact("Another", fakeArtifact, [], {
+      const another = m.contract("Another", fakeArtifact, [], {
         value: m.getParameter("value"),
       });
 
@@ -175,7 +173,7 @@ describe("contractFromArtifact", () => {
 
   it("should be able to pass a string as from option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      const another = m.contractFromArtifact("Another", fakeArtifact, [], {
+      const another = m.contract("Another", fakeArtifact, [], {
         from: "0x2",
       });
 
@@ -199,7 +197,7 @@ describe("contractFromArtifact", () => {
 
   it("Should be able to pass an AccountRuntimeValue as from option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      const another = m.contractFromArtifact("Another", fakeArtifact, [], {
+      const another = m.contract("Another", fakeArtifact, [], {
         from: m.getAccount(1),
       });
 
@@ -225,7 +223,7 @@ describe("contractFromArtifact", () => {
   describe("Arguments", () => {
     it("Should support base values as arguments", () => {
       const module = buildModule("Module", (m) => {
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
+        const contract1 = m.contract("Contract1", fakeArtifact, [
           1,
           true,
           "string",
@@ -245,9 +243,7 @@ describe("contractFromArtifact", () => {
 
     it("Should support arrays as arguments", () => {
       const module = buildModule("Module", (m) => {
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
-          [1, 2, 3n],
-        ]);
+        const contract1 = m.contract("Contract1", fakeArtifact, [[1, 2, 3n]]);
 
         return { contract1 };
       });
@@ -257,7 +253,7 @@ describe("contractFromArtifact", () => {
 
     it("Should support objects as arguments", () => {
       const module = buildModule("Module", (m) => {
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
+        const contract1 = m.contract("Contract1", fakeArtifact, [
           { a: 1, b: [1, 2] },
         ]);
 
@@ -273,9 +269,7 @@ describe("contractFromArtifact", () => {
     it("Should support futures as arguments", () => {
       const module = buildModule("Module", (m) => {
         const contract1 = m.contract("Contract1");
-        const contract2 = m.contractFromArtifact("Contract2", fakeArtifact, [
-          contract1,
-        ]);
+        const contract2 = m.contract("Contract2", fakeArtifact, [contract1]);
 
         return { contract1, contract2 };
       });
@@ -289,7 +283,7 @@ describe("contractFromArtifact", () => {
     it("should support nested futures as arguments", () => {
       const module = buildModule("Module", (m) => {
         const contract1 = m.contract("Contract1");
-        const contract2 = m.contractFromArtifact("Contract2", fakeArtifact, [
+        const contract2 = m.contract("Contract2", fakeArtifact, [
           { arr: [contract1] },
         ]);
 
@@ -305,9 +299,7 @@ describe("contractFromArtifact", () => {
     it("should support AccountRuntimeValues as arguments", () => {
       const module = buildModule("Module", (m) => {
         const account1 = m.getAccount(1);
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
-          account1,
-        ]);
+        const contract1 = m.contract("Contract1", fakeArtifact, [account1]);
 
         return { contract1 };
       });
@@ -322,7 +314,7 @@ describe("contractFromArtifact", () => {
     it("should support nested AccountRuntimeValues as arguments", () => {
       const module = buildModule("Module", (m) => {
         const account1 = m.getAccount(1);
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
+        const contract1 = m.contract("Contract1", fakeArtifact, [
           { arr: [account1] },
         ]);
 
@@ -340,9 +332,7 @@ describe("contractFromArtifact", () => {
     it("should support ModuleParameterRuntimeValue as arguments", () => {
       const module = buildModule("Module", (m) => {
         const p = m.getParameter("p", 123);
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
-          p,
-        ]);
+        const contract1 = m.contract("Contract1", fakeArtifact, [p]);
 
         return { contract1 };
       });
@@ -361,9 +351,7 @@ describe("contractFromArtifact", () => {
     it("should support nested ModuleParameterRuntimeValue as arguments", () => {
       const module = buildModule("Module", (m) => {
         const p = m.getParameter("p", 123);
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, [
-          { arr: [p] },
-        ]);
+        const contract1 = m.contract("Contract1", fakeArtifact, [{ arr: [p] }]);
 
         return { contract1 };
       });
@@ -378,20 +366,12 @@ describe("contractFromArtifact", () => {
   describe("passing id", () => {
     it("should use contract from artifact twice by passing an id", () => {
       const moduleWithSameContractTwice = buildModule("Module1", (m) => {
-        const sameContract1 = m.contractFromArtifact(
-          "SameContract",
-          fakeArtifact,
-          [],
-          { id: "first" }
-        );
-        const sameContract2 = m.contractFromArtifact(
-          "SameContract",
-          fakeArtifact,
-          [],
-          {
-            id: "second",
-          }
-        );
+        const sameContract1 = m.contract("SameContract", fakeArtifact, [], {
+          id: "first",
+        });
+        const sameContract2 = m.contract("SameContract", fakeArtifact, [], {
+          id: "second",
+        });
 
         return { sameContract1, sameContract2 };
       });
@@ -412,14 +392,8 @@ describe("contractFromArtifact", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            const sameContract1 = m.contractFromArtifact(
-              "SameContract",
-              fakeArtifact
-            );
-            const sameContract2 = m.contractFromArtifact(
-              "SameContract",
-              fakeArtifact
-            );
+            const sameContract1 = m.contract("SameContract", fakeArtifact);
+            const sameContract2 = m.contract("SameContract", fakeArtifact);
 
             return { sameContract1, sameContract2 };
           }),
@@ -431,22 +405,12 @@ describe("contractFromArtifact", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            const sameContract1 = m.contractFromArtifact(
-              "SameContract",
-              fakeArtifact,
-              [],
-              {
-                id: "same",
-              }
-            );
-            const sameContract2 = m.contractFromArtifact(
-              "SameContract",
-              fakeArtifact,
-              [],
-              {
-                id: "same",
-              }
-            );
+            const sameContract1 = m.contract("SameContract", fakeArtifact, [], {
+              id: "same",
+            });
+            const sameContract2 = m.contract("SameContract", fakeArtifact, [], {
+              id: "same",
+            });
 
             return { sameContract1, sameContract2 };
           }),
@@ -461,14 +425,9 @@ describe("contractFromArtifact", () => {
         assert.throws(
           () =>
             buildModule("Module1", (m) => {
-              const another = m.contractFromArtifact(
-                "Another",
-                fakeArtifact,
-                [],
-                {
-                  value: 42 as any,
-                }
-              );
+              const another = m.contract("Another", fakeArtifact, [], {
+                value: 42 as any,
+              });
 
               return { another };
             }),
@@ -480,14 +439,9 @@ describe("contractFromArtifact", () => {
         assert.throws(
           () =>
             buildModule("Module1", (m) => {
-              const another = m.contractFromArtifact(
-                "Another",
-                fakeArtifact,
-                [],
-                {
-                  from: 1 as any,
-                }
-              );
+              const another = m.contract("Another", fakeArtifact, [], {
+                from: 1 as any,
+              });
 
               return { another };
             }),
@@ -502,7 +456,7 @@ describe("contractFromArtifact", () => {
               const another = m.contract("Another", []);
               const call = m.call(another, "test");
 
-              const test = m.contractFromArtifact("Test", fakeArtifact, [], {
+              const test = m.contract("Test", fakeArtifact, [], {
                 libraries: { Call: call as any },
               });
 
@@ -516,11 +470,7 @@ describe("contractFromArtifact", () => {
         assert.throws(
           () =>
             buildModule("Module1", (m) => {
-              const another = m.contractFromArtifact(
-                "Another",
-                {} as Artifact,
-                []
-              );
+              const another = m.contract("Another", {} as Artifact, []);
 
               return { another };
             }),
@@ -544,11 +494,7 @@ describe("contractFromArtifact", () => {
 
       it("should not validate an incorrect number of constructor args", async () => {
         const module = buildModule("Module1", (m) => {
-          const contract1 = m.contractFromArtifact(
-            "Test",
-            fakeArtifact,
-            [1, 2, 3]
-          );
+          const contract1 = m.contract("Test", fakeArtifact, [1, 2, 3]);
 
           return { contract1 };
         });
@@ -581,7 +527,7 @@ describe("contractFromArtifact", () => {
       it("should not validate a missing module parameter", async () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p");
-          const contract1 = m.contractFromArtifact("Test", fakeArtifact, [p]);
+          const contract1 = m.contract("Test", fakeArtifact, [p]);
 
           return { contract1 };
         });
@@ -623,7 +569,7 @@ describe("contractFromArtifact", () => {
 
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", 123);
-          const contract1 = m.contractFromArtifact("Test", fakerArtifact, [p]);
+          const contract1 = m.contract("Test", fakerArtifact, [p]);
 
           return { contract1 };
         });
@@ -658,7 +604,7 @@ describe("contractFromArtifact", () => {
 
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", false as unknown as bigint);
-          const contract1 = m.contractFromArtifact("Test", fakerArtifact, [], {
+          const contract1 = m.contract("Test", fakerArtifact, [], {
             value: p,
           });
 
@@ -696,7 +642,7 @@ describe("contractFromArtifact", () => {
 
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", 42n);
-          const contract1 = m.contractFromArtifact("Test", fakerArtifact, [], {
+          const contract1 = m.contract("Test", fakerArtifact, [], {
             value: p,
           });
 
@@ -720,7 +666,7 @@ describe("contractFromArtifact", () => {
       it("should not validate a missing module parameter (deeply nested)", async () => {
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p");
-          const contract1 = m.contractFromArtifact("Test", fakeArtifact, [
+          const contract1 = m.contract("Test", fakeArtifact, [
             [123, { really: { deeply: { nested: [p] } } }],
           ]);
 
@@ -764,7 +710,7 @@ describe("contractFromArtifact", () => {
 
         const module = buildModule("Module1", (m) => {
           const p = m.getParameter("p", 123);
-          const contract1 = m.contractFromArtifact("Test", fakerArtifact, [
+          const contract1 = m.contract("Test", fakerArtifact, [
             [123, { really: { deeply: { nested: [p] } } }],
           ]);
 
@@ -788,7 +734,7 @@ describe("contractFromArtifact", () => {
       it("should not validate a negative account index", async () => {
         const module = buildModule("Module1", (m) => {
           const account = m.getAccount(-1);
-          const contract1 = m.contractFromArtifact("Test", fakeArtifact, [], {
+          const contract1 = m.contract("Test", fakeArtifact, [], {
             from: account,
           });
 
@@ -811,7 +757,7 @@ describe("contractFromArtifact", () => {
       it("should not validate an account index greater than the number of available accounts", async () => {
         const module = buildModule("Module1", (m) => {
           const account = m.getAccount(1);
-          const contract1 = m.contractFromArtifact("Test", fakeArtifact, [], {
+          const contract1 = m.contract("Test", fakeArtifact, [], {
             from: account,
           });
 

--- a/packages/core/test/libraryFromArtifact.ts
+++ b/packages/core/test/libraryFromArtifact.ts
@@ -21,7 +21,7 @@ describe("libraryFromArtifact", () => {
 
   it("should be able to deploy with a library based on an artifact", () => {
     const moduleWithContractFromArtifact = buildModule("Module1", (m) => {
-      const library1 = m.libraryFromArtifact("Library1", fakeArtifact);
+      const library1 = m.library("Library1", fakeArtifact);
 
       return { library1 };
     });
@@ -45,7 +45,7 @@ describe("libraryFromArtifact", () => {
   it("should be able to pass an after dependency", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.library("Example");
-      const another = m.libraryFromArtifact("Another", fakeArtifact, {
+      const another = m.library("Another", fakeArtifact, {
         after: [example],
       });
 
@@ -64,7 +64,7 @@ describe("libraryFromArtifact", () => {
   it("should be able to pass a library as a dependency of a library", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.library("Example");
-      const another = m.libraryFromArtifact("Another", fakeArtifact, {
+      const another = m.library("Another", fakeArtifact, {
         libraries: { Example: example },
       });
 
@@ -94,7 +94,7 @@ describe("libraryFromArtifact", () => {
 
   it("should be able to pass a string as from option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      const another = m.libraryFromArtifact("Another", fakeArtifact, {
+      const another = m.library("Another", fakeArtifact, {
         from: "0x2",
       });
 
@@ -118,7 +118,7 @@ describe("libraryFromArtifact", () => {
 
   it("Should be able to pass an AccountRuntimeValue as from option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      const another = m.libraryFromArtifact("Another", fakeArtifact, {
+      const another = m.library("Another", fakeArtifact, {
         from: m.getAccount(1),
       });
 
@@ -144,18 +144,12 @@ describe("libraryFromArtifact", () => {
   describe("passing id", () => {
     it("should use library from artifact twice by passing an id", () => {
       const moduleWithSameContractTwice = buildModule("Module1", (m) => {
-        const sameContract1 = m.libraryFromArtifact(
-          "SameContract",
-          fakeArtifact,
-          { id: "first" }
-        );
-        const sameContract2 = m.libraryFromArtifact(
-          "SameContract",
-          fakeArtifact,
-          {
-            id: "second",
-          }
-        );
+        const sameContract1 = m.library("SameContract", fakeArtifact, {
+          id: "first",
+        });
+        const sameContract2 = m.library("SameContract", fakeArtifact, {
+          id: "second",
+        });
 
         return { sameContract1, sameContract2 };
       });
@@ -176,14 +170,8 @@ describe("libraryFromArtifact", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            const sameContract1 = m.libraryFromArtifact(
-              "SameContract",
-              fakeArtifact
-            );
-            const sameContract2 = m.libraryFromArtifact(
-              "SameContract",
-              fakeArtifact
-            );
+            const sameContract1 = m.library("SameContract", fakeArtifact);
+            const sameContract2 = m.library("SameContract", fakeArtifact);
 
             return { sameContract1, sameContract2 };
           }),
@@ -195,20 +183,12 @@ describe("libraryFromArtifact", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            const sameContract1 = m.libraryFromArtifact(
-              "SameContract",
-              fakeArtifact,
-              {
-                id: "same",
-              }
-            );
-            const sameContract2 = m.libraryFromArtifact(
-              "SameContract",
-              fakeArtifact,
-              {
-                id: "same",
-              }
-            );
+            const sameContract1 = m.library("SameContract", fakeArtifact, {
+              id: "same",
+            });
+            const sameContract2 = m.library("SameContract", fakeArtifact, {
+              id: "same",
+            });
 
             return { sameContract1, sameContract2 };
           }),
@@ -223,7 +203,7 @@ describe("libraryFromArtifact", () => {
         assert.throws(
           () =>
             buildModule("Module1", (m) => {
-              const another = m.libraryFromArtifact("Another", fakeArtifact, {
+              const another = m.library("Another", fakeArtifact, {
                 from: 1 as any,
               });
 
@@ -240,7 +220,7 @@ describe("libraryFromArtifact", () => {
               const another = m.contract("Another", []);
               const call = m.call(another, "test");
 
-              const test = m.libraryFromArtifact("Test", fakeArtifact, {
+              const test = m.library("Test", fakeArtifact, {
                 libraries: { Call: call as any },
               });
 
@@ -254,7 +234,7 @@ describe("libraryFromArtifact", () => {
         assert.throws(
           () =>
             buildModule("Module1", (m) => {
-              const another = m.libraryFromArtifact("Another", {} as Artifact);
+              const another = m.library("Another", {} as Artifact);
 
               return { another };
             }),
@@ -279,7 +259,7 @@ describe("libraryFromArtifact", () => {
       it("should not validate a negative account index", async () => {
         const module = buildModule("Module1", (m) => {
           const account = m.getAccount(-1);
-          const test = m.libraryFromArtifact("Test", fakeArtifact, {
+          const test = m.library("Test", fakeArtifact, {
             from: account,
           });
 
@@ -302,7 +282,7 @@ describe("libraryFromArtifact", () => {
       it("should not validate an account index greater than the number of available accounts", async () => {
         const module = buildModule("Module1", (m) => {
           const account = m.getAccount(1);
-          const test = m.libraryFromArtifact("Test", fakeArtifact, {
+          const test = m.library("Test", fakeArtifact, {
             from: account,
           });
 

--- a/packages/core/test/libraryFromArtifact.ts
+++ b/packages/core/test/libraryFromArtifact.ts
@@ -229,18 +229,6 @@ describe("libraryFromArtifact", () => {
           /Given library 'Call' is not a valid Future/
         );
       });
-
-      it("should not validate an invalid artifact", () => {
-        assert.throws(
-          () =>
-            buildModule("Module1", (m) => {
-              const another = m.library("Another", {} as Artifact);
-
-              return { another };
-            }),
-          /Invalid artifact given/
-        );
-      });
     });
 
     describe("stage two", () => {

--- a/packages/core/test/readEventArgument.ts
+++ b/packages/core/test/readEventArgument.ts
@@ -41,7 +41,7 @@ describe("Read event argument", () => {
       ) as ReadEventArgumentFuture[];
 
       assert.equal(read1.futureToReadFrom, mod.results.contract);
-      assert.equal(read2.futureToReadFrom, mod.results.contract);
+      assert.equal(read2.futureToReadFrom, mod.results.contractFromArtifact);
       assert.equal(read3.futureToReadFrom, callFuture);
     });
 

--- a/packages/core/test/readEventArgument.ts
+++ b/packages/core/test/readEventArgument.ts
@@ -19,7 +19,7 @@ describe("Read event argument", () => {
 
       const mod = buildModule("Module1", (m) => {
         const contract = m.contract("Contract");
-        const contractFromArtifact = m.contractFromArtifact(
+        const contractFromArtifact = m.contract(
           "ContractFromArtifact",
           fakeArtifact
         );
@@ -41,7 +41,7 @@ describe("Read event argument", () => {
       ) as ReadEventArgumentFuture[];
 
       assert.equal(read1.futureToReadFrom, mod.results.contract);
-      assert.equal(read2.futureToReadFrom, mod.results.contractFromArtifact);
+      assert.equal(read2.futureToReadFrom, mod.results.contract);
       assert.equal(read3.futureToReadFrom, callFuture);
     });
 
@@ -263,7 +263,7 @@ describe("Read event argument", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.readEventArgument(another, "test", "arg");
 
           return { another };

--- a/packages/core/test/reconciliation/futures/reconcileArtifactContractAt.ts
+++ b/packages/core/test/reconciliation/futures/reconcileArtifactContractAt.ts
@@ -69,11 +69,7 @@ describe("Reconciliation - artifact contract at", () => {
 
   it("should reconcile when using an address string", async () => {
     const submoduleDefinition = buildModule("Submodule", (m) => {
-      const contract1 = m.contractAtFromArtifact(
-        "Contract1",
-        exampleAddress,
-        mockArtifact
-      );
+      const contract1 = m.contractAt("Contract1", exampleAddress, mockArtifact);
 
       return { contract1 };
     });
@@ -101,7 +97,7 @@ describe("Reconciliation - artifact contract at", () => {
       const example = m.contract("Example");
       const call = m.staticCall(example, "getAddress");
 
-      const another = m.contractAtFromArtifact("Another", call, mockArtifact);
+      const another = m.contractAt("Another", call, mockArtifact);
 
       return { another };
     });
@@ -145,7 +141,7 @@ describe("Reconciliation - artifact contract at", () => {
 
   it("should find changes to contract name unreconciliable", async () => {
     const moduleDefinition = buildModule("Module", (m) => {
-      const contract1 = m.contractAtFromArtifact(
+      const contract1 = m.contractAt(
         "ContractChanged",
         exampleAddress,
         mockArtifact,
@@ -181,7 +177,7 @@ describe("Reconciliation - artifact contract at", () => {
 
   it("should find changes to contract address as a literal unreconciliable", async () => {
     const moduleDefinition = buildModule("Module", (m) => {
-      const contract1 = m.contractAtFromArtifact(
+      const contract1 = m.contractAt(
         "Contract1",
         exampleAddress,
         mockArtifact,

--- a/packages/core/test/reconciliation/futures/reconcileArtifactContractDeployment.ts
+++ b/packages/core/test/reconciliation/futures/reconcileArtifactContractDeployment.ts
@@ -42,16 +42,11 @@ describe("Reconciliation - artifact contract", () => {
       const supply = m.getParameter("supply", BigInt(1000));
       const safeMath = m.library("SafeMath");
 
-      const contract1 = m.contractFromArtifact(
-        "Contract1",
-        mockArtifact,
-        [{ supply }],
-        {
-          libraries: {
-            SafeMath: safeMath,
-          },
-        }
-      );
+      const contract1 = m.contract("Contract1", mockArtifact, [{ supply }], {
+        libraries: {
+          SafeMath: safeMath,
+        },
+      });
 
       return { contract1 };
     });
@@ -92,12 +87,9 @@ describe("Reconciliation - artifact contract", () => {
 
   it("should find changes to contract name unreconciliable", async () => {
     const moduleDefinition = buildModule("Module", (m) => {
-      const contract1 = m.contractFromArtifact(
-        "ContractChanged",
-        mockArtifact,
-        [],
-        { id: "Example" }
-      );
+      const contract1 = m.contract("ContractChanged", mockArtifact, [], {
+        id: "Example",
+      });
 
       return { contract1 };
     });
@@ -128,7 +120,7 @@ describe("Reconciliation - artifact contract", () => {
       const supply = m.getParameter("supply", BigInt(500));
       const ticker = m.getParameter("ticker", "CodeCoin");
 
-      const contract1 = m.contractFromArtifact("Contract1", mockArtifact, [
+      const contract1 = m.contract("Contract1", mockArtifact, [
         owner,
         { nested: { supply } },
         [1, ticker, 3],
@@ -164,7 +156,7 @@ describe("Reconciliation - artifact contract", () => {
     const moduleDefinition = buildModule("Module", (m) => {
       const safeMath = m.library("SafeMath");
 
-      const contract1 = m.contractFromArtifact("Contract1", mockArtifact, [], {
+      const contract1 = m.contract("Contract1", mockArtifact, [], {
         libraries: {
           SafeMath: safeMath,
         },
@@ -207,7 +199,7 @@ describe("Reconciliation - artifact contract", () => {
 
   it("should find changes to value unreconciliable", async () => {
     const moduleDefinition = buildModule("Module", (m) => {
-      const contract1 = m.contractFromArtifact("Contract1", mockArtifact, [], {
+      const contract1 = m.contract("Contract1", mockArtifact, [], {
         id: "Example",
         value: BigInt(4),
       });
@@ -236,7 +228,7 @@ describe("Reconciliation - artifact contract", () => {
 
   it("should find changes to from unreconciliable", async () => {
     const moduleDefinition = buildModule("Module", (m) => {
-      const contract1 = m.contractFromArtifact("Contract1", mockArtifact, [], {
+      const contract1 = m.contract("Contract1", mockArtifact, [], {
         id: "Example",
         from: twoAddress,
       });

--- a/packages/core/test/reconciliation/futures/reconcileArtifactLibraryDeployment.ts
+++ b/packages/core/test/reconciliation/futures/reconcileArtifactLibraryDeployment.ts
@@ -41,7 +41,7 @@ describe("Reconciliation - artifact library", () => {
     const submoduleDefinition = buildModule("Submodule", (m) => {
       const safeMath = m.library("SafeMath");
 
-      const mainLib = m.libraryFromArtifact("MainLibrary", mockArtifact, {
+      const mainLib = m.library("MainLibrary", mockArtifact, {
         libraries: { SafeMath: safeMath },
       });
 
@@ -84,7 +84,7 @@ describe("Reconciliation - artifact library", () => {
 
   it("should find changes to contract name unreconciliable", async () => {
     const moduleDefinition = buildModule("Module", (m) => {
-      const library1 = m.libraryFromArtifact("LibraryChanged", mockArtifact, {
+      const library1 = m.library("LibraryChanged", mockArtifact, {
         id: "Example",
       });
 
@@ -115,7 +115,7 @@ describe("Reconciliation - artifact library", () => {
     const moduleDefinition = buildModule("Module", (m) => {
       const safeMath = m.library("SafeMath");
 
-      const mainLib = m.libraryFromArtifact("MainLibrary", mockArtifact, {
+      const mainLib = m.library("MainLibrary", mockArtifact, {
         libraries: { Changed: safeMath },
       });
 
@@ -159,7 +159,7 @@ describe("Reconciliation - artifact library", () => {
 
   it("should find changes to contract name unreconciliable", async () => {
     const moduleDefinition = buildModule("Module", (m) => {
-      const library1 = m.libraryFromArtifact("Library1", mockArtifact, {
+      const library1 = m.library("Library1", mockArtifact, {
         id: "Example",
         from: twoAddress,
       });

--- a/packages/core/test/staticCall.ts
+++ b/packages/core/test/staticCall.ts
@@ -537,7 +537,7 @@ describe("static call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.staticCall(another, "test");
 
           return { another };
@@ -576,7 +576,7 @@ describe("static call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.staticCall(another, "inc", [1, 2]);
 
           return { another };
@@ -633,7 +633,7 @@ describe("static call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.staticCall(another, "inc(bool,uint256)", [1, 2, 3]);
 
           return { another };
@@ -672,7 +672,7 @@ describe("static call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.staticCall(another, "inc", [1]);
 
           return { another };
@@ -956,7 +956,7 @@ describe("static call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           const account = m.getAccount(-1);
           m.staticCall(another, "inc", [1], 0, { from: account });
 
@@ -1001,7 +1001,7 @@ describe("static call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           const account = m.getAccount(1);
           m.staticCall(another, "inc", [1], 0, { from: account });
 

--- a/packages/core/test/staticCall.ts
+++ b/packages/core/test/staticCall.ts
@@ -711,7 +711,7 @@ describe("static call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.staticCall(another, "inc", [], "a");
 
           return { another };
@@ -750,7 +750,7 @@ describe("static call", () => {
         };
 
         const module = buildModule("Module1", (m) => {
-          const another = m.contractFromArtifact("Another", fakeArtifact, []);
+          const another = m.contract("Another", fakeArtifact, []);
           m.staticCall(another, "inc", [], 2);
 
           return { another };

--- a/packages/core/test/stored-deployment-serializer.ts
+++ b/packages/core/test/stored-deployment-serializer.ts
@@ -80,7 +80,7 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a contractFromArtifact deployment", () => {
       const module = buildModule("Module1", (m) => {
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, []);
+        const contract1 = m.contract("Contract1", fakeArtifact, []);
 
         return { contract1 };
       });
@@ -93,18 +93,13 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a contractFromArtifact deployment with dependency", () => {
       const module = buildModule("Module1", (m) => {
-        const contract1 = m.contractFromArtifact("Contract1", fakeArtifact, []);
+        const contract1 = m.contract("Contract1", fakeArtifact, []);
 
-        const contract2 = m.contractFromArtifact("Contract2", fakeArtifact, [
-          contract1,
-        ]);
+        const contract2 = m.contract("Contract2", fakeArtifact, [contract1]);
 
-        const contract3 = m.contractFromArtifact(
-          "Contract3",
-          fakeArtifact,
-          [],
-          { after: [contract2] }
-        );
+        const contract3 = m.contract("Contract3", fakeArtifact, [], {
+          after: [contract2],
+        });
 
         return { contract1, contract2, contract3 };
       });
@@ -172,11 +167,7 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a contractAt", () => {
       const module = buildModule("Module1", (m) => {
-        const contract1 = m.contractAtFromArtifact(
-          "Contract1",
-          "0x0",
-          fakeArtifact
-        );
+        const contract1 = m.contractAt("Contract1", "0x0", fakeArtifact);
 
         return { contract1 };
       });
@@ -189,17 +180,9 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a contractAt with a future address", () => {
       const module = buildModule("Module1", (m) => {
-        const contract1 = m.contractAtFromArtifact(
-          "Contract1",
-          "0x0",
-          fakeArtifact
-        );
+        const contract1 = m.contractAt("Contract1", "0x0", fakeArtifact);
         const call = m.staticCall(contract1, "getAddress");
-        const contract2 = m.contractAtFromArtifact(
-          "Contract2",
-          call,
-          fakeArtifact
-        );
+        const contract2 = m.contractAt("Contract2", call, fakeArtifact);
 
         return { contract1, contract2 };
       });
@@ -212,19 +195,10 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a contractAt with dependency", () => {
       const module = buildModule("Module1", (m) => {
-        const contract1 = m.contractAtFromArtifact(
-          "Contract1",
-          "0x0",
-          fakeArtifact
-        );
-        const contract2 = m.contractAtFromArtifact(
-          "Contract2",
-          "0x0",
-          fakeArtifact,
-          {
-            after: [contract1],
-          }
-        );
+        const contract1 = m.contractAt("Contract1", "0x0", fakeArtifact);
+        const contract2 = m.contractAt("Contract2", "0x0", fakeArtifact, {
+          after: [contract1],
+        });
 
         return { contract1, contract2 };
       });
@@ -284,22 +258,17 @@ describe("stored deployment serializer", () => {
           },
         });
 
-        const contract3 = m.contractFromArtifact(
-          "Contract3",
-          fakeArtifact,
-          [],
-          {
-            libraries: {
-              Lib1: library1,
-            },
-          }
-        );
+        const contract3 = m.contract("Contract3", fakeArtifact, [], {
+          libraries: {
+            Lib1: library1,
+          },
+        });
 
         const library4 = m.library("Library4", {
           libraries: { Lib1: library1 },
         });
 
-        const library5 = m.libraryFromArtifact("Library5", fakeArtifact, {
+        const library5 = m.library("Library5", fakeArtifact, {
           libraries: { Lib1: library1 },
         });
 
@@ -329,7 +298,7 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a libraryFromArtifact deployment", () => {
       const module = buildModule("Module1", (m) => {
-        const library1 = m.libraryFromArtifact("Contract1", fakeArtifact);
+        const library1 = m.library("Contract1", fakeArtifact);
 
         return { library1 };
       });
@@ -342,9 +311,9 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a libraryFromArtifact deployment with dependency", () => {
       const module = buildModule("Module1", (m) => {
-        const library1 = m.libraryFromArtifact("Library1", fakeArtifact);
+        const library1 = m.library("Library1", fakeArtifact);
 
-        const library2 = m.libraryFromArtifact("Library2", fakeArtifact, {
+        const library2 = m.library("Library2", fakeArtifact, {
           after: [library1],
         });
 

--- a/packages/core/test/validations/id-rules.ts
+++ b/packages/core/test/validations/id-rules.ts
@@ -35,7 +35,7 @@ describe("id rules", () => {
     it("should not allow non-alphanumerics in contractFromArtifact ids", () => {
       assert.throws(() => {
         buildModule("MyModule", (m) => {
-          const myContract = m.contractFromArtifact(
+          const myContract = m.contract(
             "MyContractFromArtifact",
             fakeArtifact,
             [],
@@ -64,7 +64,7 @@ describe("id rules", () => {
     it("should not allow non-alphanumerics in libraryFromArtifact ids", () => {
       assert.throws(() => {
         buildModule("MyModule", (m) => {
-          const myLibraryFromArtifact = m.libraryFromArtifact(
+          const myLibraryFromArtifact = m.library(
             "MyLibraryFromArtifact",
             fakeArtifact,
             {
@@ -120,7 +120,7 @@ describe("id rules", () => {
     it("should not allow non-alphanumerics in contractAtFromArtifact ids", () => {
       assert.throws(() => {
         buildModule("MyModule", (m) => {
-          const myContractAt = m.contractAtFromArtifact(
+          const myContractAt = m.contractAt(
             "MyContract",
             exampleAddress,
             fakeArtifact,
@@ -173,10 +173,7 @@ describe("id rules", () => {
     it("should not allow non-alphanumerics in contractFromArtifact contract name", () => {
       assert.throws(() => {
         buildModule("MyModule", (m) => {
-          const myContract = m.contractFromArtifact(
-            "MyContract:v2",
-            fakeArtifact
-          );
+          const myContract = m.contract("MyContract:v2", fakeArtifact);
 
           return { myContract };
         });
@@ -196,7 +193,7 @@ describe("id rules", () => {
     it("should not allow non-alphanumerics in libraryFromArtifact contract names", () => {
       assert.throws(() => {
         buildModule("MyModule", (m) => {
-          const myLibraryFromArtifact = m.libraryFromArtifact(
+          const myLibraryFromArtifact = m.library(
             "MyLibraryFromArtifact:v2",
             fakeArtifact
           );
@@ -219,7 +216,7 @@ describe("id rules", () => {
     it("should not allow non-alphanumerics in contractAtFromArtifact contract names", () => {
       assert.throws(() => {
         buildModule("MyModule", (m) => {
-          const myContractAt = m.contractAtFromArtifact(
+          const myContractAt = m.contractAt(
             "MyContractAt:v2",
             exampleAddress,
             fakeArtifact

--- a/packages/hardhat-plugin/test/contracts.ts
+++ b/packages/hardhat-plugin/test/contracts.ts
@@ -76,9 +76,7 @@ describe("contract deploys", () => {
     const artifact = await this.hre.artifacts.readArtifact("Greeter");
 
     const moduleDefinition = buildModule("ArtifactModule", (m) => {
-      const greeter = m.contractFromArtifact("Greeter", artifact, [
-        "Hello World",
-      ]);
+      const greeter = m.contract("Greeter", artifact, ["Hello World"]);
 
       return { greeter };
     });

--- a/packages/hardhat-plugin/test/events.ts
+++ b/packages/hardhat-plugin/test/events.ts
@@ -48,7 +48,7 @@ describe("events", () => {
         "fooAddress"
       );
 
-      const foo = m.contractAtFromArtifact("Foo", newAddress, artifact);
+      const foo = m.contractAt("Foo", newAddress, artifact);
 
       return { fooFactory, foo };
     });

--- a/packages/hardhat-plugin/test/execution/deploy-contract-at-from-artifact.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract-at-from-artifact.ts
@@ -38,7 +38,7 @@ describe.skip("execution - deploy contractAt from artifact", function () {
     const fooArtifact = await this.hre.artifacts.readArtifact("Foo");
 
     const contractAtModuleDefinition = buildModule("FooModule", (m) => {
-      const atFoo = m.contractAtFromArtifact("AtFoo", fooAddress, fooArtifact);
+      const atFoo = m.contractAt("AtFoo", fooAddress, fooArtifact);
 
       return { atFoo };
     });

--- a/packages/hardhat-plugin/test/execution/deploy-contract-from-artifact.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract-from-artifact.ts
@@ -17,7 +17,7 @@ describe("execution - deploy contract from artifact", function () {
     const fooArtifact = await this.hre.artifacts.readArtifact("Foo");
 
     const moduleDefinition = buildModule("FooModule", (m) => {
-      const foo = m.contractFromArtifact("Foo", fooArtifact);
+      const foo = m.contract("Foo", fooArtifact);
 
       return { foo };
     });

--- a/packages/hardhat-plugin/test/existing-contract.ts
+++ b/packages/hardhat-plugin/test/existing-contract.ts
@@ -31,8 +31,8 @@ describe("existing contract", () => {
       await firstResult.usesContract.getAddress();
 
     const secondModuleDefinition = buildModule("SecondModule", (m) => {
-      const bar = m.contractAtFromArtifact("Bar", barAddress, barArtifact);
-      const usesContract = m.contractAtFromArtifact(
+      const bar = m.contractAt("Bar", barAddress, barArtifact);
+      const usesContract = m.contractAt(
         "UsesContract",
         usesContractAddress,
         usesContractArtifact

--- a/packages/hardhat-plugin/test/libraries.ts
+++ b/packages/hardhat-plugin/test/libraries.ts
@@ -41,7 +41,7 @@ describe("libraries", () => {
     );
 
     const moduleDefinition = buildModule("ArtifactLibraryModule", (m) => {
-      const rubbishMath = m.libraryFromArtifact("RubbishMath", libraryArtifact);
+      const rubbishMath = m.library("RubbishMath", libraryArtifact);
       const dependsOnLib = m.contract("DependsOnLib", [], {
         libraries: {
           RubbishMath: rubbishMath,

--- a/packages/hardhat-plugin/test/static-calls.ts
+++ b/packages/hardhat-plugin/test/static-calls.ts
@@ -44,7 +44,7 @@ describe("static calls", () => {
         after: [createCall],
       });
 
-      const foo = m.contractAtFromArtifact("Foo", newAddress, artifact);
+      const foo = m.contractAt("Foo", newAddress, artifact);
 
       return { fooFactory, foo };
     });
@@ -167,7 +167,7 @@ describe("static calls", () => {
         after: [createCall],
       });
 
-      const foo = m.contractAtFromArtifact("Foo", nonAddress, artifact);
+      const foo = m.contractAt("Foo", nonAddress, artifact);
 
       return { fooFactory, foo };
     });

--- a/packages/ui/test/to-mermaid.ts
+++ b/packages/ui/test/to-mermaid.ts
@@ -121,21 +121,12 @@ describe("to-mermaid", () => {
     const moduleDefinition = buildModule("Module", (m) => {
       const basic = m.contract("BasicContract");
       const library = m.library("BasicLibrary");
-      const libFromArtifact = m.libraryFromArtifact(
-        "BasicLibrary",
-        libArtifact,
-        {
-          id: "BasicLibrary2",
-        }
-      );
-      const withLib = m.contractFromArtifact(
-        "ContractWithLibrary",
-        withLibArtifact,
-        [],
-        {
-          libraries: { BasicLibrary: library },
-        }
-      );
+      const libFromArtifact = m.library("BasicLibrary", libArtifact, {
+        id: "BasicLibrary2",
+      });
+      const withLib = m.contract("ContractWithLibrary", withLibArtifact, [], {
+        libraries: { BasicLibrary: library },
+      });
 
       const call = m.call(basic, "basicFunction", [40]);
       const eventArg = m.readEventArgument(call, "BasicEvent", "eventArg");
@@ -144,7 +135,7 @@ describe("to-mermaid", () => {
       const duplicate = m.contractAt("BasicContract", basic, {
         id: "BasicContract2",
       });
-      const duplicateWithLib = m.contractAtFromArtifact(
+      const duplicateWithLib = m.contractAt(
         "ContractWithLibrary",
         withLib,
         withLibArtifact,


### PR DESCRIPTION
Closes #448 