### PR TITLE
feat/constrain-ids

### DIFF
--- a/examples/complete/ignition/CompleteModule.js
+++ b/examples/complete/ignition/CompleteModule.js
@@ -33,7 +33,7 @@ module.exports = buildModule("CompleteModule", (m) => {
     { id: "ContractWithLibrary2" }
   );
 
-  m.send("test-send", duplicate, 123n);
+  m.send("test_send", duplicate, 123n);
 
   return {
     basic,

--- a/examples/ens/ignition/ENS.js
+++ b/examples/ens/ignition/ENS.js
@@ -30,7 +30,7 @@ const resolverModule = buildModule("RESOLVER", (m) => {
   const resolver = m.contract("PublicResolver", [ens, ZERO_ADDRESS]);
 
   m.call(ens, "setSubnodeOwner", [ZERO_HASH, resolverLabel, account], {
-    id: "set-subnode-owner-for-resolver",
+    id: "set_subnode_owner_for_resolver",
   });
 
   m.call(ens, "setResolver", [resolverNode, resolver]);
@@ -50,7 +50,7 @@ const reverseRegistrarModule = buildModule("REVERSEREGISTRAR", (m) => {
   const reverseRegistrar = m.contract("ReverseRegistrar", [ens, resolver]);
 
   m.call(ens, "setSubnodeOwner", [ZERO_HASH, reverseLabel, account], {
-    id: "set-subnode-owner-reverse",
+    id: "set_subnode_owner_reverse",
   });
 
   m.call(
@@ -58,7 +58,7 @@ const reverseRegistrarModule = buildModule("REVERSEREGISTRAR", (m) => {
     "setSubnodeOwner",
     [reverseTldHash, addrLabel, reverseRegistrar],
     {
-      id: "set-subnode-addr-label",
+      id: "set_subnode_addr_label",
     }
   );
 

--- a/examples/ens/ignition/test-registrar.js
+++ b/examples/ens/ignition/test-registrar.js
@@ -22,7 +22,7 @@ module.exports = buildModule("TEST_registrar", (m) => {
   const registrar = m.contract("FIFSRegistrar", [ens, tldHash]);
 
   m.call(ens, "setSubnodeOwner", [ZERO_HASH, tldLabel, ACCOUNT_0], {
-    id: "set-subnode-owner-for-registrar",
+    id: "set_subnode_owner_for_registrar",
   });
 
   return { ens, resolver, registrar, reverseRegistrar };

--- a/examples/ens/ignition/test-registrar.js
+++ b/examples/ens/ignition/test-registrar.js
@@ -11,7 +11,7 @@ const ZERO_HASH =
 
 const ACCOUNT_0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
-module.exports = buildModule("TEST registrar", (m) => {
+module.exports = buildModule("TEST_registrar", (m) => {
   const tld = "test";
   const tldHash = namehash.hash(tld);
   const tldLabel = labelhash(tld);

--- a/packages/core/src/build-module.ts
+++ b/packages/core/src/build-module.ts
@@ -1,5 +1,6 @@
 import { IgnitionError } from "./errors";
 import { ModuleConstructor } from "./internal/module-builder";
+import { isValidIgnitionIdentifier } from "./internal/utils/identifier-validators";
 import { IgnitionModule, IgnitionModuleResult } from "./types/module";
 import { IgnitionModuleBuilder } from "./types/module-builder";
 
@@ -25,9 +26,9 @@ export function buildModule<
     throw new IgnitionError(`\`moduleId\` must be a string`);
   }
 
-  if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(moduleId)) {
+  if (!isValidIgnitionIdentifier(moduleId)) {
     throw new IgnitionError(
-      `The moduleId "${moduleId}" contains banned characters, ids can only contain alphanumerics, underscores or dashes`
+      `The moduleId "${moduleId}" contains banned characters, ids can only contain alphanumerics or underscores`
     );
   }
 

--- a/packages/core/src/build-module.ts
+++ b/packages/core/src/build-module.ts
@@ -25,6 +25,12 @@ export function buildModule<
     throw new IgnitionError(`\`moduleId\` must be a string`);
   }
 
+  if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(moduleId)) {
+    throw new IgnitionError(
+      `The moduleId "${moduleId}" contains banned characters, ids can only contain alphanumerics, underscores or dashes`
+    );
+  }
+
   if (typeof moduleDefintionFunction !== "function") {
     throw new IgnitionError(`\`moduleDefintionFunction\` must be a function`);
   }

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -178,6 +178,7 @@ class IgnitionModuleBuilderImplementation<
     options.value ??= BigInt(0);
 
     /* validation start */
+    this._assertValidId(options.id, this.contract);
     this._assertUniqueContractId(futureId);
     this._assertValidLibraries(options.libraries, this.contract);
     this._assertValidValue(options.value, this.contract);
@@ -223,6 +224,7 @@ class IgnitionModuleBuilderImplementation<
     options.value ??= BigInt(0);
 
     /* validation start */
+    this._assertValidId(options.id, this.contractFromArtifact);
     this._assertUniqueArtifactContractId(futureId);
     this._assertValidLibraries(options.libraries, this.contractFromArtifact);
     this._assertValidValue(options.value, this.contractFromArtifact);
@@ -269,6 +271,7 @@ class IgnitionModuleBuilderImplementation<
     options.libraries ??= {};
 
     /* validation start */
+    this._assertValidId(options.id, this.library);
     this._assertUniqueLibraryId(futureId);
     this._assertValidLibraries(options.libraries, this.library);
     this._assertValidFrom(options.from, this.library);
@@ -305,6 +308,7 @@ class IgnitionModuleBuilderImplementation<
     options.libraries ??= {};
 
     /* validation start */
+    this._assertValidId(options.id, this.libraryFromArtifact);
     this._assertUniqueArtifactLibraryId(futureId);
     this._assertValidLibraries(options.libraries, this.libraryFromArtifact);
     this._assertValidFrom(options.from, this.libraryFromArtifact);
@@ -344,6 +348,7 @@ class IgnitionModuleBuilderImplementation<
     options.value ??= BigInt(0);
 
     /* validation start */
+    this._assertValidId(options.id, this.call);
     this._assertUniqueCallId(futureId);
     this._assertValidValue(options.value, this.call);
     this._assertValidFrom(options.from, this.call);
@@ -386,6 +391,7 @@ class IgnitionModuleBuilderImplementation<
     const futureId = `${this._module.id}:${contractFuture.contractName}#${id}`;
 
     /* validation start */
+    this._assertValidId(options.id, this.staticCall);
     this._assertUniqueStaticCallId(futureId);
     this._assertValidFrom(options.from, this.staticCall);
     this._assertValidCallableContract(contractFuture, this.staticCall);
@@ -429,6 +435,7 @@ class IgnitionModuleBuilderImplementation<
     const futureId = `${this._module.id}:${id}`;
 
     /* validation start */
+    this._assertValidId(options.id, this.contractAt);
     this._assertUniqueContractAtId(futureId);
     this._assertValidAddress(address, this.contractAt);
     /* validation end */
@@ -466,6 +473,7 @@ class IgnitionModuleBuilderImplementation<
     const futureId = `${this._module.id}:${id}`;
 
     /* validation start */
+    this._assertValidId(options.id, this.contractAtFromArtifact);
     this._assertUniqueContractAtFromArtifactId(futureId);
     this._assertValidAddress(address, this.contractAtFromArtifact);
     this._assertValidArtifact(artifact, this.contractAtFromArtifact);
@@ -529,6 +537,7 @@ class IgnitionModuleBuilderImplementation<
     const futureId = `${this._module.id}:${id}`;
 
     /* validation start */
+    this._assertValidId(options.id, this.readEventArgument);
     this._assertUniqueReadEventArgumentId(futureId);
     this._assertValidNameOrIndex(nameOrIndex, this.readEventArgument);
     /* validation end */
@@ -628,6 +637,21 @@ class IgnitionModuleBuilderImplementation<
     Error.captureStackTrace(validationError, func);
 
     throw validationError;
+  }
+
+  private _assertValidId(id: string | undefined, func: (...[]: any[]) => any) {
+    if (id === undefined) {
+      return;
+    }
+
+    if (/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(id)) {
+      return;
+    }
+
+    this._throwErrorWithStackTrace(
+      `The id "${id}" contains banned characters, ids can only contain alphanumerics, underscores or dashes`,
+      func
+    );
   }
 
   private _assertUniqueFutureId(

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -71,7 +71,7 @@ import {
   toSendDataFutureId,
 } from "./utils/future-id-builders";
 import {
-  isValidFunctionName,
+  isValidFunctionOrEventName,
   isValidIgnitionIdentifier,
   isValidSolidityIdentifier,
 } from "./utils/identifier-validators";
@@ -725,7 +725,7 @@ class IgnitionModuleBuilderImplementation<
     eventName: string,
     func: (...[]: any[]) => any
   ) {
-    if (isValidSolidityIdentifier(eventName)) {
+    if (isValidFunctionOrEventName(eventName)) {
       return;
     }
 
@@ -739,7 +739,7 @@ class IgnitionModuleBuilderImplementation<
     functionName: string,
     func: (...[]: any[]) => any
   ) {
-    if (isValidFunctionName(functionName)) {
+    if (isValidFunctionOrEventName(functionName)) {
       return;
     }
 

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -432,10 +432,10 @@ class IgnitionModuleBuilderImplementation<
     /* validation start */
     this._assertValidId(options.id, this.staticCall);
     this._assertValidFunctionName(functionName, this.staticCall);
+    this._assertValidNameOrIndex(nameOrIndex, this.staticCall);
     this._assertUniqueStaticCallId(futureId);
     this._assertValidFrom(options.from, this.staticCall);
     this._assertValidCallableContract(contractFuture, this.staticCall);
-    this._assertValidNameOrIndex(nameOrIndex, this.staticCall);
     /* validation end */
 
     const future = new NamedStaticCallFutureImplementation(

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -70,23 +70,17 @@ import {
   toReadEventArgumentFutureId,
   toSendDataFutureId,
 } from "./utils/future-id-builders";
+import {
+  isValidFunctionName,
+  isValidIgnitionIdentifier,
+  isValidSolidityIdentifier,
+} from "./utils/identifier-validators";
 
 const STUB_MODULE_RESULTS = {
   [inspect.custom](): string {
     return "<Module being constructed - No results available yet>";
   },
 };
-
-/**
- * The regex that solidity uses to validate identifiers.
- */
-const solidityIdentifierRegex = /^[a-zA-Z$_][a-zA-Z0-9$_]*$/;
-
-/**
- * A regex capturing the solidity identifier rule but extended to support
- * the `myfun(uint256,bool)` parameter syntax
- */
-const functionNameRegex = /^[a-zA-Z$_][a-zA-Z0-9$_,()]*$/;
 
 /**
  * This class is in charge of turning `IgnitionModuleDefinition`s into
@@ -703,12 +697,12 @@ class IgnitionModuleBuilderImplementation<
       return;
     }
 
-    if (/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(id)) {
+    if (isValidIgnitionIdentifier(id)) {
       return;
     }
 
     this._throwErrorWithStackTrace(
-      `The id "${id}" contains banned characters, ids can only contain alphanumerics, underscores or dashes`,
+      `The id "${id}" contains banned characters, ids can only contain alphanumerics or underscores`,
       func
     );
   }
@@ -717,7 +711,7 @@ class IgnitionModuleBuilderImplementation<
     contractName: string,
     func: (...[]: any[]) => any
   ) {
-    if (solidityIdentifierRegex.test(contractName)) {
+    if (isValidSolidityIdentifier(contractName)) {
       return;
     }
 
@@ -731,7 +725,7 @@ class IgnitionModuleBuilderImplementation<
     eventName: string,
     func: (...[]: any[]) => any
   ) {
-    if (solidityIdentifierRegex.test(eventName)) {
+    if (isValidSolidityIdentifier(eventName)) {
       return;
     }
 
@@ -745,7 +739,7 @@ class IgnitionModuleBuilderImplementation<
     functionName: string,
     func: (...[]: any[]) => any
   ) {
-    if (functionNameRegex.test(functionName)) {
+    if (isValidFunctionName(functionName)) {
       return;
     }
 
@@ -893,18 +887,22 @@ class IgnitionModuleBuilderImplementation<
     artifact: Artifact,
     func: (...[]: any[]) => any
   ) {
-    if (!isArtifactType(artifact)) {
-      this._throwErrorWithStackTrace(`Invalid artifact given`, func);
+    if (isArtifactType(artifact)) {
+      return;
     }
+
+    this._throwErrorWithStackTrace(`Invalid artifact given`, func);
   }
 
   private _assertValidCallableContract(
     contract: CallableContractFuture<string>,
     func: (...[]: any[]) => any
   ) {
-    if (!isCallableContractFuture(contract)) {
-      this._throwErrorWithStackTrace(`Invalid contract given`, func);
+    if (isCallableContractFuture(contract)) {
+      return;
     }
+
+    this._throwErrorWithStackTrace(`Invalid contract given`, func);
   }
 
   private _assertValidNameOrIndex(
@@ -919,7 +917,7 @@ class IgnitionModuleBuilderImplementation<
       return;
     }
 
-    if (solidityIdentifierRegex.test(nameOrIndex)) {
+    if (isValidSolidityIdentifier(nameOrIndex)) {
       return;
     }
 

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -590,12 +590,11 @@ class IgnitionModuleBuilderImplementation<
     data?: string,
     options: SendDataOptions = {}
   ): SendDataFuture {
-    const futureId = `${this._module.id}:${options.id ?? id}`;
+    const futureId = `${this._module.id}:${id}`;
     const val = value ?? BigInt(0);
 
     /* validation start */
     this._assertValidId(id, this.send);
-    this._assertValidId(options.id, this.send);
     this._assertUniqueSendId(futureId);
     this._assertValidAddress(to, this.send);
     this._assertValidValue(val, this.send);

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -72,6 +72,17 @@ const STUB_MODULE_RESULTS = {
 };
 
 /**
+ * The regex that solidity uses to validate identifiers.
+ */
+const solidityIdentifierRegex = /^[a-zA-Z$_][a-zA-Z0-9$_]*$/;
+
+/**
+ * A regex capturing the solidity identifier rule but extended to support
+ * the `myfun(uint256,bool)` parameter syntax
+ */
+const functionNameRegex = /^[a-zA-Z$_][a-zA-Z0-9$_,()]*$/;
+
+/**
  * This class is in charge of turning `IgnitionModuleDefinition`s into
  * `IgnitionModule`s.
  *
@@ -179,6 +190,7 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.contract);
+    this._assertValidContractName(contractName, this.contract);
     this._assertUniqueContractId(futureId);
     this._assertValidLibraries(options.libraries, this.contract);
     this._assertValidValue(options.value, this.contract);
@@ -225,6 +237,7 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.contractFromArtifact);
+    this._assertValidContractName(contractName, this.contractFromArtifact);
     this._assertUniqueArtifactContractId(futureId);
     this._assertValidLibraries(options.libraries, this.contractFromArtifact);
     this._assertValidValue(options.value, this.contractFromArtifact);
@@ -272,6 +285,7 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.library);
+    this._assertValidContractName(libraryName, this.library);
     this._assertUniqueLibraryId(futureId);
     this._assertValidLibraries(options.libraries, this.library);
     this._assertValidFrom(options.from, this.library);
@@ -309,6 +323,7 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.libraryFromArtifact);
+    this._assertValidContractName(libraryName, this.libraryFromArtifact);
     this._assertUniqueArtifactLibraryId(futureId);
     this._assertValidLibraries(options.libraries, this.libraryFromArtifact);
     this._assertValidFrom(options.from, this.libraryFromArtifact);
@@ -349,6 +364,7 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.call);
+    this._assertValidFunctionName(functionName, this.call);
     this._assertUniqueCallId(futureId);
     this._assertValidValue(options.value, this.call);
     this._assertValidFrom(options.from, this.call);
@@ -392,6 +408,7 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.staticCall);
+    this._assertValidFunctionName(functionName, this.staticCall);
     this._assertUniqueStaticCallId(futureId);
     this._assertValidFrom(options.from, this.staticCall);
     this._assertValidCallableContract(contractFuture, this.staticCall);
@@ -436,6 +453,7 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.contractAt);
+    this._assertValidContractName(contractName, this.contractAt);
     this._assertUniqueContractAtId(futureId);
     this._assertValidAddress(address, this.contractAt);
     /* validation end */
@@ -474,6 +492,7 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.contractAtFromArtifact);
+    this._assertValidContractName(contractName, this.contractAt);
     this._assertUniqueContractAtFromArtifactId(futureId);
     this._assertValidAddress(address, this.contractAtFromArtifact);
     this._assertValidArtifact(artifact, this.contractAtFromArtifact);
@@ -538,6 +557,8 @@ class IgnitionModuleBuilderImplementation<
 
     /* validation start */
     this._assertValidId(options.id, this.readEventArgument);
+    this._assertValidEventName(eventName, this.readEventArgument);
+    this._assertValidArgumentName(argumentName, this.readEventArgument);
     this._assertUniqueReadEventArgumentId(futureId);
     this._assertValidNameOrIndex(nameOrIndex, this.readEventArgument);
     /* validation end */
@@ -573,6 +594,8 @@ class IgnitionModuleBuilderImplementation<
     const val = value ?? BigInt(0);
 
     /* validation start */
+    this._assertValidId(id, this.send);
+    this._assertValidId(options.id, this.send);
     this._assertUniqueSendId(futureId);
     this._assertValidAddress(to, this.send);
     this._assertValidValue(val, this.send);
@@ -650,6 +673,62 @@ class IgnitionModuleBuilderImplementation<
 
     this._throwErrorWithStackTrace(
       `The id "${id}" contains banned characters, ids can only contain alphanumerics, underscores or dashes`,
+      func
+    );
+  }
+
+  private _assertValidContractName(
+    contractName: string,
+    func: (...[]: any[]) => any
+  ) {
+    if (solidityIdentifierRegex.test(contractName)) {
+      return;
+    }
+
+    this._throwErrorWithStackTrace(
+      `The contract "${contractName}" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs`,
+      func
+    );
+  }
+
+  private _assertValidEventName(
+    eventName: string,
+    func: (...[]: any[]) => any
+  ) {
+    if (solidityIdentifierRegex.test(eventName)) {
+      return;
+    }
+
+    this._throwErrorWithStackTrace(
+      `The event "${eventName}" contains banned characters, event names can only contain alphanumerics, underscores or dollar signs`,
+      func
+    );
+  }
+
+  private _assertValidArgumentName(
+    argName: string,
+    func: (...[]: any[]) => any
+  ) {
+    if (solidityIdentifierRegex.test(argName)) {
+      return;
+    }
+
+    this._throwErrorWithStackTrace(
+      `The argument "${argName}" contains banned characters, argument names can only contain alphanumerics, underscores or dollar signs`,
+      func
+    );
+  }
+
+  private _assertValidFunctionName(
+    functionName: string,
+    func: (...[]: any[]) => any
+  ) {
+    if (functionNameRegex.test(functionName)) {
+      return;
+    }
+
+    this._throwErrorWithStackTrace(
+      `The function name "${functionName}" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs`,
       func
     );
   }

--- a/packages/core/src/internal/utils/future-id-builders.ts
+++ b/packages/core/src/internal/utils/future-id-builders.ts
@@ -2,12 +2,12 @@
  * The seperator in ids that indicated before as the module id and after
  * as the parts making up the particular future.
  */
-const MODULE_SEPERATOR = ":";
+const MODULE_SEPERATOR = "#";
 
 /**
  * The seperator in ids that indicated different subparts of the future key.
  */
-const SUBKEY_SEPERATOR = "#";
+const SUBKEY_SEPERATOR = ".";
 
 /**
  * Construct the future id for a contract or library deployment, namespaced by the
@@ -77,7 +77,7 @@ export function toReadEventArgumentFutureId(
 ) {
   const futureKey =
     userProvidedId ??
-    `${contractName}#${eventName}${SUBKEY_SEPERATOR}${nameOrIndex}${SUBKEY_SEPERATOR}${eventIndex}`;
+    `${contractName}${SUBKEY_SEPERATOR}${eventName}${SUBKEY_SEPERATOR}${nameOrIndex}${SUBKEY_SEPERATOR}${eventIndex}`;
 
   return `${moduleId}${MODULE_SEPERATOR}${futureKey}`;
 }

--- a/packages/core/src/internal/utils/future-id-builders.ts
+++ b/packages/core/src/internal/utils/future-id-builders.ts
@@ -46,9 +46,10 @@ export function toCallFutureId(
   contractName: string,
   functionName: string
 ) {
-  return `${moduleId}${MODULE_SEPERATOR}${contractName}${SUBKEY_SEPERATOR}${
-    userProvidedId ?? functionName
-  }`;
+  const futureKey =
+    userProvidedId ?? `${contractName}${SUBKEY_SEPERATOR}${functionName}`;
+
+  return `${moduleId}${MODULE_SEPERATOR}${futureKey}`;
 }
 
 /**

--- a/packages/core/src/internal/utils/future-id-builders.ts
+++ b/packages/core/src/internal/utils/future-id-builders.ts
@@ -1,0 +1,94 @@
+/**
+ * The seperator in ids that indicated before as the module id and after
+ * as the parts making up the particular future.
+ */
+const MODULE_SEPERATOR = ":";
+
+/**
+ * The seperator in ids that indicated different subparts of the future key.
+ */
+const SUBKEY_SEPERATOR = "#";
+
+/**
+ * Construct the future id for a contract or library deployment, namespaced by the
+ * moduleId.
+ *
+ * @param moduleId - the id of the module the future is part of
+ * @param userProvidedId - the overriding id provided by the user (it will still
+ * be namespaced)
+ * @param contractOrLibraryName - the contract or library name as a fallback
+ * @returns the future id
+ */
+export function toDeploymentFutureId(
+  moduleId: string,
+  userProvidedId: string | undefined,
+  contractOrLibraryName: string
+) {
+  return `${moduleId}${MODULE_SEPERATOR}${
+    userProvidedId ?? contractOrLibraryName
+  }`;
+}
+
+/**
+ * Construct the future id for a call or static call, namespaced by the moduleId.
+ *
+ * @param moduleId - the id of the module the future is part of
+ * @param userProvidedId - the overriding id provided by the user (it will still
+ * be namespaced)
+ * @param contractName - the contract or library name that forms part of the
+ * fallback
+ * @param functionName - the function name that forms part of the fallback
+ * @returns the future id
+ */
+export function toCallFutureId(
+  moduleId: string,
+  userProvidedId: string | undefined,
+  contractName: string,
+  functionName: string
+) {
+  return `${moduleId}${MODULE_SEPERATOR}${contractName}${SUBKEY_SEPERATOR}${
+    userProvidedId ?? functionName
+  }`;
+}
+
+/**
+ * Construct the future id for a read event argument future, namespaced by
+ * the moduleId.
+ *
+ * @param moduleId - the id of the module the future is part of
+ * @param userProvidedId - the overriding id provided by the user (it will still
+ * be namespaced)
+ * @param contractName - the contract or library name that forms part of the
+ * fallback
+ * @param eventName - the event name that forms part of the fallback
+ * @param nameOrIndex - the argument name or argumentindex that forms part
+ * of the fallback
+ * @param eventIndex - the event index that forms part of the fallback
+ * @returns the future id
+ */
+export function toReadEventArgumentFutureId(
+  moduleId: string,
+  userProvidedId: string | undefined,
+  contractName: string,
+  eventName: string,
+  nameOrIndex: string | number,
+  eventIndex: number
+) {
+  const futureKey =
+    userProvidedId ??
+    `${contractName}#${eventName}${SUBKEY_SEPERATOR}${nameOrIndex}${SUBKEY_SEPERATOR}${eventIndex}`;
+
+  return `${moduleId}${MODULE_SEPERATOR}${futureKey}`;
+}
+
+/**
+ * Construct the future id for a send data future, namespaced by the moduleId.
+ *
+ * @param moduleId - the id of the module the future is part of
+ * @param userProvidedId - the overriding id provided by the user (it will still
+ * be namespaced)
+ * @returns the future id
+ */
+export function toSendDataFutureId(moduleId: string, userProvidedId: string) {
+  return `${moduleId}${MODULE_SEPERATOR}${userProvidedId}`;
+}

--- a/packages/core/src/internal/utils/identifier-validators.ts
+++ b/packages/core/src/internal/utils/identifier-validators.ts
@@ -39,13 +39,13 @@ export function isValidSolidityIdentifier(identifier: string): boolean {
 }
 
 /**
- * Does the function name match Ignition's rules for function names. This is
+ * Does the function or event name match Ignition's rules. This is
  * looser than Solidity's rules, but allows Ethers style `myfun(uint256,bool)`
- * function specification.
+ * function/event specifications.
  *
  * @param functionName - the function name to test
  * @returns true if the function name is valid
  */
-export function isValidFunctionName(functionName: string): boolean {
+export function isValidFunctionOrEventName(functionName: string): boolean {
   return functionNameRegex.test(functionName);
 }

--- a/packages/core/src/internal/utils/identifier-validators.ts
+++ b/packages/core/src/internal/utils/identifier-validators.ts
@@ -1,0 +1,51 @@
+/**
+ * A regex that captures Ignitions rules for user provided ids, specifically
+ * that they can only contain alphanumerics and underscores, and that they
+ * start with a letter.
+ */
+const ignitionIdRegex = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+
+/**
+ * The regex that captures Solidity's identifier rule.
+ */
+const solidityIdentifierRegex = /^[a-zA-Z$_][a-zA-Z0-9$_]*$/;
+
+/**
+ * A regex capturing the solidity identifier rule but extended to support
+ * the `myfun(uint256,bool)` parameter syntax
+ */
+const functionNameRegex = /^[a-zA-Z$_][a-zA-Z0-9$_,()]*$/;
+
+/**
+ * Does the identifier match Ignition's rules for ids. Specifically that they
+ * started with a letter and only contain alphanumerics and underscores.
+ *
+ * @param identifier - the id to test
+ * @returns true if the identifier is valid
+ */
+export function isValidIgnitionIdentifier(identifier: string): boolean {
+  return ignitionIdRegex.test(identifier);
+}
+
+/**
+ * Does the identifier match Solidity's rules for ids. See the Solidity
+ * language spec for more details.
+ *
+ * @param identifier - the id to test
+ * @returns true if the identifier is a valid Solidity identifier
+ */
+export function isValidSolidityIdentifier(identifier: string): boolean {
+  return solidityIdentifierRegex.test(identifier);
+}
+
+/**
+ * Does the function name match Ignition's rules for function names. This is
+ * looser than Solidity's rules, but allows Ethers style `myfun(uint256,bool)`
+ * function specification.
+ *
+ * @param functionName - the function name to test
+ * @returns true if the function name is valid
+ */
+export function isValidFunctionName(functionName: string): boolean {
+  return functionNameRegex.test(functionName);
+}

--- a/packages/core/src/types/module-builder.ts
+++ b/packages/core/src/types/module-builder.ts
@@ -135,7 +135,6 @@ export interface ReadEventArgumentOptions {
  * @beta
  */
 export interface SendDataOptions {
-  id?: string;
   after?: Future[];
   from?: string | AccountRuntimeValue;
 }

--- a/packages/core/test/batcher.ts
+++ b/packages/core/test/batcher.ts
@@ -35,7 +35,7 @@ describe("batcher", () => {
       return { contract1 };
     });
 
-    assertBatching({ ignitionModule }, [["Module1:Contract1"]]);
+    assertBatching({ ignitionModule }, [["Module1#Contract1"]]);
   });
 
   it("should batch through dependencies", () => {
@@ -57,9 +57,9 @@ describe("batcher", () => {
     });
 
     assertBatching({ ignitionModule }, [
-      ["Module1:Contract1", "Module1:Contract2"],
-      ["Module1:Contract3"],
-      ["Module1:Contract4", "Module1:Contract5"],
+      ["Module1#Contract1", "Module1#Contract2"],
+      ["Module1#Contract3"],
+      ["Module1#Contract4", "Module1#Contract5"],
     ]);
   });
 
@@ -98,15 +98,15 @@ describe("batcher", () => {
     });
 
     assertBatching({ ignitionModule }, [
-      ["SubmoduleLeft:Contract1", "SubmoduleRight:Contract2"],
+      ["SubmoduleLeft#Contract1", "SubmoduleRight#Contract2"],
       [
-        "SubmoduleLeft:Contract1#configure",
-        "SubmoduleRight:Contract2#configure",
+        "SubmoduleLeft#Contract1.configure",
+        "SubmoduleRight#Contract2.configure",
       ],
-      ["SubmoduleMiddle:Contract3"],
-      ["SubmoduleMiddle:Contract3#configure"],
-      ["Module:Contract4"],
-      ["Module:Contract4#configure"],
+      ["SubmoduleMiddle#Contract3"],
+      ["SubmoduleMiddle#Contract3.configure"],
+      ["Module#Contract4"],
+      ["Module#Contract4.configure"],
     ]);
   });
 
@@ -141,8 +141,8 @@ describe("batcher", () => {
     });
 
     assertBatching({ ignitionModule }, [
-      ["Left:Contract1", "Middle:Contract3", "Right:Contract2"],
-      ["Module:Contract4"],
+      ["Left#Contract1", "Middle#Contract3", "Right#Contract2"],
+      ["Module#Contract4"],
     ]);
   });
 
@@ -162,15 +162,15 @@ describe("batcher", () => {
         deploymentState: {
           chainId: 123,
           executionStates: {
-            "Module1:Contract2": {
+            "Module1#Contract2": {
               ...exampleDeploymentState,
-              id: "Module1:Contract2",
+              id: "Module1#Contract2",
               status: ExecutionStatus.SUCCESS,
             },
           },
         },
       },
-      [["Module1:Contract1"], ["Module1:Contract3"]]
+      [["Module1#Contract1"], ["Module1#Contract3"]]
     );
   });
 });

--- a/packages/core/test/call.ts
+++ b/packages/core/test/call.ts
@@ -29,7 +29,7 @@ describe("call", () => {
     assert.equal(moduleWithASingleContract.id, "Module1");
     assert.equal(
       moduleWithASingleContract.results.contract1.id,
-      "Module1:Contract1"
+      "Module1#Contract1"
     );
 
     // 1 contract future & 1 call future
@@ -60,15 +60,15 @@ describe("call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedContractCallFutureImplementation)) {
@@ -93,15 +93,15 @@ describe("call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedContractCallFutureImplementation)) {
@@ -125,7 +125,7 @@ describe("call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedContractCallFutureImplementation)) {
@@ -147,7 +147,7 @@ describe("call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedContractCallFutureImplementation)) {
@@ -172,7 +172,7 @@ describe("call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedContractCallFutureImplementation)) {
@@ -194,7 +194,7 @@ describe("call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedContractCallFutureImplementation)) {
@@ -383,11 +383,11 @@ describe("call", () => {
       assert.equal(moduleWithSameCallTwice.id, "Module1");
 
       const callFuture = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:first"
+        ({ id }) => id === "Module1#first"
       );
 
       const callFuture2 = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:second"
+        ({ id }) => id === "Module1#second"
       );
 
       assert.isDefined(callFuture);
@@ -404,7 +404,7 @@ describe("call", () => {
 
             return { sameContract1 };
           }),
-        /Duplicated id Module1:SameContract#test found in module Module1/
+        /Duplicated id Module1#SameContract.test found in module Module1/
       );
     });
 
@@ -417,7 +417,7 @@ describe("call", () => {
             m.call(sameContract1, "test", [], { id: "first" });
             return { sameContract1 };
           }),
-        /Duplicated id Module1:first found in module Module1/
+        /Duplicated id Module1#first found in module Module1/
       );
     });
   });

--- a/packages/core/test/call.ts
+++ b/packages/core/test/call.ts
@@ -383,11 +383,11 @@ describe("call", () => {
       assert.equal(moduleWithSameCallTwice.id, "Module1");
 
       const callFuture = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:Example#first"
+        ({ id }) => id === "Module1:first"
       );
 
       const callFuture2 = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:Example#second"
+        ({ id }) => id === "Module1:second"
       );
 
       assert.isDefined(callFuture);
@@ -417,7 +417,7 @@ describe("call", () => {
             m.call(sameContract1, "test", [], { id: "first" });
             return { sameContract1 };
           }),
-        /Duplicated id Module1:SameContract#first found in module Module1/
+        /Duplicated id Module1:first found in module Module1/
       );
     });
   });

--- a/packages/core/test/contract.ts
+++ b/packages/core/test/contract.ts
@@ -27,7 +27,7 @@ describe("contract", () => {
     assert.equal(moduleWithASingleContract.id, "Module1");
     assert.equal(
       moduleWithASingleContract.results.contract1.id,
-      "Module1:Contract1"
+      "Module1#Contract1"
     );
 
     // 1 contract future
@@ -52,11 +52,11 @@ describe("contract", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -80,11 +80,11 @@ describe("contract", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -110,11 +110,11 @@ describe("contract", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -138,7 +138,7 @@ describe("contract", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -162,7 +162,7 @@ describe("contract", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -187,7 +187,7 @@ describe("contract", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -209,7 +209,7 @@ describe("contract", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -368,11 +368,11 @@ describe("contract", () => {
       assert.equal(moduleWithSameContractTwice.id, "Module1");
       assert.equal(
         moduleWithSameContractTwice.results.sameContract1.id,
-        "Module1:first"
+        "Module1#first"
       );
       assert.equal(
         moduleWithSameContractTwice.results.sameContract2.id,
-        "Module1:second"
+        "Module1#second"
       );
     });
 
@@ -385,7 +385,7 @@ describe("contract", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:SameContract found in module Module1/
+        /Duplicated id Module1#SameContract found in module Module1/
       );
     });
 
@@ -402,7 +402,7 @@ describe("contract", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:same found in module Module1/
+        /Duplicated id Module1#same found in module Module1/
       );
     });
   });

--- a/packages/core/test/contractAt.ts
+++ b/packages/core/test/contractAt.ts
@@ -29,7 +29,7 @@ describe("contractAt", () => {
     assert.equal(moduleWithContractFromArtifact.id, "Module1");
     assert.equal(
       moduleWithContractFromArtifact.results.contract1.id,
-      "Module1:Contract1"
+      "Module1#Contract1"
     );
 
     // Stores the address
@@ -79,7 +79,7 @@ describe("contractAt", () => {
     const anotherFuture = moduleWithDependentContracts.results.another;
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#getAddress"
+      ({ id }) => id === "Module1#Example.getAddress"
     );
 
     assert.equal(anotherFuture.dependencies.size, 1);
@@ -139,11 +139,11 @@ describe("contractAt", () => {
       assert.equal(moduleWithSameContractTwice.id, "Module1");
       assert.equal(
         moduleWithSameContractTwice.results.sameContract1.id,
-        "Module1:first"
+        "Module1#first"
       );
       assert.equal(
         moduleWithSameContractTwice.results.sameContract2.id,
-        "Module1:second"
+        "Module1#second"
       );
     });
 
@@ -156,7 +156,7 @@ describe("contractAt", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:SameContract found in module Module1/
+        /Duplicated id Module1#SameContract found in module Module1/
       );
     });
 
@@ -183,7 +183,7 @@ describe("contractAt", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:same found in module Module1/
+        /Duplicated id Module1#same found in module Module1/
       );
     });
   });

--- a/packages/core/test/contractAtFromArtifact.ts
+++ b/packages/core/test/contractAtFromArtifact.ts
@@ -33,7 +33,7 @@ describe("contractAtFromArtifact", () => {
     assert.equal(moduleWithContractFromArtifact.id, "Module1");
     assert.equal(
       moduleWithContractFromArtifact.results.contract1.id,
-      "Module1:Contract1"
+      "Module1#Contract1"
     );
 
     // Stores the address
@@ -88,7 +88,7 @@ describe("contractAtFromArtifact", () => {
     const anotherFuture = moduleWithDependentContracts.results.another;
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#getAddress"
+      ({ id }) => id === "Module1#Example.getAddress"
     );
 
     assert.equal(anotherFuture.dependencies.size, 1);
@@ -156,11 +156,11 @@ describe("contractAtFromArtifact", () => {
       assert.equal(moduleWithSameContractTwice.id, "Module1");
       assert.equal(
         moduleWithSameContractTwice.results.sameContract1.id,
-        "Module1:first"
+        "Module1#first"
       );
       assert.equal(
         moduleWithSameContractTwice.results.sameContract2.id,
-        "Module1:second"
+        "Module1#second"
       );
     });
 
@@ -181,7 +181,7 @@ describe("contractAtFromArtifact", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:SameContract found in module Module1/
+        /Duplicated id Module1#SameContract found in module Module1/
       );
     });
 
@@ -208,7 +208,7 @@ describe("contractAtFromArtifact", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:same found in module Module1/
+        /Duplicated id Module1#same found in module Module1/
       );
     });
   });

--- a/packages/core/test/contractFromArtifact.ts
+++ b/packages/core/test/contractFromArtifact.ts
@@ -37,7 +37,7 @@ describe("contractFromArtifact", () => {
     assert.equal(moduleWithContractFromArtifact.id, "Module1");
     assert.equal(
       moduleWithContractFromArtifact.results.contract1.id,
-      "Module1:Contract1"
+      "Module1#Contract1"
     );
 
     // Stores the arguments
@@ -104,11 +104,11 @@ describe("contractFromArtifact", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -134,7 +134,7 @@ describe("contractFromArtifact", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -158,7 +158,7 @@ describe("contractFromArtifact", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -185,7 +185,7 @@ describe("contractFromArtifact", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -209,7 +209,7 @@ describe("contractFromArtifact", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -400,11 +400,11 @@ describe("contractFromArtifact", () => {
       assert.equal(moduleWithSameContractTwice.id, "Module1");
       assert.equal(
         moduleWithSameContractTwice.results.sameContract1.id,
-        "Module1:first"
+        "Module1#first"
       );
       assert.equal(
         moduleWithSameContractTwice.results.sameContract2.id,
-        "Module1:second"
+        "Module1#second"
       );
     });
 
@@ -423,7 +423,7 @@ describe("contractFromArtifact", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:SameContract found in module Module1/
+        /Duplicated id Module1#SameContract found in module Module1/
       );
     });
 
@@ -450,7 +450,7 @@ describe("contractFromArtifact", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:same found in module Module1/
+        /Duplicated id Module1#same found in module Module1/
       );
     });
   });

--- a/packages/core/test/library.ts
+++ b/packages/core/test/library.ts
@@ -25,7 +25,7 @@ describe("library", () => {
     assert.equal(moduleWithASingleContract.id, "Module1");
     assert.equal(
       moduleWithASingleContract.results.library1.id,
-      "Module1:Library1"
+      "Module1#Library1"
     );
 
     // 1 contract future
@@ -50,11 +50,11 @@ describe("library", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -80,11 +80,11 @@ describe("library", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -110,7 +110,7 @@ describe("library", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -134,7 +134,7 @@ describe("library", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -161,11 +161,11 @@ describe("library", () => {
       assert.equal(moduleWithSameContractTwice.id, "Module1");
       assert.equal(
         moduleWithSameContractTwice.results.sameContract1.id,
-        "Module1:first"
+        "Module1#first"
       );
       assert.equal(
         moduleWithSameContractTwice.results.sameContract2.id,
-        "Module1:second"
+        "Module1#second"
       );
     });
 
@@ -178,7 +178,7 @@ describe("library", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:SameContract found in module Module1/
+        /Duplicated id Module1#SameContract found in module Module1/
       );
     });
 
@@ -195,7 +195,7 @@ describe("library", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:same found in module Module1/
+        /Duplicated id Module1#same found in module Module1/
       );
     });
   });

--- a/packages/core/test/libraryFromArtifact.ts
+++ b/packages/core/test/libraryFromArtifact.ts
@@ -32,7 +32,7 @@ describe("libraryFromArtifact", () => {
     assert.equal(moduleWithContractFromArtifact.id, "Module1");
     assert.equal(
       moduleWithContractFromArtifact.results.library1.id,
-      "Module1:Library1"
+      "Module1#Library1"
     );
 
     // 1 contract future
@@ -74,11 +74,11 @@ describe("libraryFromArtifact", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -104,7 +104,7 @@ describe("libraryFromArtifact", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -128,7 +128,7 @@ describe("libraryFromArtifact", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     if (
@@ -164,11 +164,11 @@ describe("libraryFromArtifact", () => {
       assert.equal(moduleWithSameContractTwice.id, "Module1");
       assert.equal(
         moduleWithSameContractTwice.results.sameContract1.id,
-        "Module1:first"
+        "Module1#first"
       );
       assert.equal(
         moduleWithSameContractTwice.results.sameContract2.id,
-        "Module1:second"
+        "Module1#second"
       );
     });
 
@@ -187,7 +187,7 @@ describe("libraryFromArtifact", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:SameContract found in module Module1/
+        /Duplicated id Module1#SameContract found in module Module1/
       );
     });
 
@@ -212,7 +212,7 @@ describe("libraryFromArtifact", () => {
 
             return { sameContract1, sameContract2 };
           }),
-        /Duplicated id Module1:same found in module Module1/
+        /Duplicated id Module1#same found in module Module1/
       );
     });
   });

--- a/packages/core/test/readEventArgument.ts
+++ b/packages/core/test/readEventArgument.ts
@@ -161,8 +161,8 @@ describe("Read event argument", () => {
       assert.equal(mod.id, "Module1");
       const futuresIds = Array.from(mod.futures).map((f) => f.id);
 
-      assert.include(futuresIds, "Module1:Main#EventName#arg1#0");
-      assert.include(futuresIds, "Module1:Emitter#EventName2#arg2#1");
+      assert.include(futuresIds, "Module1#Main.EventName.arg1.0");
+      assert.include(futuresIds, "Module1#Emitter.EventName2.arg2.1");
     });
 
     it("should be able to read the same argument twice by passing a explicit id", () => {
@@ -185,8 +185,8 @@ describe("Read event argument", () => {
         moduleWithSameReadEventArgumentTwice.futures
       ).map((f) => f.id);
 
-      assert.include(futuresIds, "Module1:Example#EventName#arg1#0");
-      assert.include(futuresIds, "Module1:second");
+      assert.include(futuresIds, "Module1#Example.EventName.arg1.0");
+      assert.include(futuresIds, "Module1#second");
     });
   });
 

--- a/packages/core/test/readEventArgument.ts
+++ b/packages/core/test/readEventArgument.ts
@@ -211,6 +211,7 @@ describe("Read event argument", () => {
           () =>
             buildModule("Module1", (m) => {
               const another = m.contract("Another", []);
+
               m.readEventArgument(another, "test", {} as any);
 
               return { another };

--- a/packages/core/test/reconciliation/futures/reconcileArtifactContractAt.ts
+++ b/packages/core/test/reconciliation/futures/reconcileArtifactContractAt.ts
@@ -86,7 +86,7 @@ describe("Reconciliation - artifact contract at", () => {
 
     const deploymentState = createDeploymentState({
       ...exampleContractAtState,
-      id: `Submodule:Contract1`,
+      id: `Submodule#Contract1`,
       futureType: FutureType.ARTIFACT_CONTRACT_AT,
       status: ExecutionStatus.STARTED,
       contractAddress: exampleAddress,
@@ -109,7 +109,7 @@ describe("Reconciliation - artifact contract at", () => {
     const deploymentState = createDeploymentState(
       {
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
         status: ExecutionStatus.SUCCESS,
         contractName: "Example",
@@ -120,7 +120,7 @@ describe("Reconciliation - artifact contract at", () => {
       },
       {
         ...exampleStaticCallState,
-        id: "Module:Example#getAddress",
+        id: "Module#Example.getAddress",
         futureType: FutureType.NAMED_STATIC_CALL,
         status: ExecutionStatus.SUCCESS,
         functionName: "getAddress",
@@ -131,7 +131,7 @@ describe("Reconciliation - artifact contract at", () => {
       },
       {
         ...exampleContractAtState,
-        id: "Module:Another",
+        id: "Module#Another",
         futureType: FutureType.ARTIFACT_CONTRACT_AT,
         status: ExecutionStatus.STARTED,
         contractName: "Another",
@@ -161,7 +161,7 @@ describe("Reconciliation - artifact contract at", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleContractAtState,
-        id: "Module:Factory",
+        id: "Module#Factory",
         futureType: FutureType.ARTIFACT_CONTRACT_AT,
         status: ExecutionStatus.STARTED,
         contractName: "ContractUnchanged",
@@ -172,7 +172,7 @@ describe("Reconciliation - artifact contract at", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Factory",
+        futureId: "Module#Factory",
         failure:
           "Contract name has been changed from ContractUnchanged to ContractChanged",
       },
@@ -197,7 +197,7 @@ describe("Reconciliation - artifact contract at", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleContractAtState,
-        id: "Module:Factory",
+        id: "Module#Factory",
         futureType: FutureType.ARTIFACT_CONTRACT_AT,
         status: ExecutionStatus.STARTED,
         contractAddress: differentAddress,
@@ -206,7 +206,7 @@ describe("Reconciliation - artifact contract at", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Factory",
+        futureId: "Module#Factory",
         failure:
           "Address has been changed from 0xBA12222222228d8Ba445958a75a0704d566BF2C8 to 0x1F98431c8aD98523631AE4a59f267346ea31F984",
       },

--- a/packages/core/test/reconciliation/futures/reconcileArtifactContractDeployment.ts
+++ b/packages/core/test/reconciliation/futures/reconcileArtifactContractDeployment.ts
@@ -67,7 +67,7 @@ describe("Reconciliation - artifact contract", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Submodule:SafeMath",
+          id: "Submodule#SafeMath",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "SafeMath",
@@ -78,7 +78,7 @@ describe("Reconciliation - artifact contract", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Submodule:Contract1",
+          id: "Submodule#Contract1",
           futureType: FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.STARTED,
           constructorArgs: [{ supply: BigInt(1000) }],
@@ -106,7 +106,7 @@ describe("Reconciliation - artifact contract", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         futureType: FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
         status: ExecutionStatus.STARTED,
         contractName: "ContractUnchanged",
@@ -115,7 +115,7 @@ describe("Reconciliation - artifact contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure:
           "Contract name has been changed from ContractUnchanged to ContractChanged",
       },
@@ -141,7 +141,7 @@ describe("Reconciliation - artifact contract", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Contract1",
+        id: "Module#Contract1",
         futureType: FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
         status: ExecutionStatus.STARTED,
         constructorArgs: [
@@ -154,7 +154,7 @@ describe("Reconciliation - artifact contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1",
+        futureId: "Module#Contract1",
         failure: "Argument at index 2 has been changed",
       },
     ]);
@@ -178,7 +178,7 @@ describe("Reconciliation - artifact contract", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:SafeMath",
+          id: "Module#SafeMath",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "SafeMath",
@@ -189,7 +189,7 @@ describe("Reconciliation - artifact contract", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           futureType: FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.STARTED,
           libraries: {},
@@ -199,7 +199,7 @@ describe("Reconciliation - artifact contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1",
+        futureId: "Module#Contract1",
         failure: "Library SafeMath has been added",
       },
     ]);
@@ -219,7 +219,7 @@ describe("Reconciliation - artifact contract", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         futureType: FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
         status: ExecutionStatus.STARTED,
         value: BigInt(3),
@@ -228,7 +228,7 @@ describe("Reconciliation - artifact contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure: "Value has been changed from 3 to 4",
       },
     ]);
@@ -248,7 +248,7 @@ describe("Reconciliation - artifact contract", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         futureType: FutureType.ARTIFACT_CONTRACT_DEPLOYMENT,
         status: ExecutionStatus.STARTED,
         from: oneAddress,
@@ -257,7 +257,7 @@ describe("Reconciliation - artifact contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure: `From account has been changed from ${oneAddress} to ${twoAddress}`,
       },
     ]);

--- a/packages/core/test/reconciliation/futures/reconcileArtifactLibraryDeployment.ts
+++ b/packages/core/test/reconciliation/futures/reconcileArtifactLibraryDeployment.ts
@@ -59,7 +59,7 @@ describe("Reconciliation - artifact library", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Submodule:SafeMath",
+          id: "Submodule#SafeMath",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "SafeMath",
@@ -70,7 +70,7 @@ describe("Reconciliation - artifact library", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Submodule:MainLibrary",
+          id: "Submodule#MainLibrary",
           futureType: FutureType.ARTIFACT_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.STARTED,
           contractName: "MainLibrary",
@@ -95,7 +95,7 @@ describe("Reconciliation - artifact library", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         futureType: FutureType.ARTIFACT_LIBRARY_DEPLOYMENT,
         status: ExecutionStatus.STARTED,
         contractName: "LibraryUnchanged",
@@ -104,7 +104,7 @@ describe("Reconciliation - artifact library", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure:
           "Contract name has been changed from LibraryUnchanged to LibraryChanged",
       },
@@ -127,7 +127,7 @@ describe("Reconciliation - artifact library", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:SafeMath",
+          id: "Module#SafeMath",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "SafeMath",
@@ -138,7 +138,7 @@ describe("Reconciliation - artifact library", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Module:MainLibrary",
+          id: "Module#MainLibrary",
           futureType: FutureType.ARTIFACT_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.STARTED,
           contractName: "MainLibrary",
@@ -151,7 +151,7 @@ describe("Reconciliation - artifact library", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:MainLibrary",
+        futureId: "Module#MainLibrary",
         failure: "Library Unchanged has been removed",
       },
     ]);
@@ -171,7 +171,7 @@ describe("Reconciliation - artifact library", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         futureType: FutureType.ARTIFACT_LIBRARY_DEPLOYMENT,
         status: ExecutionStatus.STARTED,
         contractName: "Library1",
@@ -181,7 +181,7 @@ describe("Reconciliation - artifact library", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure: `From account has been changed from ${oneAddress} to ${twoAddress}`,
       },
     ]);

--- a/packages/core/test/reconciliation/futures/reconcileNamedContractAt.ts
+++ b/packages/core/test/reconciliation/futures/reconcileNamedContractAt.ts
@@ -81,7 +81,7 @@ describe("Reconciliation - named contract at", () => {
 
     const deploymentState = createDeploymentState({
       ...exampleContractAtState,
-      id: `Submodule:Contract1`,
+      id: `Submodule#Contract1`,
       futureType: FutureType.NAMED_CONTRACT_AT,
       status: ExecutionStatus.STARTED,
       contractAddress: exampleAddress,
@@ -103,7 +103,7 @@ describe("Reconciliation - named contract at", () => {
     const previousExecutionState = createDeploymentState(
       {
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
         status: ExecutionStatus.SUCCESS,
         contractName: "Example",
@@ -114,7 +114,7 @@ describe("Reconciliation - named contract at", () => {
       },
       {
         ...exampleStaticCallState,
-        id: "Module:Example#getAddress",
+        id: "Module#Example.getAddress",
         futureType: FutureType.NAMED_STATIC_CALL,
         status: ExecutionStatus.SUCCESS,
         functionName: "getAddress",
@@ -125,7 +125,7 @@ describe("Reconciliation - named contract at", () => {
       },
       {
         ...exampleContractAtState,
-        id: "Module:Another",
+        id: "Module#Another",
         futureType: FutureType.NAMED_CONTRACT_AT,
         status: ExecutionStatus.STARTED,
         contractAddress: differentAddress,
@@ -149,7 +149,7 @@ describe("Reconciliation - named contract at", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleContractAtState,
-        id: "Module:Factory",
+        id: "Module#Factory",
         futureType: FutureType.NAMED_CONTRACT_AT,
         status: ExecutionStatus.STARTED,
         contractName: "ContractUnchanged",
@@ -159,7 +159,7 @@ describe("Reconciliation - named contract at", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Factory",
+        futureId: "Module#Factory",
         failure:
           "Contract name has been changed from ContractUnchanged to ContractChanged",
       },
@@ -179,7 +179,7 @@ describe("Reconciliation - named contract at", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleContractAtState,
-        id: "Module:Factory",
+        id: "Module#Factory",
         futureType: FutureType.NAMED_CONTRACT_AT,
         status: ExecutionStatus.STARTED,
         contractAddress: differentAddress,
@@ -188,7 +188,7 @@ describe("Reconciliation - named contract at", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Factory",
+        futureId: "Module#Factory",
         failure:
           "Address has been changed from 0xBA12222222228d8Ba445958a75a0704d566BF2C8 to 0x1F98431c8aD98523631AE4a59f267346ea31F984",
       },

--- a/packages/core/test/reconciliation/futures/reconcileNamedContractCall.ts
+++ b/packages/core/test/reconciliation/futures/reconcileNamedContractCall.ts
@@ -117,7 +117,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:Contract1#config",
+          id: "Module:config",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "function1",
@@ -128,7 +128,7 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#config",
+        futureId: "Module:config",
         failure:
           "Contract address has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (future Module:Contract1)",
       },
@@ -158,7 +158,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:Contract1#config",
+          id: "Module:config",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "functionUnchanged",
@@ -168,7 +168,7 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#config",
+        futureId: "Module:config",
         failure:
           "Function name has been changed from functionUnchanged to functionChanged",
       },
@@ -240,7 +240,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:Contract1#config",
+          id: "Module:config",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "function1",
@@ -251,7 +251,7 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#config",
+        futureId: "Module:config",
         failure: "Value has been changed from 2 to 3",
       },
     ]);
@@ -280,7 +280,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:Contract1#config",
+          id: "Module:config",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "function1",
@@ -291,7 +291,7 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#config",
+        futureId: "Module:config",
         failure: `From account has been changed from ${oneAddress} to ${twoAddress}`,
       },
     ]);

--- a/packages/core/test/reconciliation/futures/reconcileNamedContractCall.ts
+++ b/packages/core/test/reconciliation/futures/reconcileNamedContractCall.ts
@@ -75,7 +75,7 @@ describe("Reconciliation - named contract call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Submodule:Contract1",
+          id: "Submodule#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -84,7 +84,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Submodule:Contract1#function1",
+          id: "Submodule#Contract1.function1",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.SUCCESS,
           functionName: "function1",
@@ -108,7 +108,7 @@ describe("Reconciliation - named contract call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -117,7 +117,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:config",
+          id: "Module#config",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "function1",
@@ -128,9 +128,9 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:config",
+        futureId: "Module#config",
         failure:
-          "Contract address has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (future Module:Contract1)",
+          "Contract address has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (future Module#Contract1)",
       },
     ]);
   });
@@ -149,7 +149,7 @@ describe("Reconciliation - named contract call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -158,7 +158,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:config",
+          id: "Module#config",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "functionUnchanged",
@@ -168,7 +168,7 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:config",
+        futureId: "Module#config",
         failure:
           "Function name has been changed from functionUnchanged to functionChanged",
       },
@@ -191,7 +191,7 @@ describe("Reconciliation - named contract call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -200,7 +200,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:Contract1#function1",
+          id: "Module#Contract1.function1",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "function1",
@@ -211,7 +211,7 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#function1",
+        futureId: "Module#Contract1.function1",
         failure: "Argument at index 0 has been changed",
       },
     ]);
@@ -231,7 +231,7 @@ describe("Reconciliation - named contract call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -240,7 +240,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:config",
+          id: "Module#config",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "function1",
@@ -251,7 +251,7 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:config",
+        futureId: "Module#config",
         failure: "Value has been changed from 2 to 3",
       },
     ]);
@@ -271,7 +271,7 @@ describe("Reconciliation - named contract call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -280,7 +280,7 @@ describe("Reconciliation - named contract call", () => {
         },
         {
           ...exampleContractCallState,
-          id: "Module:config",
+          id: "Module#config",
           futureType: FutureType.NAMED_CONTRACT_CALL,
           status: ExecutionStatus.STARTED,
           functionName: "function1",
@@ -291,7 +291,7 @@ describe("Reconciliation - named contract call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:config",
+        futureId: "Module#config",
         failure: `From account has been changed from ${oneAddress} to ${twoAddress}`,
       },
     ]);

--- a/packages/core/test/reconciliation/futures/reconcileNamedContractDeployment.ts
+++ b/packages/core/test/reconciliation/futures/reconcileNamedContractDeployment.ts
@@ -69,7 +69,7 @@ describe("Reconciliation - named contract", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Submodule:SafeMath",
+          id: "Submodule#SafeMath",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "SafeMath",
@@ -80,7 +80,7 @@ describe("Reconciliation - named contract", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Submodule:Contract1",
+          id: "Submodule#Contract1",
           status: ExecutionStatus.STARTED,
           constructorArgs: [
             "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
@@ -109,7 +109,7 @@ describe("Reconciliation - named contract", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         status: ExecutionStatus.STARTED,
         contractName: "ContractUnchanged",
       })
@@ -117,7 +117,7 @@ describe("Reconciliation - named contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure:
           "Contract name has been changed from ContractUnchanged to ContractChanged",
       },
@@ -145,7 +145,7 @@ describe("Reconciliation - named contract", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         status: ExecutionStatus.STARTED,
         contractName: "ContractUnchanged",
         constructorArgs: [1, 2, 3],
@@ -154,7 +154,7 @@ describe("Reconciliation - named contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure:
           "Contract name has been changed from ContractUnchanged to ContractChanged",
       },
@@ -179,7 +179,7 @@ describe("Reconciliation - named contract", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:SafeMath",
+          id: "Module#SafeMath",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "SafeMath",
@@ -190,7 +190,7 @@ describe("Reconciliation - named contract", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.STARTED,
           libraries: {},
         }
@@ -199,7 +199,7 @@ describe("Reconciliation - named contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1",
+        futureId: "Module#Contract1",
         failure: "Library SafeMath has been added",
       },
     ]);
@@ -219,7 +219,7 @@ describe("Reconciliation - named contract", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         status: ExecutionStatus.STARTED,
         contractName: "Contract",
         value: BigInt(2),
@@ -228,7 +228,7 @@ describe("Reconciliation - named contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure: "Value has been changed from 2 to 3",
       },
     ]);
@@ -248,7 +248,7 @@ describe("Reconciliation - named contract", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Example",
+        id: "Module#Example",
         status: ExecutionStatus.STARTED,
         contractName: "Contract",
         from: oneAddress,
@@ -257,7 +257,7 @@ describe("Reconciliation - named contract", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Example",
+        futureId: "Module#Example",
         failure: `From account has been changed from ${oneAddress} to ${twoAddress}`,
       },
     ]);

--- a/packages/core/test/reconciliation/futures/reconcileNamedLibraryDeployment.ts
+++ b/packages/core/test/reconciliation/futures/reconcileNamedLibraryDeployment.ts
@@ -59,7 +59,7 @@ describe("Reconciliation - named library", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Submodule:SafeMath",
+          id: "Submodule#SafeMath",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "SafeMath",
@@ -70,7 +70,7 @@ describe("Reconciliation - named library", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Submodule:MainLibrary",
+          id: "Submodule#MainLibrary",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.STARTED,
           contractName: "MainLibrary",
@@ -93,7 +93,7 @@ describe("Reconciliation - named library", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Library",
+        id: "Module#Library",
         futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
         status: ExecutionStatus.STARTED,
         contractName: "LibraryUnchanged",
@@ -102,7 +102,7 @@ describe("Reconciliation - named library", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Library",
+        futureId: "Module#Library",
         failure:
           "Contract name has been changed from LibraryUnchanged to LibraryChanged",
       },
@@ -125,7 +125,7 @@ describe("Reconciliation - named library", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:SafeMath",
+          id: "Module#SafeMath",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "SafeMath",
@@ -136,7 +136,7 @@ describe("Reconciliation - named library", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Module:MainLibrary",
+          id: "Module#MainLibrary",
           futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
           status: ExecutionStatus.STARTED,
           contractName: "MainLibrary",
@@ -149,7 +149,7 @@ describe("Reconciliation - named library", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:MainLibrary",
+        futureId: "Module#MainLibrary",
         failure: "Library Unchanged has been removed",
       },
     ]);
@@ -166,7 +166,7 @@ describe("Reconciliation - named library", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module:Library",
+        id: "Module#Library",
         futureType: FutureType.NAMED_LIBRARY_DEPLOYMENT,
         status: ExecutionStatus.STARTED,
         contractName: "Library",
@@ -176,7 +176,7 @@ describe("Reconciliation - named library", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Library",
+        futureId: "Module#Library",
         failure: `From account has been changed from ${oneAddress} to ${twoAddress}`,
       },
     ]);

--- a/packages/core/test/reconciliation/futures/reconcileNamedStaticCall.ts
+++ b/packages/core/test/reconciliation/futures/reconcileNamedStaticCall.ts
@@ -75,7 +75,7 @@ describe("Reconciliation - named static call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Submodule:Contract1",
+          id: "Submodule#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -84,7 +84,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Submodule:Contract1#function1",
+          id: "Submodule#Contract1.function1",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.SUCCESS,
           contractAddress: exampleAddress,
@@ -109,7 +109,7 @@ describe("Reconciliation - named static call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -118,7 +118,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:config",
+          id: "Module#config",
           status: ExecutionStatus.STARTED,
           functionName: "function1",
           contractAddress: exampleAddress,
@@ -128,9 +128,9 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:config",
+        futureId: "Module#config",
         failure:
-          "Contract address has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (future Module:Contract1)",
+          "Contract address has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (future Module#Contract1)",
       },
     ]);
   });
@@ -149,7 +149,7 @@ describe("Reconciliation - named static call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -158,7 +158,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:config",
+          id: "Module#config",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.STARTED,
           contractAddress: exampleAddress,
@@ -169,7 +169,7 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:config",
+        futureId: "Module#config",
         failure:
           "Function name has been changed from functionUnchanged to functionChanged",
       },
@@ -192,7 +192,7 @@ describe("Reconciliation - named static call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -201,7 +201,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:Contract1#function1",
+          id: "Module#Contract1.function1",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.STARTED,
           contractAddress: exampleAddress,
@@ -213,7 +213,7 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#function1",
+        futureId: "Module#Contract1.function1",
         failure: "Argument at index 0 has been changed",
       },
     ]);
@@ -236,7 +236,7 @@ describe("Reconciliation - named static call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -245,7 +245,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:config",
+          id: "Module#config",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.STARTED,
           contractAddress: exampleAddress,
@@ -257,7 +257,7 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:config",
+        futureId: "Module#config",
         failure: `From account has been changed from ${oneAddress} to ${twoAddress}`,
       },
     ]);
@@ -277,7 +277,7 @@ describe("Reconciliation - named static call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract",
+          id: "Module#Contract",
           futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           result: {
@@ -288,7 +288,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:Contract#function",
+          id: "Module#Contract.function",
           status: ExecutionStatus.STARTED,
           nameOrIndex: "argUnchanged",
         }
@@ -297,7 +297,7 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract#function",
+        futureId: "Module#Contract.function",
         failure:
           "Argument name or index has been changed from argUnchanged to argChanged",
       },
@@ -331,7 +331,7 @@ describe("Reconciliation - named static call", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -340,10 +340,10 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:first_call",
+          id: "Module#first_call",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.SUCCESS,
-          dependencies: new Set(["Module:Contract1"]),
+          dependencies: new Set(["Module#Contract1"]),
           contractAddress: exampleAddress,
           functionName: "function1",
           args: ["first"],
@@ -354,10 +354,10 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:second_call",
+          id: "Module#second_call",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.SUCCESS,
-          dependencies: new Set(["Module:Contract1", "Module:first_call"]),
+          dependencies: new Set(["Module#Contract1", "Module#first_call"]),
           contractAddress: exampleAddress,
           functionName: "function1",
           args: ["second"],
@@ -368,9 +368,9 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Module:Contract2",
+          id: "Module#Contract2",
           status: ExecutionStatus.STARTED,
-          dependencies: new Set(["Module:first_call", "Module:second_call"]),
+          dependencies: new Set(["Module#first_call", "Module#second_call"]),
           contractName: "Contract2",
           constructorArgs: ["first"],
           result: {
@@ -383,7 +383,7 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract2",
+        futureId: "Module#Contract2",
         failure: "Argument at index 0 has been changed",
       },
     ]);

--- a/packages/core/test/reconciliation/futures/reconcileNamedStaticCall.ts
+++ b/packages/core/test/reconciliation/futures/reconcileNamedStaticCall.ts
@@ -118,7 +118,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:Contract1#config",
+          id: "Module:config",
           status: ExecutionStatus.STARTED,
           functionName: "function1",
           contractAddress: exampleAddress,
@@ -128,7 +128,7 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#config",
+        futureId: "Module:config",
         failure:
           "Contract address has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (future Module:Contract1)",
       },
@@ -158,7 +158,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:Contract1#config",
+          id: "Module:config",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.STARTED,
           contractAddress: exampleAddress,
@@ -169,7 +169,7 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#config",
+        futureId: "Module:config",
         failure:
           "Function name has been changed from functionUnchanged to functionChanged",
       },
@@ -245,7 +245,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:Contract1#config",
+          id: "Module:config",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.STARTED,
           contractAddress: exampleAddress,
@@ -257,7 +257,7 @@ describe("Reconciliation - named static call", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract1#config",
+        futureId: "Module:config",
         failure: `From account has been changed from ${oneAddress} to ${twoAddress}`,
       },
     ]);
@@ -354,13 +354,10 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:Contract1#second_call",
+          id: "Module:second_call",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.SUCCESS,
-          dependencies: new Set([
-            "Module:Contract1",
-            "Module:Contract1#first_call",
-          ]),
+          dependencies: new Set(["Module:Contract1", "Module:first_call"]),
           contractAddress: exampleAddress,
           functionName: "function1",
           args: ["second"],
@@ -373,10 +370,7 @@ describe("Reconciliation - named static call", () => {
           ...exampleDeploymentState,
           id: "Module:Contract2",
           status: ExecutionStatus.STARTED,
-          dependencies: new Set([
-            "Module:Contract1#first_call",
-            "Module:Contract1#second_call",
-          ]),
+          dependencies: new Set(["Module:first_call", "Module:second_call"]),
           contractName: "Contract2",
           constructorArgs: ["first"],
           result: {

--- a/packages/core/test/reconciliation/futures/reconcileNamedStaticCall.ts
+++ b/packages/core/test/reconciliation/futures/reconcileNamedStaticCall.ts
@@ -309,10 +309,10 @@ describe("Reconciliation - named static call", () => {
       const contract1 = m.contract("Contract1");
 
       const resultArg1 = m.staticCall(contract1, "function1", ["first"], 0, {
-        id: "first-call",
+        id: "first_call",
       });
       const resultArg2 = m.staticCall(contract1, "function1", ["second"], 0, {
-        id: "second-call",
+        id: "second_call",
         after: [resultArg1],
       });
 
@@ -340,7 +340,7 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:first-call",
+          id: "Module:first_call",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.SUCCESS,
           dependencies: new Set(["Module:Contract1"]),
@@ -354,12 +354,12 @@ describe("Reconciliation - named static call", () => {
         },
         {
           ...exampleStaticCallState,
-          id: "Module:Contract1#second-call",
+          id: "Module:Contract1#second_call",
           futureType: FutureType.NAMED_STATIC_CALL,
           status: ExecutionStatus.SUCCESS,
           dependencies: new Set([
             "Module:Contract1",
-            "Module:Contract1#first-call",
+            "Module:Contract1#first_call",
           ]),
           contractAddress: exampleAddress,
           functionName: "function1",
@@ -374,8 +374,8 @@ describe("Reconciliation - named static call", () => {
           id: "Module:Contract2",
           status: ExecutionStatus.STARTED,
           dependencies: new Set([
-            "Module:Contract1#first-call",
-            "Module:Contract1#second-call",
+            "Module:Contract1#first_call",
+            "Module:Contract1#second_call",
           ]),
           contractName: "Contract2",
           constructorArgs: ["first"],

--- a/packages/core/test/reconciliation/futures/reconcileReadEventArgument.ts
+++ b/packages/core/test/reconciliation/futures/reconcileReadEventArgument.ts
@@ -74,7 +74,7 @@ describe("Reconciliation - read event argument", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Submodule:Contract",
+          id: "Submodule#Contract",
           futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "Contract",
@@ -85,7 +85,7 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleReadArgState,
-          id: "Submodule:Contract#EventName1#arg1#0",
+          id: "Submodule#Contract.EventName1.arg1.0",
           status: ExecutionStatus.STARTED,
           eventName: "EventName1",
           nameOrIndex: "arg1",
@@ -110,7 +110,7 @@ describe("Reconciliation - read event argument", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract",
+          id: "Module#Contract",
           futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "Contract",
@@ -121,7 +121,7 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleReadArgState,
-          id: "Module:ReadEvent",
+          id: "Module#ReadEvent",
           status: ExecutionStatus.STARTED,
           eventName: "eventUnchanged",
         }
@@ -130,7 +130,7 @@ describe("Reconciliation - read event argument", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:ReadEvent",
+        futureId: "Module#ReadEvent",
         failure:
           "Event name has been changed from eventUnchanged to EventChanged",
       },
@@ -153,7 +153,7 @@ describe("Reconciliation - read event argument", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract",
+          id: "Module#Contract",
           futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           result: {
@@ -164,7 +164,7 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleReadArgState,
-          id: "Module:ReadEvent",
+          id: "Module#ReadEvent",
           status: ExecutionStatus.STARTED,
           nameOrIndex: "argUnchanged",
         }
@@ -173,7 +173,7 @@ describe("Reconciliation - read event argument", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:ReadEvent",
+        futureId: "Module#ReadEvent",
         failure:
           "Argument name or index has been changed from argUnchanged to argChanged",
       },
@@ -197,7 +197,7 @@ describe("Reconciliation - read event argument", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract",
+          id: "Module#Contract",
           futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           result: {
@@ -208,7 +208,7 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleReadArgState,
-          id: "Module:ReadEvent",
+          id: "Module#ReadEvent",
           status: ExecutionStatus.STARTED,
           eventIndex: 1,
         }
@@ -217,7 +217,7 @@ describe("Reconciliation - read event argument", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:ReadEvent",
+        futureId: "Module#ReadEvent",
         failure: "Event index has been changed from 1 to 3",
       },
     ]);
@@ -241,7 +241,7 @@ describe("Reconciliation - read event argument", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "Contract1",
@@ -252,7 +252,7 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Module:Contract2",
+          id: "Module#Contract2",
           futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.SUCCESS,
           contractName: "Contract2",
@@ -263,7 +263,7 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleReadArgState,
-          id: "Module:ReadEvent",
+          id: "Module#ReadEvent",
           status: ExecutionStatus.STARTED,
           emitterAddress: exampleAddress,
         }
@@ -272,9 +272,9 @@ describe("Reconciliation - read event argument", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:ReadEvent",
+        futureId: "Module#ReadEvent",
         failure:
-          "Emitter has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (future Module:Contract2)",
+          "Emitter has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (future Module#Contract2)",
       },
     ]);
   });
@@ -306,7 +306,7 @@ describe("Reconciliation - read event argument", () => {
       createDeploymentState(
         {
           ...exampleDeploymentState,
-          id: "Module:Contract1",
+          id: "Module#Contract1",
           status: ExecutionStatus.SUCCESS,
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -315,9 +315,9 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleReadArgState,
-          id: "Module:ReadEvent1",
+          id: "Module#ReadEvent1",
           status: ExecutionStatus.SUCCESS,
-          dependencies: new Set(["Module:Contract1"]),
+          dependencies: new Set(["Module#Contract1"]),
           eventName: "event1",
           nameOrIndex: "argument1",
           emitterAddress: exampleAddress,
@@ -325,9 +325,9 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleReadArgState,
-          id: "Module:ReadEvent2",
+          id: "Module#ReadEvent2",
           status: ExecutionStatus.SUCCESS,
-          dependencies: new Set(["Module:Contract1"]),
+          dependencies: new Set(["Module#Contract1"]),
           eventName: "event2",
           nameOrIndex: "argument2",
           emitterAddress: exampleAddress,
@@ -335,9 +335,9 @@ describe("Reconciliation - read event argument", () => {
         },
         {
           ...exampleDeploymentState,
-          id: "Module:Contract2",
+          id: "Module#Contract2",
           status: ExecutionStatus.STARTED,
-          dependencies: new Set(["Module:ReadEvent1", "Module:ReadEvent2"]),
+          dependencies: new Set(["Module#ReadEvent1", "Module#ReadEvent2"]),
           contractName: "Contract2",
           result: {
             type: ExecutionResultType.SUCCESS,
@@ -350,7 +350,7 @@ describe("Reconciliation - read event argument", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:Contract2",
+        futureId: "Module#Contract2",
         failure: "Argument at index 0 has been changed",
       },
     ]);

--- a/packages/core/test/reconciliation/futures/reconcileSendData.ts
+++ b/packages/core/test/reconciliation/futures/reconcileSendData.ts
@@ -50,7 +50,7 @@ describe("Reconciliation - send data", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleSendState,
-        id: "Submodule:test_send",
+        id: "Submodule#test_send",
         status: ExecutionStatus.STARTED,
       })
     );
@@ -67,7 +67,7 @@ describe("Reconciliation - send data", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleSendState,
-        id: "Module:test_send",
+        id: "Module#test_send",
         status: ExecutionStatus.STARTED,
         data: "0x",
       })
@@ -85,7 +85,7 @@ describe("Reconciliation - send data", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleSendState,
-        id: "Module:test_send",
+        id: "Module#test_send",
         status: ExecutionStatus.STARTED,
         to: exampleAddress,
       })
@@ -93,7 +93,7 @@ describe("Reconciliation - send data", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:test_send",
+        futureId: "Module#test_send",
         failure:
           'Address "to" has been changed from 0x1F98431c8aD98523631AE4a59f267346ea31F984 to 0xBA12222222228d8Ba445958a75a0704d566BF2C8',
       },
@@ -111,7 +111,7 @@ describe("Reconciliation - send data", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleSendState,
-        id: "Module:test_send",
+        id: "Module#test_send",
         status: ExecutionStatus.STARTED,
         data: "unchanged_data",
       })
@@ -119,7 +119,7 @@ describe("Reconciliation - send data", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:test_send",
+        futureId: "Module#test_send",
         failure: "Data has been changed from unchanged_data to changed_data",
       },
     ]);
@@ -136,7 +136,7 @@ describe("Reconciliation - send data", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleSendState,
-        id: "Module:test_send",
+        id: "Module#test_send",
         status: ExecutionStatus.STARTED,
         value: 2n,
       })
@@ -144,7 +144,7 @@ describe("Reconciliation - send data", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:test_send",
+        futureId: "Module#test_send",
         failure: "Value has been changed from 2 to 3",
       },
     ]);
@@ -163,7 +163,7 @@ describe("Reconciliation - send data", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleSendState,
-        id: "Module:test_send",
+        id: "Module#test_send",
         status: ExecutionStatus.STARTED,
         from: exampleAddress,
       })
@@ -171,7 +171,7 @@ describe("Reconciliation - send data", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module:test_send",
+        futureId: "Module#test_send",
         failure: `From account has been changed from ${exampleAddress} to ${differentAddress}`,
       },
     ]);

--- a/packages/core/test/reconciliation/reconciler.ts
+++ b/packages/core/test/reconciliation/reconciler.ts
@@ -22,7 +22,7 @@ import {
 
 describe("Reconciliation", () => {
   const exampleDeploymentState: DeploymentExecutionState = {
-    id: "Module1:Contract1",
+    id: "Module1#Contract1",
     type: ExecutionSateType.DEPLOYMENT_EXECUTION_STATE,
     futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
     strategy: "basic",
@@ -90,14 +90,14 @@ describe("Reconciliation", () => {
       moduleDefinition,
       createDeploymentState({
         ...exampleDeploymentState,
-        id: "Module1:ContractMissed", // This future is not in the module
+        id: "Module1#ContractMissed", // This future is not in the module
         status: ExecutionStatus.STARTED,
       })
     );
 
     assert.deepStrictEqual(
       reconiliationResult.missingExecutedFutures,
-      ["Module1:ContractMissed"],
+      ["Module1#ContractMissed"],
       "Expected one missing previous executed future"
     );
   });
@@ -112,7 +112,7 @@ describe("Reconciliation", () => {
     const reconiliationResult = await reconcile(moduleDefinition, {
       chainId: 123,
       executionStates: {
-        "Module1:Example": {
+        "Module1#Example": {
           ...exampleDeploymentState,
           futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
           status: ExecutionStatus.STARTED,
@@ -122,9 +122,9 @@ describe("Reconciliation", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module1:Example",
+        futureId: "Module1#Example",
         failure:
-          "Future with id Module1:Example has changed from NAMED_CONTRACT_DEPLOYMENT to NAMED_LIBRARY_DEPLOYMENT",
+          "Future with id Module1#Example has changed from NAMED_CONTRACT_DEPLOYMENT to NAMED_LIBRARY_DEPLOYMENT",
       },
     ]);
   });
@@ -139,7 +139,7 @@ describe("Reconciliation", () => {
     const reconiliationResult = await reconcile(moduleDefinition, {
       chainId: 123,
       executionStates: {
-        "Module1:Example": {
+        "Module1#Example": {
           ...exampleDeploymentState,
           status: ExecutionStatus.TIMEOUT,
         },
@@ -148,9 +148,9 @@ describe("Reconciliation", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module1:Contract1",
+        futureId: "Module1#Contract1",
         failure:
-          "The previous run of the future Module1:Contract1 timed out, and will need wiped before running again",
+          "The previous run of the future Module1#Contract1 timed out, and will need wiped before running again",
       },
     ]);
   });
@@ -165,7 +165,7 @@ describe("Reconciliation", () => {
     const reconiliationResult = await reconcile(moduleDefinition, {
       chainId: 123,
       executionStates: {
-        "Module1:Example": {
+        "Module1#Example": {
           ...exampleDeploymentState,
           status: ExecutionStatus.FAILED,
         },
@@ -174,9 +174,9 @@ describe("Reconciliation", () => {
 
     assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
       {
-        futureId: "Module1:Contract1",
+        futureId: "Module1#Contract1",
         failure:
-          "The previous run of the future Module1:Contract1 failed, and will need wiped before running again",
+          "The previous run of the future Module1#Contract1 failed, and will need wiped before running again",
       },
     ]);
   });
@@ -192,7 +192,7 @@ describe("Reconciliation", () => {
       const reconiliationResult = await reconcile(moduleDefinition, {
         chainId: 123,
         executionStates: {
-          "Module1:Contract1": {
+          "Module1#Contract1": {
             ...exampleDeploymentState,
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.STARTED,
@@ -225,7 +225,7 @@ describe("Reconciliation", () => {
 
       assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
         {
-          futureId: "Module1:Contract1",
+          futureId: "Module1#Contract1",
           failure: `From account has been changed from ${exampleAccounts[3]} to ${exampleAccounts[2]}`,
         },
       ]);
@@ -251,24 +251,24 @@ describe("Reconciliation", () => {
         createDeploymentState(
           {
             ...exampleDeploymentState,
-            id: "Module:Contract1",
+            id: "Module#Contract1",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.SUCCESS,
             contractName: "Contract1",
           },
           {
             ...exampleDeploymentState,
-            id: "Module:Contract2",
+            id: "Module#Contract2",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.SUCCESS,
             contractName: "Contract2",
           },
           {
             ...exampleDeploymentState,
-            id: "Module:Contract3",
+            id: "Module#Contract3",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.STARTED,
-            dependencies: new Set(["Module:Contract2", "Module:Contract2"]),
+            dependencies: new Set(["Module#Contract2", "Module#Contract2"]),
             contractName: "Contract3",
           }
         )
@@ -291,24 +291,24 @@ describe("Reconciliation", () => {
         createDeploymentState(
           {
             ...exampleDeploymentState,
-            id: "Module:Contract1",
+            id: "Module#Contract1",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.SUCCESS,
             contractName: "Contract1",
           },
           {
             ...exampleDeploymentState,
-            id: "Module:Contract2",
+            id: "Module#Contract2",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.SUCCESS,
             contractName: "Contract2",
           },
           {
             ...exampleDeploymentState,
-            id: "Module:Contract3",
+            id: "Module#Contract3",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.SUCCESS,
-            dependencies: new Set(["Module:Contract1", "Module:Contract2"]),
+            dependencies: new Set(["Module#Contract1", "Module#Contract2"]),
             contractName: "Contract3",
           }
         )
@@ -330,14 +330,14 @@ describe("Reconciliation", () => {
         createDeploymentState(
           {
             ...exampleDeploymentState,
-            id: "Module:Contract1",
+            id: "Module#Contract1",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.SUCCESS,
             contractName: "Contract1",
           },
           {
             ...exampleDeploymentState,
-            id: "Module:Contract2",
+            id: "Module#Contract2",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.STARTED,
             contractName: "Contract2",
@@ -362,14 +362,14 @@ describe("Reconciliation", () => {
         createDeploymentState(
           {
             ...exampleDeploymentState,
-            id: "Module:Contract1",
+            id: "Module#Contract1",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.STARTED, // Could still be in flight
             contractName: "Contract1",
           },
           {
             ...exampleDeploymentState,
-            id: "Module:Contract2",
+            id: "Module#Contract2",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.SUCCESS,
             dependencies: new Set<string>(), // no deps on last run
@@ -380,9 +380,9 @@ describe("Reconciliation", () => {
 
       assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
         {
-          futureId: "Module:Contract2",
+          futureId: "Module#Contract2",
           failure:
-            "A dependency from Module:Contract2 to Module:Contract1 has been added, and both futures had already started executing, so this change is incompatible",
+            "A dependency from Module#Contract2 to Module#Contract1 has been added, and both futures had already started executing, so this change is incompatible",
         },
       ]);
     });
@@ -404,7 +404,7 @@ describe("Reconciliation", () => {
         createDeploymentState(
           {
             ...exampleDeploymentState,
-            id: "Module:ContractOriginal",
+            id: "Module#ContractOriginal",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.SUCCESS,
             dependencies: new Set<string>(), // no deps on last run
@@ -412,10 +412,10 @@ describe("Reconciliation", () => {
           },
           {
             ...exampleDeploymentState,
-            id: "Module:Contract2",
+            id: "Module#Contract2",
             futureType: FutureType.NAMED_CONTRACT_DEPLOYMENT,
             status: ExecutionStatus.STARTED,
-            dependencies: new Set<string>("Module:ContractOriginal"), // no deps on last run
+            dependencies: new Set<string>("Module#ContractOriginal"), // no deps on last run
             contractName: "Contract2",
             constructorArgs: [exampleAddress],
           }
@@ -424,9 +424,9 @@ describe("Reconciliation", () => {
 
       assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
         {
-          futureId: "Module:Contract2",
+          futureId: "Module#Contract2",
           failure:
-            "A dependency from Module:Contract2 to Module:ContractNew has been added. The former has started executing before the latter started executing, so this change is incompatible.",
+            "A dependency from Module#Contract2 to Module#ContractNew has been added. The former has started executing before the latter started executing, so this change is incompatible.",
         },
       ]);
     });
@@ -450,15 +450,15 @@ describe("Reconciliation", () => {
       };
 
       const storedArtifactMap = {
-        "Module:Contract1": moduleArtifactMap.Contract1,
+        "Module#Contract1": moduleArtifactMap.Contract1,
       };
 
       const reconciliationResult = await reconcile(
         moduleDefinition,
         createDeploymentState({
           ...exampleDeploymentState,
-          id: "Module:Contract1",
-          artifactId: "Module:Contract1",
+          id: "Module#Contract1",
+          artifactId: "Module#Contract1",
         }),
         new ArtifactMapDeploymentLoader(storedArtifactMap),
         new ArtifactMapResolver(moduleArtifactMap)
@@ -484,7 +484,7 @@ describe("Reconciliation", () => {
       };
 
       const storedArtifactMap = {
-        "Module:Contract1": {
+        "Module#Contract1": {
           abi: [],
           bytecode: "0xbbbbbb",
           contractName: "Contract1",
@@ -496,8 +496,8 @@ describe("Reconciliation", () => {
         moduleDefinition,
         createDeploymentState({
           ...exampleDeploymentState,
-          id: "Module:Contract1",
-          artifactId: "Module:Contract1",
+          id: "Module#Contract1",
+          artifactId: "Module#Contract1",
         }),
         new ArtifactMapDeploymentLoader(storedArtifactMap),
         new ArtifactMapResolver(moduleArtifactMap)
@@ -505,7 +505,7 @@ describe("Reconciliation", () => {
 
       assert.deepStrictEqual(reconciliationResult.reconciliationFailures, [
         {
-          futureId: "Module:Contract1",
+          futureId: "Module#Contract1",
           failure: "Artifact bytecodes have been changed",
         },
       ]);
@@ -532,7 +532,7 @@ describe("Reconciliation", () => {
       });
 
       const storedArtifactMap = {
-        "Module:Contract1": {
+        "Module#Contract1": {
           abi: [],
           bytecode: mainnetWethBytecode,
           contractName: "Contract1",
@@ -553,8 +553,8 @@ describe("Reconciliation", () => {
         moduleDefinition,
         createDeploymentState({
           ...exampleDeploymentState,
-          id: "Module:Contract1",
-          artifactId: "Module:Contract1",
+          id: "Module#Contract1",
+          artifactId: "Module#Contract1",
         }),
         new ArtifactMapDeploymentLoader(storedArtifactMap),
         new ArtifactMapResolver(moduleArtifactMap)

--- a/packages/core/test/send.ts
+++ b/packages/core/test/send.ts
@@ -33,7 +33,7 @@ describe("send", () => {
     assert.equal(moduleWithASingleContract.submodules.size, 0);
 
     const sendFuture = [...moduleWithASingleContract.futures].find(
-      ({ id }) => id === "Module1:test_send"
+      ({ id }) => id === "Module1#test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -54,11 +54,11 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test_send"
+      ({ id }) => id === "Module1#test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -80,11 +80,11 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test_send"
+      ({ id }) => id === "Module1#test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -105,7 +105,7 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test_send"
+      ({ id }) => id === "Module1#test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -125,7 +125,7 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test_send"
+      ({ id }) => id === "Module1#test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -148,7 +148,7 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test_send"
+      ({ id }) => id === "Module1#test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -168,7 +168,7 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test_send"
+      ({ id }) => id === "Module1#test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -190,11 +190,11 @@ describe("send", () => {
       return {};
     });
 
-    const futureC = Array.from(module.futures).find((f) => f.id === "Module:C");
+    const futureC = Array.from(module.futures).find((f) => f.id === "Module#C");
     assertInstanceOf(futureC, SendDataFutureImplementation);
 
     const futureC2 = Array.from(module.futures).find(
-      (f) => f.id === "Module:C2"
+      (f) => f.id === "Module#C2"
     );
     assertInstanceOf(futureC2, SendDataFutureImplementation);
 
@@ -219,11 +219,11 @@ describe("send", () => {
       assert.equal(moduleWithSameCallTwice.id, "Module1");
 
       const sendFuture = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:first"
+        ({ id }) => id === "Module1#first"
       );
 
       const sendFuture2 = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:second"
+        ({ id }) => id === "Module1#second"
       );
 
       assert.isDefined(sendFuture);
@@ -239,7 +239,7 @@ describe("send", () => {
 
             return {};
           }),
-        /Duplicated id Module1:test_send found in module Module1/
+        /Duplicated id Module1#test_send found in module Module1/
       );
     });
 
@@ -251,7 +251,7 @@ describe("send", () => {
             m.send("first", "0xtest", 0n, "test");
             return {};
           }),
-        /Duplicated id Module1:first found in module Module1/
+        /Duplicated id Module1#first found in module Module1/
       );
     });
   });

--- a/packages/core/test/send.ts
+++ b/packages/core/test/send.ts
@@ -210,8 +210,8 @@ describe("send", () => {
   describe("passing id", () => {
     it("should be able to call the same function twice by passing an id", () => {
       const moduleWithSameCallTwice = buildModule("Module1", (m) => {
-        m.send("test_send", "0xtest", 0n, "test", { id: "first" });
-        m.send("test_send", "0xtest", 0n, "test", { id: "second" });
+        m.send("first", "0xtest", 0n, "test");
+        m.send("second", "0xtest", 0n, "test");
 
         return {};
       });
@@ -247,8 +247,8 @@ describe("send", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            m.send("test_send", "0xtest", 0n, "test", { id: "first" });
-            m.send("test_send", "0xtest", 0n, "test", { id: "first" });
+            m.send("first", "0xtest", 0n, "test");
+            m.send("first", "0xtest", 0n, "test");
             return {};
           }),
         /Duplicated id Module1:first found in module Module1/

--- a/packages/core/test/send.ts
+++ b/packages/core/test/send.ts
@@ -15,7 +15,7 @@ import { assertInstanceOf, setupMockArtifactResolver } from "./helpers";
 describe("send", () => {
   it("should be able to setup a send", () => {
     const moduleWithASingleContract = buildModule("Module1", (m) => {
-      m.send("test send", "0xtest", 0n, "test-data");
+      m.send("test_send", "0xtest", 0n, "test-data");
 
       return {};
     });
@@ -33,7 +33,7 @@ describe("send", () => {
     assert.equal(moduleWithASingleContract.submodules.size, 0);
 
     const sendFuture = [...moduleWithASingleContract.futures].find(
-      ({ id }) => id === "Module1:test send"
+      ({ id }) => id === "Module1:test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -46,7 +46,7 @@ describe("send", () => {
   it("should be able to pass one contract as the 'to' arg for a send", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.contract("Example");
-      m.send("test send", example, 0n, "");
+      m.send("test_send", example, 0n, "");
 
       return { example };
     });
@@ -58,7 +58,7 @@ describe("send", () => {
     );
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test send"
+      ({ id }) => id === "Module1:test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -72,7 +72,7 @@ describe("send", () => {
   it("should be able to pass one contract as an after dependency of a send", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.contract("Example");
-      m.send("test send", "0xtest", 0n, "", { after: [example] });
+      m.send("test_send", "0xtest", 0n, "", { after: [example] });
 
       return { example };
     });
@@ -84,7 +84,7 @@ describe("send", () => {
     );
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test send"
+      ({ id }) => id === "Module1:test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -97,7 +97,7 @@ describe("send", () => {
 
   it("should be able to pass a value", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      m.send("test send", "0xtest", 42n, "");
+      m.send("test_send", "0xtest", 42n, "");
 
       return {};
     });
@@ -105,7 +105,7 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test send"
+      ({ id }) => id === "Module1:test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -117,7 +117,7 @@ describe("send", () => {
 
   it("Should be able to pass a ModuleParameterRuntimeValue as a value option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      m.send("test send", "0xtest", m.getParameter("value"), "");
+      m.send("test_send", "0xtest", m.getParameter("value"), "");
 
       return {};
     });
@@ -125,7 +125,7 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test send"
+      ({ id }) => id === "Module1:test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -140,7 +140,7 @@ describe("send", () => {
 
   it("should be able to pass a string as from option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      m.send("test send", "0xtest", 0n, "", { from: "0x2" });
+      m.send("test_send", "0xtest", 0n, "", { from: "0x2" });
 
       return {};
     });
@@ -148,7 +148,7 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test send"
+      ({ id }) => id === "Module1:test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -160,7 +160,7 @@ describe("send", () => {
 
   it("Should be able to pass an AccountRuntimeValue as from option", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
-      m.send("test send", "0xtest", 0n, "", { from: m.getAccount(1) });
+      m.send("test_send", "0xtest", 0n, "", { from: m.getAccount(1) });
 
       return {};
     });
@@ -168,7 +168,7 @@ describe("send", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const sendFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:test send"
+      ({ id }) => id === "Module1:test_send"
     );
 
     if (!(sendFuture instanceof SendDataFutureImplementation)) {
@@ -210,8 +210,8 @@ describe("send", () => {
   describe("passing id", () => {
     it("should be able to call the same function twice by passing an id", () => {
       const moduleWithSameCallTwice = buildModule("Module1", (m) => {
-        m.send("test send", "0xtest", 0n, "test", { id: "first" });
-        m.send("test send", "0xtest", 0n, "test", { id: "second" });
+        m.send("test_send", "0xtest", 0n, "test", { id: "first" });
+        m.send("test_send", "0xtest", 0n, "test", { id: "second" });
 
         return {};
       });
@@ -234,12 +234,12 @@ describe("send", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            m.send("test send", "0xtest", 0n, "test");
-            m.send("test send", "0xtest", 0n, "test");
+            m.send("test_send", "0xtest", 0n, "test");
+            m.send("test_send", "0xtest", 0n, "test");
 
             return {};
           }),
-        /Duplicated id Module1:test send found in module Module1/
+        /Duplicated id Module1:test_send found in module Module1/
       );
     });
 
@@ -247,8 +247,8 @@ describe("send", () => {
       assert.throws(
         () =>
           buildModule("Module1", (m) => {
-            m.send("test send", "0xtest", 0n, "test", { id: "first" });
-            m.send("test send", "0xtest", 0n, "test", { id: "first" });
+            m.send("test_send", "0xtest", 0n, "test", { id: "first" });
+            m.send("test_send", "0xtest", 0n, "test", { id: "first" });
             return {};
           }),
         /Duplicated id Module1:first found in module Module1/

--- a/packages/core/test/staticCall.ts
+++ b/packages/core/test/staticCall.ts
@@ -398,11 +398,11 @@ describe("static call", () => {
       assert.equal(moduleWithSameCallTwice.id, "Module1");
 
       const callFuture = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:Example#first"
+        ({ id }) => id === "Module1:first"
       );
 
       const callFuture2 = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:Example#second"
+        ({ id }) => id === "Module1:second"
       );
 
       assert.isDefined(callFuture);
@@ -432,7 +432,7 @@ describe("static call", () => {
             m.staticCall(sameContract1, "test", [], 0, { id: "first" });
             return { sameContract1 };
           }),
-        /Duplicated id Module1:SameContract#first found in module Module1/
+        /Duplicated id Module1:first found in module Module1/
       );
     });
   });

--- a/packages/core/test/staticCall.ts
+++ b/packages/core/test/staticCall.ts
@@ -30,7 +30,7 @@ describe("static call", () => {
     assert.equal(moduleWithASingleContract.id, "Module1");
     assert.equal(
       moduleWithASingleContract.results.contract1.id,
-      "Module1:Contract1"
+      "Module1#Contract1"
     );
 
     // 1 contract future & 1 call future
@@ -61,15 +61,15 @@ describe("static call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedStaticCallFutureImplementation)) {
@@ -94,15 +94,15 @@ describe("static call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const exampleFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example"
+      ({ id }) => id === "Module1#Example"
     );
 
     const anotherFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Another"
+      ({ id }) => id === "Module1#Another"
     );
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedStaticCallFutureImplementation)) {
@@ -128,11 +128,11 @@ describe("static call", () => {
     assert.isDefined(moduleWithASingleContract);
 
     const staticCallFuture = [...moduleWithASingleContract.futures].find(
-      ({ id }) => id === "Module1:Contract1#test"
+      ({ id }) => id === "Module1#Contract1.test"
     );
 
     const callFuture = [...moduleWithASingleContract.futures].find(
-      ({ id }) => id === "Module1:Contract1#test2"
+      ({ id }) => id === "Module1#Contract1.test2"
     );
 
     if (!(callFuture instanceof NamedContractCallFutureImplementation)) {
@@ -156,11 +156,11 @@ describe("static call", () => {
     assert.isDefined(moduleWithASingleContract);
 
     const staticCallFuture = [...moduleWithASingleContract.futures].find(
-      ({ id }) => id === "Module1:Contract1#test"
+      ({ id }) => id === "Module1#Contract1.test"
     );
 
     const staticCallFuture2 = [...moduleWithASingleContract.futures].find(
-      ({ id }) => id === "Module1:Contract1#test2"
+      ({ id }) => id === "Module1#Contract1.test2"
     );
 
     if (!(staticCallFuture instanceof NamedStaticCallFutureImplementation)) {
@@ -187,7 +187,7 @@ describe("static call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedStaticCallFutureImplementation)) {
@@ -209,7 +209,7 @@ describe("static call", () => {
     assert.isDefined(moduleWithDependentContracts);
 
     const callFuture = [...moduleWithDependentContracts.futures].find(
-      ({ id }) => id === "Module1:Example#test"
+      ({ id }) => id === "Module1#Example.test"
     );
 
     if (!(callFuture instanceof NamedStaticCallFutureImplementation)) {
@@ -398,11 +398,11 @@ describe("static call", () => {
       assert.equal(moduleWithSameCallTwice.id, "Module1");
 
       const callFuture = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:first"
+        ({ id }) => id === "Module1#first"
       );
 
       const callFuture2 = [...moduleWithSameCallTwice.futures].find(
-        ({ id }) => id === "Module1:second"
+        ({ id }) => id === "Module1#second"
       );
 
       assert.isDefined(callFuture);
@@ -419,7 +419,7 @@ describe("static call", () => {
 
             return { sameContract1 };
           }),
-        /Duplicated id Module1:SameContract#test found in module Module1/
+        /Duplicated id Module1#SameContract.test found in module Module1/
       );
     });
 
@@ -432,7 +432,7 @@ describe("static call", () => {
             m.staticCall(sameContract1, "test", [], 0, { id: "first" });
             return { sameContract1 };
           }),
-        /Duplicated id Module1:first found in module Module1/
+        /Duplicated id Module1#first found in module Module1/
       );
     });
   });

--- a/packages/core/test/useModule.ts
+++ b/packages/core/test/useModule.ts
@@ -211,7 +211,7 @@ describe("useModule", () => {
       assert.deepStrictEqual(result, {
         type: DeploymentResultType.VALIDATION_ERROR,
         errors: {
-          "Submodule1:Contract1": [
+          "Submodule1#Contract1": [
             "Module parameter 'param1' requires a value but was given none",
           ],
         },

--- a/packages/core/test/utils/future-id-builders.ts
+++ b/packages/core/test/utils/future-id-builders.ts
@@ -32,10 +32,10 @@ describe("future id rules", () => {
       );
     });
 
-    it("namespaces the user provided id to the module and contract being called", () => {
+    it("namespaces the user provided id to the module", () => {
       assert.equal(
         toCallFutureId("MyModule", "MyId", "MyContract", "MyFunction"),
-        "MyModule:MyContract#MyId"
+        "MyModule:MyId"
       );
     });
   });

--- a/packages/core/test/utils/future-id-builders.ts
+++ b/packages/core/test/utils/future-id-builders.ts
@@ -55,6 +55,20 @@ describe("future id rules", () => {
       );
     });
 
+    it("the fallback id should be built even when the arg is an index", () => {
+      assert.equal(
+        toReadEventArgumentFutureId(
+          "MyModule",
+          undefined,
+          "MyContract",
+          "MyFunction",
+          3,
+          2
+        ),
+        "MyModule#MyContract.MyFunction.3.2"
+      );
+    });
+
     it("namespaces the user provided id to the module", () => {
       assert.equal(
         toReadEventArgumentFutureId(

--- a/packages/core/test/utils/future-id-builders.ts
+++ b/packages/core/test/utils/future-id-builders.ts
@@ -12,14 +12,14 @@ describe("future id rules", () => {
     it("the fallback id should be built based on the contract or library name", () => {
       assert.equal(
         toDeploymentFutureId("MyModule", undefined, "MyContract"),
-        "MyModule:MyContract"
+        "MyModule#MyContract"
       );
     });
 
     it("namespaces to the module a user provided id", () => {
       assert.equal(
         toDeploymentFutureId("MyModule", "MyId", "MyContract"),
-        "MyModule:MyId"
+        "MyModule#MyId"
       );
     });
   });
@@ -28,14 +28,14 @@ describe("future id rules", () => {
     it("the fallback id should be built based on the contractName and function name", () => {
       assert.equal(
         toCallFutureId("MyModule", undefined, "MyContract", "MyFunction"),
-        "MyModule:MyContract#MyFunction"
+        "MyModule#MyContract.MyFunction"
       );
     });
 
     it("namespaces the user provided id to the module", () => {
       assert.equal(
         toCallFutureId("MyModule", "MyId", "MyContract", "MyFunction"),
-        "MyModule:MyId"
+        "MyModule#MyId"
       );
     });
   });
@@ -51,7 +51,7 @@ describe("future id rules", () => {
           "MyArg",
           2
         ),
-        "MyModule:MyContract#MyFunction#MyArg#2"
+        "MyModule#MyContract.MyFunction.MyArg.2"
       );
     });
 
@@ -65,14 +65,14 @@ describe("future id rules", () => {
           "MyArg",
           2
         ),
-        "MyModule:MyId"
+        "MyModule#MyId"
       );
     });
   });
 
   describe("send data ids", () => {
     it("namespaces the user provided id to the module", () => {
-      assert.equal(toSendDataFutureId("MyModule", "MyId"), "MyModule:MyId");
+      assert.equal(toSendDataFutureId("MyModule", "MyId"), "MyModule#MyId");
     });
   });
 });

--- a/packages/core/test/utils/future-id-builders.ts
+++ b/packages/core/test/utils/future-id-builders.ts
@@ -1,0 +1,78 @@
+import { assert } from "chai";
+
+import {
+  toCallFutureId,
+  toDeploymentFutureId,
+  toReadEventArgumentFutureId,
+  toSendDataFutureId,
+} from "../../src/internal/utils/future-id-builders";
+
+describe("future id rules", () => {
+  describe("contract, library, contractAt ids", () => {
+    it("the fallback id should be built based on the contract or library name", () => {
+      assert.equal(
+        toDeploymentFutureId("MyModule", undefined, "MyContract"),
+        "MyModule:MyContract"
+      );
+    });
+
+    it("namespaces to the module a user provided id", () => {
+      assert.equal(
+        toDeploymentFutureId("MyModule", "MyId", "MyContract"),
+        "MyModule:MyId"
+      );
+    });
+  });
+
+  describe("call ids", () => {
+    it("the fallback id should be built based on the contractName and function name", () => {
+      assert.equal(
+        toCallFutureId("MyModule", undefined, "MyContract", "MyFunction"),
+        "MyModule:MyContract#MyFunction"
+      );
+    });
+
+    it("namespaces the user provided id to the module and contract being called", () => {
+      assert.equal(
+        toCallFutureId("MyModule", "MyId", "MyContract", "MyFunction"),
+        "MyModule:MyContract#MyId"
+      );
+    });
+  });
+
+  describe("read event argument ids", () => {
+    it("the fallback id should be built based on the contractName, event name, arg name and index", () => {
+      assert.equal(
+        toReadEventArgumentFutureId(
+          "MyModule",
+          undefined,
+          "MyContract",
+          "MyFunction",
+          "MyArg",
+          2
+        ),
+        "MyModule:MyContract#MyFunction#MyArg#2"
+      );
+    });
+
+    it("namespaces the user provided id to the module", () => {
+      assert.equal(
+        toReadEventArgumentFutureId(
+          "MyModule",
+          "MyId",
+          "MyContract",
+          "MyFunction",
+          "MyArg",
+          2
+        ),
+        "MyModule:MyId"
+      );
+    });
+  });
+
+  describe("send data ids", () => {
+    it("namespaces the user provided id to the module", () => {
+      assert.equal(toSendDataFutureId("MyModule", "MyId"), "MyModule:MyId");
+    });
+  });
+});

--- a/packages/core/test/validations/id-rules.ts
+++ b/packages/core/test/validations/id-rules.ts
@@ -6,8 +6,20 @@ import { fakeArtifact } from "../helpers";
 describe("id rules", () => {
   const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 
+  describe("constrain module ids", () => {
+    it("should not allow non-alphanumerics in module ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule:v2", (m) => {
+          const myContract = m.contract("MyContract");
+
+          return { myContract };
+        });
+      }, /The moduleId "MyModule:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+  });
+
   // Windows is not going to allow these characters in filenames
-  describe("ban colons and other non-alphanumeric characters", () => {
+  describe("constrain user provided ids", () => {
     it("should not allow non-alphanumerics in contract ids", () => {
       assert.throws(() => {
         buildModule("MyModule", (m) => {
@@ -134,6 +146,142 @@ describe("id rules", () => {
           return { myContract };
         });
       }, /The id "MyReadEventArgument:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in send id", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          m.send("MySend:v2", exampleAddress, 2n);
+
+          return {};
+        });
+      }, /The id "MySend:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+  });
+
+  describe("constrain contract names", () => {
+    it("should not allow non-alphanumerics in contract name", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract:v2");
+
+          return { myContract };
+        });
+      }, /The contract "MyContract:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
+    });
+
+    it("should not allow non-alphanumerics in contractFromArtifact contract name", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contractFromArtifact(
+            "MyContract:v2",
+            fakeArtifact
+          );
+
+          return { myContract };
+        });
+      }, /The contract "MyContract:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
+    });
+
+    it("should not allow non-alphanumerics in library contract names", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const library = m.library("MyLibrary:v2");
+
+          return { library };
+        });
+      }, /The contract "MyLibrary:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
+    });
+
+    it("should not allow non-alphanumerics in libraryFromArtifact contract names", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myLibraryFromArtifact = m.libraryFromArtifact(
+            "MyLibraryFromArtifact:v2",
+            fakeArtifact
+          );
+
+          return { myLibraryFromArtifact };
+        });
+      }, /The contract "MyLibraryFromArtifact:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
+    });
+
+    it("should not allow non-alphanumerics in contractAt contract names", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContractAt = m.contractAt("MyContract:v2", exampleAddress);
+
+          return { myContractAt };
+        });
+      }, /The contract "MyContract:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
+    });
+
+    it("should not allow non-alphanumerics in contractAtFromArtifact contract names", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContractAt = m.contractAtFromArtifact(
+            "MyContractAt:v2",
+            exampleAddress,
+            fakeArtifact
+          );
+
+          return { myContractAt };
+        });
+      }, /The contract "MyContractAt:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
+    });
+  });
+
+  describe("constrain function names", () => {
+    it("should not allow non-alphanumerics in call function names", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.call(myContract, "config:v2");
+
+          return { myContract };
+        });
+      }, /The function name "config:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
+    });
+
+    it("should not allow non-alphanumerics in static call ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.staticCall(myContract, "config:v2");
+
+          return { myContract };
+        });
+      }, /The function name "config:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
+    });
+  });
+
+  describe("constrain event names", () => {
+    it("should not allow non-alphanumerics in readEventArgument event names", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.readEventArgument(myContract, "MyEvent:v2", "MyArg");
+
+          return { myContract };
+        });
+      }, /The event "MyEvent:v2" contains banned characters, event names can only contain alphanumerics, underscores or dollar signs/);
+    });
+  });
+
+  describe("constrain argument names", () => {
+    it("should not allow non-alphanumerics in readEventArgument argument names", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.readEventArgument(myContract, "MyEvent", "MyArg:v2");
+
+          return { myContract };
+        });
+      }, /The argument "MyArg:v2" contains banned characters, argument names can only contain alphanumerics, underscores or dollar signs/);
     });
   });
 });

--- a/packages/core/test/validations/id-rules.ts
+++ b/packages/core/test/validations/id-rules.ts
@@ -1,0 +1,139 @@
+import { assert } from "chai";
+
+import { buildModule } from "../../src/build-module";
+import { fakeArtifact } from "../helpers";
+
+describe("id rules", () => {
+  const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+
+  // Windows is not going to allow these characters in filenames
+  describe("ban colons and other non-alphanumeric characters", () => {
+    it("should not allow non-alphanumerics in contract ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract", [], {
+            id: "MyContract:v2",
+          });
+
+          return { myContract };
+        });
+      }, /The id "MyContract:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in contractFromArtifact ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contractFromArtifact(
+            "MyContractFromArtifact",
+            fakeArtifact,
+            [],
+            {
+              id: "MyContractFromArtifact:v2",
+            }
+          );
+
+          return { myContract };
+        });
+      }, /The id "MyContractFromArtifact:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in library ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const library = m.library("MyLibrary", {
+            id: "MyLibrary:v2",
+          });
+
+          return { library };
+        });
+      }, /The id "MyLibrary:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in libraryFromArtifact ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myLibraryFromArtifact = m.libraryFromArtifact(
+            "MyLibraryFromArtifact",
+            fakeArtifact,
+            {
+              id: "MyLibraryFromArtifact:v2",
+            }
+          );
+
+          return { myLibraryFromArtifact };
+        });
+      }, /The id "MyLibraryFromArtifact:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in call ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.call(myContract, "config", [], {
+            id: "MyCall:v2",
+          });
+
+          return { myContract };
+        });
+      }, /The id "MyCall:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in static call ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.staticCall(myContract, "config", [], {
+            id: "MyStaticCall:v2",
+          });
+
+          return { myContract };
+        });
+      }, /The id "MyStaticCall:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in contractAt ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContractAt = m.contractAt("MyContract", exampleAddress, {
+            id: "MyContractAt:v2",
+          });
+
+          return { myContractAt };
+        });
+      }, /The id "MyContractAt:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in contractAtFromArtifact ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContractAt = m.contractAtFromArtifact(
+            "MyContract",
+            exampleAddress,
+            fakeArtifact,
+            {
+              id: "MyContractAt:v2",
+            }
+          );
+
+          return { myContractAt };
+        });
+      }, /The id "MyContractAt:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+
+    it("should not allow non-alphanumerics in readEventArgument ids", () => {
+      assert.throws(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.readEventArgument(myContract, "MyEvent", "ArgName", {
+            id: "MyReadEventArgument:v2",
+          });
+
+          return { myContract };
+        });
+      }, /The id "MyReadEventArgument:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+    });
+  });
+});

--- a/packages/core/test/validations/id-rules.ts
+++ b/packages/core/test/validations/id-rules.ts
@@ -255,6 +255,18 @@ describe("id rules", () => {
         });
       }, /The function name "config:v2" contains banned characters, contract names can only contain alphanumerics, underscores or dollar signs/);
     });
+
+    it("should allow ethers style function specification", () => {
+      assert.doesNotThrow(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.staticCall(myContract, "config(uint256,bool)");
+
+          return { myContract };
+        });
+      });
+    });
   });
 
   describe("constrain event names", () => {
@@ -268,6 +280,18 @@ describe("id rules", () => {
           return { myContract };
         });
       }, /The event "MyEvent:v2" contains banned characters, event names can only contain alphanumerics, underscores or dollar signs/);
+    });
+
+    it("should allow ethers sytle event specification", () => {
+      assert.doesNotThrow(() => {
+        buildModule("MyModule", (m) => {
+          const myContract = m.contract("MyContract");
+
+          m.readEventArgument(myContract, "MyEvent(bool,bool)", "MyArg");
+
+          return { myContract };
+        });
+      });
     });
   });
 

--- a/packages/core/test/validations/id-rules.ts
+++ b/packages/core/test/validations/id-rules.ts
@@ -96,7 +96,7 @@ describe("id rules", () => {
         buildModule("MyModule", (m) => {
           const myContract = m.contract("MyContract");
 
-          m.staticCall(myContract, "config", [], {
+          m.staticCall(myContract, "config", [], 0, {
             id: "MyStaticCall:v2",
           });
 

--- a/packages/core/test/validations/id-rules.ts
+++ b/packages/core/test/validations/id-rules.ts
@@ -14,7 +14,7 @@ describe("id rules", () => {
 
           return { myContract };
         });
-      }, /The moduleId "MyModule:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The moduleId "MyModule:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
   });
 
@@ -29,7 +29,7 @@ describe("id rules", () => {
 
           return { myContract };
         });
-      }, /The id "MyContract:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyContract:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in contractFromArtifact ids", () => {
@@ -46,7 +46,7 @@ describe("id rules", () => {
 
           return { myContract };
         });
-      }, /The id "MyContractFromArtifact:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyContractFromArtifact:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in library ids", () => {
@@ -58,7 +58,7 @@ describe("id rules", () => {
 
           return { library };
         });
-      }, /The id "MyLibrary:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyLibrary:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in libraryFromArtifact ids", () => {
@@ -74,7 +74,7 @@ describe("id rules", () => {
 
           return { myLibraryFromArtifact };
         });
-      }, /The id "MyLibraryFromArtifact:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyLibraryFromArtifact:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in call ids", () => {
@@ -88,7 +88,7 @@ describe("id rules", () => {
 
           return { myContract };
         });
-      }, /The id "MyCall:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyCall:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in static call ids", () => {
@@ -102,7 +102,7 @@ describe("id rules", () => {
 
           return { myContract };
         });
-      }, /The id "MyStaticCall:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyStaticCall:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in contractAt ids", () => {
@@ -114,7 +114,7 @@ describe("id rules", () => {
 
           return { myContractAt };
         });
-      }, /The id "MyContractAt:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyContractAt:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in contractAtFromArtifact ids", () => {
@@ -131,7 +131,7 @@ describe("id rules", () => {
 
           return { myContractAt };
         });
-      }, /The id "MyContractAt:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyContractAt:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in readEventArgument ids", () => {
@@ -145,7 +145,7 @@ describe("id rules", () => {
 
           return { myContract };
         });
-      }, /The id "MyReadEventArgument:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MyReadEventArgument:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
 
     it("should not allow non-alphanumerics in send id", () => {
@@ -155,7 +155,7 @@ describe("id rules", () => {
 
           return {};
         });
-      }, /The id "MySend:v2" contains banned characters, ids can only contain alphanumerics, underscores or dashes/);
+      }, /The id "MySend:v2" contains banned characters, ids can only contain alphanumerics or underscores/);
     });
   });
 

--- a/packages/hardhat-plugin/test/events.ts
+++ b/packages/hardhat-plugin/test/events.ts
@@ -63,7 +63,7 @@ describe("events", () => {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const sendEmitter = m.contract("SendDataEmitter");
 
-      const send = m.send("send-data-event", sendEmitter);
+      const send = m.send("send_data_event", sendEmitter);
 
       const output = m.readEventArgument(send, "SendDataEvent", "arg", {
         emitter: sendEmitter,

--- a/packages/hardhat-plugin/test/static-calls.ts
+++ b/packages/hardhat-plugin/test/static-calls.ts
@@ -149,7 +149,7 @@ describe("static calls", () => {
 
     await assert.isRejected(
       this.deploy(moduleDefinition),
-      /Future 'FooModule:FooFactory#nonAddressResult' must be a valid address/
+      /Future 'FooModule#FooFactory.nonAddressResult' must be a valid address/
     );
   });
 
@@ -174,7 +174,7 @@ describe("static calls", () => {
 
     await assert.isRejected(
       this.deploy(moduleDefinition),
-      /Future 'FooModule:FooFactory#nonAddressResult' must be a valid address/
+      /Future 'FooModule#FooFactory.nonAddressResult' must be a valid address/
     );
   });
 });

--- a/packages/hardhat-plugin/test/use-module.ts
+++ b/packages/hardhat-plugin/test/use-module.ts
@@ -43,7 +43,7 @@ describe("useModule", function () {
           const secondCall = m.call(trace, "addEntry", ["second"]);
 
           m.call(trace, "addEntry", ["third"], {
-            id: "third-add-entry",
+            id: "third_add_entry",
             after: [secondCall],
           });
 

--- a/packages/ui/scripts/generate-example-deployment-json.js
+++ b/packages/ui/scripts/generate-example-deployment-json.js
@@ -1,10 +1,7 @@
-import {
-  ModuleConstructor,
-  StoredDeploymentSerializer,
-} from "@ignored/ignition-core";
+import { StoredDeploymentSerializer } from "@ignored/ignition-core";
 import { writeFile } from "node:fs/promises";
 
-import moduleDefinition from "../examples/ComplexModule.js";
+import complexModule from "../examples/ComplexModule.js";
 
 const main = async () => {
   await writeDeploymentJsonFor({
@@ -12,12 +9,12 @@ const main = async () => {
       chainId: 999,
       networkName: "Hardhat",
     },
-    moduleDefinition: moduleDefinition,
+    module: complexModule,
   });
 };
 
 async function writeDeploymentJsonFor(deployment) {
-  const serializedDeployment = serializeDeployment(deployment);
+  const serializedDeployment = StoredDeploymentSerializer.serialize(deployment);
 
   console.log("Deployment written to ./public/deployment.json");
 
@@ -25,18 +22,6 @@ async function writeDeploymentJsonFor(deployment) {
     "./public/deployment.json",
     JSON.stringify(serializedDeployment, undefined, 2)
   );
-}
-
-function serializeDeployment(deployment) {
-  const constructor = new ModuleConstructor(deployment.details.chainId, []);
-  const module = constructor.construct(deployment.moduleDefinition);
-
-  const serializedModule = StoredDeploymentSerializer.serialize({
-    details: deployment.details,
-    module,
-  });
-
-  return serializedModule;
 }
 
 main();

--- a/packages/ui/src/pages/plan-overview/components/action.tsx
+++ b/packages/ui/src/pages/plan-overview/components/action.tsx
@@ -16,7 +16,7 @@ export const Action: React.FC<{
   const displayText = toDisplayText(future);
 
   const navigateToFuture = useCallback(() => {
-    return navigate(`/future/${future.id}`);
+    return navigate(`/future/${encodeURIComponent(future.id)}`);
   }, [future.id, navigate]);
 
   return (

--- a/packages/ui/test/to-mermaid.ts
+++ b/packages/ui/test/to-mermaid.ts
@@ -19,7 +19,7 @@ describe("to-mermaid", () => {
         subgraph Module
           direction BT
 
-          Module:Contract1["Deploy Contract1"]
+          Module#Contract1["Deploy Contract1"]
         end
 
       classDef startModule stroke-width:4px`;
@@ -43,7 +43,7 @@ describe("to-mermaid", () => {
         subgraph Test_registrar
           direction BT
 
-          Test_registrar:Contract1["Deploy Contract1"]
+          Test_registrar#Contract1["Deploy Contract1"]
         end
 
       classDef startModule stroke-width:4px`;
@@ -83,21 +83,21 @@ describe("to-mermaid", () => {
         subgraph Module
           direction BT
 
-          Module:Contract3["Deploy Contract3"]
+          Module#Contract3["Deploy Contract3"]
         end
         subgraph Submodule1
           direction BT
 
-          Submodule1:Contract1["Deploy Contract1"]
+          Submodule1#Contract1["Deploy Contract1"]
         end
         subgraph Submodule2
           direction BT
 
-          Submodule2:Contract2["Deploy Contract2"]
+          Submodule2#Contract2["Deploy Contract2"]
         end
 
-      Module:Contract3 --> Submodule1:Contract1
-      Module:Contract3 --> Submodule2:Contract2
+      Module#Contract3 --> Submodule1#Contract1
+      Module#Contract3 --> Submodule2#Contract2
 
       Module -.-> Submodule1
       Module -.-> Submodule2
@@ -171,26 +171,26 @@ describe("to-mermaid", () => {
         subgraph Module
           direction BT
 
-          Module:BasicContract["Deploy BasicContract"]
-          Module:BasicLibrary["Deploy library BasicLibrary"]
-          Module:BasicLibrary2["Deploy library from artifact BasicLibrary"]
-          Module:ContractWithLibrary["Deploy from artifact ContractWithLibrary"]
-          Module:BasicContract#basicFunction["Call BasicContract/basicFunction"]
-          Module:BasicContract#BasicEvent#eventArg#0["Read event from future Module:BasicContract#basicFunction (event BasicEvent argument eventArg)"]
-          Module:ContractWithLibrary#readonlyFunction["Static call ContractWithLibrary/readonlyFunction"]
-          Module:BasicContract2["Existing contract BasicContract (Module:BasicContract)"]
-          Module:ContractWithLibrary2["Existing contract from artifact ContractWithLibrary (Module:ContractWithLibrary)"]
-          Module:test_send["Send data to Module:BasicContract2"]
+          Module#BasicContract["Deploy BasicContract"]
+          Module#BasicLibrary["Deploy library BasicLibrary"]
+          Module#BasicLibrary2["Deploy library from artifact BasicLibrary"]
+          Module#ContractWithLibrary["Deploy from artifact ContractWithLibrary"]
+          Module#BasicContract.basicFunction["Call BasicContract/basicFunction"]
+          Module#BasicContract.BasicEvent.eventArg.0["Read event from future Module#BasicContract.basicFunction (event BasicEvent argument eventArg)"]
+          Module#ContractWithLibrary.readonlyFunction["Static call ContractWithLibrary/readonlyFunction"]
+          Module#BasicContract2["Existing contract BasicContract (Module#BasicContract)"]
+          Module#ContractWithLibrary2["Existing contract from artifact ContractWithLibrary (Module#ContractWithLibrary)"]
+          Module#test_send["Send data to Module#BasicContract2"]
         end
 
-      Module:ContractWithLibrary --> Module:BasicLibrary
-      Module:BasicContract#basicFunction --> Module:BasicContract
-      Module:BasicContract#BasicEvent#eventArg#0 --> Module:BasicContract#basicFunction
-      Module:ContractWithLibrary#readonlyFunction --> Module:ContractWithLibrary
-      Module:ContractWithLibrary#readonlyFunction --> Module:BasicContract#BasicEvent#eventArg#0
-      Module:BasicContract2 --> Module:BasicContract
-      Module:ContractWithLibrary2 --> Module:ContractWithLibrary
-      Module:test_send --> Module:BasicContract2
+      Module#ContractWithLibrary --> Module#BasicLibrary
+      Module#BasicContract.basicFunction --> Module#BasicContract
+      Module#BasicContract.BasicEvent.eventArg.0 --> Module#BasicContract.basicFunction
+      Module#ContractWithLibrary.readonlyFunction --> Module#ContractWithLibrary
+      Module#ContractWithLibrary.readonlyFunction --> Module#BasicContract.BasicEvent.eventArg.0
+      Module#BasicContract2 --> Module#BasicContract
+      Module#ContractWithLibrary2 --> Module#ContractWithLibrary
+      Module#test_send --> Module#BasicContract2
 
       classDef startModule stroke-width:4px`;
 
@@ -215,13 +215,13 @@ describe("to-mermaid", () => {
         subgraph Module
           direction BT
 
-          Module:ens["Deploy ens"]
-          Module:ens#setAddr_bytes32_address_["Call ens/setAddr(bytes32,address)"]
-          Module:ens#getAddr_bytes32_address_["Static call ens/getAddr(bytes32,address)"]
+          Module#ens["Deploy ens"]
+          Module#ens.setAddr_bytes32_address_["Call ens/setAddr(bytes32,address)"]
+          Module#ens.getAddr_bytes32_address_["Static call ens/getAddr(bytes32,address)"]
         end
 
-      Module:ens#setAddr_bytes32_address_ --> Module:ens
-      Module:ens#getAddr_bytes32_address_ --> Module:ens
+      Module#ens.setAddr_bytes32_address_ --> Module#ens
+      Module#ens.getAddr_bytes32_address_ --> Module#ens
 
       classDef startModule stroke-width:4px`;
 

--- a/packages/ui/test/to-mermaid.ts
+++ b/packages/ui/test/to-mermaid.ts
@@ -28,7 +28,7 @@ describe("to-mermaid", () => {
   });
 
   it("should render a module with a space in the name", () => {
-    const moduleDefinition = buildModule("Test registrar", (m) => {
+    const moduleDefinition = buildModule("Test_registrar", (m) => {
       const p = m.getParameter("p", 123);
       const contract1 = m.contract("Contract1", [{ arr: [p] }]);
 
@@ -40,7 +40,7 @@ describe("to-mermaid", () => {
 
       Test_registrar:::startModule
 
-        subgraph Test registrar
+        subgraph Test_registrar
           direction BT
 
           Test_registrar:Contract1["Deploy Contract1"]

--- a/packages/ui/test/to-mermaid.ts
+++ b/packages/ui/test/to-mermaid.ts
@@ -151,7 +151,7 @@ describe("to-mermaid", () => {
         { id: "ContractWithLibrary2" }
       );
 
-      m.send("test-send", duplicate, 123n);
+      m.send("test_send", duplicate, 123n);
 
       return {
         basic,
@@ -180,7 +180,7 @@ describe("to-mermaid", () => {
           Module:ContractWithLibrary#readonlyFunction["Static call ContractWithLibrary/readonlyFunction"]
           Module:BasicContract2["Existing contract BasicContract (Module:BasicContract)"]
           Module:ContractWithLibrary2["Existing contract from artifact ContractWithLibrary (Module:ContractWithLibrary)"]
-          Module:test-send["Send data to Module:BasicContract2"]
+          Module:test_send["Send data to Module:BasicContract2"]
         end
 
       Module:ContractWithLibrary --> Module:BasicLibrary
@@ -190,7 +190,7 @@ describe("to-mermaid", () => {
       Module:ContractWithLibrary#readonlyFunction --> Module:BasicContract#BasicEvent#eventArg#0
       Module:BasicContract2 --> Module:BasicContract
       Module:ContractWithLibrary2 --> Module:ContractWithLibrary
-      Module:test-send --> Module:BasicContract2
+      Module:test_send --> Module:BasicContract2
 
       classDef startModule stroke-width:4px`;
 


### PR DESCRIPTION
We do not enforce any rules on the types of ids that can be used for modules or actions. This is a problem because we use those ids when writing to the file system (including on windows).

This PR introduces rules on module ids, user provided action ids and all of the components that can be used as fallbacks to generate an id.

Module ids and user provided action ids are only allowed to start with a letter and then include only alphanumerics and underscores:

```regex
/^[a-zA-Z][a-zA-Z0-9_]*$/
```

The contract names, event names, args are validated based on Solidity's identifier rules:

```regex
/^[a-zA-Z$_][a-zA-Z0-9$_]*$/
```

Function names and event names are slightly looser than the Solidity identifier rule to support *ethers* style function/event + params `myfun(uint256,bool)`:

```regex
/^[a-zA-Z$_][a-zA-Z0-9$_,()]*$/
```

With constraints on the parts that are used to build up the surrogate ids, and by ensuring our combination separators are valid we can ensure that all our ids are valid for filenames on windows/linux.

As such we are changing the separator symbols to those that can work as windows filenames, specifically:

* `:` -> `#`
* `#` -> `.`

```markdown
| Future                      | Before                                 | After                                  | User Provided ID         |
| --------------------------- | -------------------------------------- | -------------------------------------- | ------------------------ |
| contract/library/contractAt | MyModule:MyContract                    | MyModule#MyContract                    | MyModule#MyId            |
| call/staticCall             | MyModule:MyContract#MyFunction         | MyModule#MyContract.MyFunction         | MyModule#MyContract.MyId |
| readEventArgument           | MyModule:MyContract#MyFunction#MyArg#2 | MyModule#MyContract.MyFunction.MyArg.2 | MyModule#MyId            |
| send                        | MyModule:MyId                          | MyModule#MyId                          | MyModule#MyId            |

``` 

This PR also:

* removes options id from send
* changes namespacing on calls to just be `MyModule#Call1` for user provided ids matching the other rules

## Review

I would suggest taking the commits in order. The first commits refactor our code to pull the id and validation code into one place. The final commit swaps the separators (but this ends up touching quite a few files, mainly tests).
