### PR TITLE
refactor: rename executionId to networkInteractionId

### DIFF
--- a/packages/core/src/internal/deployer.ts
+++ b/packages/core/src/internal/deployer.ts
@@ -296,7 +296,7 @@ export class Deployer {
         .filter((ex) => ex.status === ExecutionStatus.TIMEOUT)
         .map((ex) => ({
           futureId: ex.id,
-          executionId: ex.networkInteractions.at(-1)!.id,
+          networkInteractionId: ex.networkInteractions.at(-1)!.id,
         })),
       failed: Object.values(deploymentState.executionStates)
         .filter(canFail)
@@ -310,7 +310,7 @@ export class Deployer {
 
           return {
             futureId: ex.id,
-            executionId: ex.networkInteractions.at(-1)!.id,
+            networkInteractionId: ex.networkInteractions.at(-1)!.id,
             error: formatExecutionError(ex.result),
           };
         }),

--- a/packages/core/src/types/deploy.ts
+++ b/packages/core/src/types/deploy.ts
@@ -120,16 +120,20 @@ export interface ExecutionErrorDeploymentResult {
   started: string[];
 
   /**
-   * A list of all the future that have timed out and the id of the execution
-   * that timed out.
+   * A list of all the future that have timed out, including details of the
+   * network interaction that timed out.
    */
-  timedOut: Array<{ futureId: string; executionId: number }>;
+  timedOut: Array<{ futureId: string; networkInteractionId: number }>;
 
   /**
-   * A list of all the future that have failed and the id of the execution
-   * that failed, and a string explaining the failure.
+   * A list of all the future that have failed, including the details of
+   * the network interaction that errored.
    */
-  failed: Array<{ futureId: string; executionId: number; error: string }>;
+  failed: Array<{
+    futureId: string;
+    networkInteractionId: number;
+    error: string;
+  }>;
 
   /**
    * A list with the id of all the future that have successfully executed.

--- a/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
@@ -140,9 +140,9 @@ const ExecutionErrorResult: React.FC<{
               Timed Out:
               <Newline />
             </Text>
-            {result.timedOut.map(({ futureId, executionId }) => (
+            {result.timedOut.map(({ futureId, networkInteractionId }) => (
               <Text key={futureId}>
-                - {futureId}/{executionId}
+                - {futureId}/{networkInteractionId}
               </Text>
             ))}
           </Box>
@@ -155,9 +155,9 @@ const ExecutionErrorResult: React.FC<{
               <Newline />
             </Text>
 
-            {result.failed.map(({ futureId, executionId, error }) => (
+            {result.failed.map(({ futureId, networkInteractionId, error }) => (
               <Text key={futureId}>
-                - {futureId}/{executionId}: {error}
+                - {futureId}/{networkInteractionId}: {error}
               </Text>
             ))}
           </Box>

--- a/packages/hardhat-plugin/src/utils/error-deployment-result-to-exception-message.ts
+++ b/packages/hardhat-plugin/src/utils/error-deployment-result-to-exception-message.ts
@@ -63,7 +63,8 @@ function _convertExecutionError(result: ExecutionErrorDeploymentResult) {
 
   if (messageDetails.timeouts) {
     const timeoutList = result.timedOut.map(
-      ({ futureId, executionId }) => `  * ${futureId}/${executionId}`
+      ({ futureId, networkInteractionId }) =>
+        `  * ${futureId}/${networkInteractionId}`
     );
 
     sections.push(`Timed out:\n\n${timeoutList.join("\n")}`);
@@ -71,8 +72,8 @@ function _convertExecutionError(result: ExecutionErrorDeploymentResult) {
 
   if (messageDetails.failures) {
     const errorList = result.failed.map(
-      ({ futureId, executionId, error }) =>
-        `  * ${futureId}/${executionId}: ${error}`
+      ({ futureId, networkInteractionId, error }) =>
+        `  * ${futureId}/${networkInteractionId}: ${error}`
     );
 
     sections.push(`Failures:\n\n${errorList.join("\n")}`);

--- a/packages/hardhat-plugin/test/utils/error-deployment-result-to-exception-message.ts
+++ b/packages/hardhat-plugin/test/utils/error-deployment-result-to-exception-message.ts
@@ -63,8 +63,8 @@ describe("display error deployment result", () => {
         type: DeploymentResultType.EXECUTION_ERROR,
         started: [],
         timedOut: [
-          { futureId: "MyModule:MyContract", executionId: 1 },
-          { futureId: "MyModule:AnotherContract", executionId: 3 },
+          { futureId: "MyModule:MyContract", networkInteractionId: 1 },
+          { futureId: "MyModule:AnotherContract", networkInteractionId: 3 },
         ],
         failed: [],
         successful: [],
@@ -89,12 +89,12 @@ Timed out:
         failed: [
           {
             futureId: "MyModule:MyContract",
-            executionId: 1,
+            networkInteractionId: 1,
             error: "Reverted with reason x",
           },
           {
             futureId: "MyModule:AnotherContract",
-            executionId: 3,
+            networkInteractionId: 3,
             error: "Reverted with reason y",
           },
         ],
@@ -117,18 +117,18 @@ Failures:
         type: DeploymentResultType.EXECUTION_ERROR,
         started: [],
         timedOut: [
-          { futureId: "MyModule:FirstContract", executionId: 1 },
-          { futureId: "MyModule:SecondContract", executionId: 3 },
+          { futureId: "MyModule:FirstContract", networkInteractionId: 1 },
+          { futureId: "MyModule:SecondContract", networkInteractionId: 3 },
         ],
         failed: [
           {
             futureId: "MyModule:ThirdContract",
-            executionId: 1,
+            networkInteractionId: 1,
             error: "Reverted with reason x",
           },
           {
             futureId: "MyModule:FourthContract",
-            executionId: 3,
+            networkInteractionId: 3,
             error: "Reverted with reason y",
           },
         ],


### PR DESCRIPTION
In deploy results we should use the correct concept name. ExecutionId was an old but related concept.