### PR TITLE
fix: rework batch complete detection

### DIFF
--- a/packages/core/src/internal/execution/future-processor/future-processor.ts
+++ b/packages/core/src/internal/execution/future-processor/future-processor.ts
@@ -64,7 +64,7 @@ export class FutureProcessor {
   public async processFuture(
     future: Future,
     deploymentState: DeploymentState
-  ): Promise<{ futureCompleted: boolean; newState: DeploymentState }> {
+  ): Promise<{ newState: DeploymentState }> {
     let exState = deploymentState.executionStates[future.id];
 
     if (exState === undefined) {
@@ -113,7 +113,7 @@ export class FutureProcessor {
 
       if (nextMessage === undefined) {
         // continue with the next future
-        return { futureCompleted: false, newState: deploymentState };
+        return { newState: deploymentState };
       }
 
       deploymentState = await applyNewMessage(
@@ -127,7 +127,7 @@ export class FutureProcessor {
       await this._recordDeployedAddressIfNeeded(nextMessage);
     }
 
-    return { futureCompleted: true, newState: deploymentState };
+    return { newState: deploymentState };
   }
 
   /**

--- a/packages/core/src/internal/views/is-batch-finished.ts
+++ b/packages/core/src/internal/views/is-batch-finished.ts
@@ -1,0 +1,22 @@
+import { DeploymentState } from "../execution/types/deployment-state";
+import { ExecutionStatus } from "../execution/types/execution-state";
+
+/**
+ * Have the futures making up a batch finished executing, as defined by
+ * no longer being `STARTED`, so they have succeeded, failed, or timed out.
+ *
+ * @param deploymentState - the deployment state
+ * @param batch - the list of future ids of the futures in the batch
+ * @returns true if all futures in the batch have finished executing
+ */
+export function isBatchFinished(
+  deploymentState: DeploymentState,
+  batch: string[]
+): boolean {
+  return batch
+    .map((futureId) => deploymentState.executionStates[futureId])
+    .every(
+      (exState) =>
+        exState !== undefined && exState.status !== ExecutionStatus.STARTED
+    );
+}

--- a/packages/core/test/execution/future-processor/named-contract-deploy.ts
+++ b/packages/core/test/execution/future-processor/named-contract-deploy.ts
@@ -60,7 +60,6 @@ describe("future processor", () => {
       );
 
       // Assert
-      assert.isTrue(result.futureCompleted);
       assert.equal(
         storedDeployedAddresses["MyModule:TestContract"],
         exampleAddress


### PR DESCRIPTION
Tweak the logic for determining whether to start the next batch so that it is derived from the deployment state.

## Preview

![batch-fix](https://github.com/NomicFoundation/ignition/assets/24030/759871a3-b7bc-4c7f-b696-8a881bbe5efe)

## Manual Testing

Update the `uniswap` example hardhat config so that automining is off but confirmations aren't ridiculous:

```js
require("@nomicfoundation/hardhat-toolbox");
require("@ignored/hardhat-ignition");

/**
 * @type import('hardhat/config').HardhatUserConfig
 */
module.exports = {
  solidity: {
    compilers: [
      {
        version: "0.5.5",
      },
      {
        version: "0.7.6",
        settings: {
          optimizer: {
            enabled: true,
            runs: 800,
          },
          metadata: {
            // do not include the metadata hash, since this is machine dependent
            // and we want all generated code to be deterministic
            // https://docs.soliditylang.org/en/v0.7.6/metadata.html
            bytecodeHash: "none",
          },
        },
      },
    ],
  },
  networks: {
    hardhat: {
      mining: {
        auto: false,
        interval: 3000,
      },
    },
  },
  ignition: {
    requiredConfirmations: 1,
  },
};
```

Then from the uniswap example dir run a node:

```shell
npx hardhat node
```

In another terminal, run the deploy against the node:

```shell
npx hardhat deploy ./ignition/Uniswap.js --network localhost
```
