### PR TITLE
Refactor previous run timeout/failure check

### DIFF
--- a/packages/core/src/internal/deployer.ts
+++ b/packages/core/src/internal/deployer.ts
@@ -1,6 +1,5 @@
 import type { IgnitionModule, IgnitionModuleResult } from "../types/module";
 
-import { IgnitionError } from "../errors";
 import { isContractFuture } from "../type-guards";
 import { ArtifactResolver } from "../types/artifact";
 import {
@@ -41,7 +40,6 @@ import {
 import { ExecutionStrategy } from "./execution/types/execution-strategy";
 import { formatExecutionError } from "./formatters";
 import { Reconciler } from "./reconciliation/reconciler";
-import { ReconciliationFailure } from "./reconciliation/types";
 import { assertIgnitionInvariant } from "./utils/assertions";
 import { getFuturesFromModule } from "./utils/get-futures-from-module";
 import { validateStageTwo } from "./validation/validateStageTwo";
@@ -151,10 +149,10 @@ export class Deployer {
       return reconciliationErrorResult;
     }
 
-    const previousRunErrors = this._checkForPreviousRunErrors(deploymentState);
+    const previousRunErrors =
+      Reconciler.checkForPreviousRunErrors(deploymentState);
 
     if (previousRunErrors.length > 0) {
-      // todo: can this be more DRY?
       const errors: PreviousRunErrorDeploymentResult["errors"] = {};
 
       for (const { futureId, failure } of previousRunErrors) {
@@ -170,7 +168,7 @@ export class Deployer {
         errors,
       };
 
-      // this._emitDeploymentCompleteEvent(reconciliationErrorResult);
+      this._emitDeploymentCompleteEvent(previousRunErrorResult);
 
       return previousRunErrorResult;
     }
@@ -342,35 +340,6 @@ export class Deployer {
           };
         }),
     };
-  }
-
-  private _checkForPreviousRunErrors(
-    deploymentState: DeploymentState
-  ): ReconciliationFailure[] {
-    const failuresOrTimeouts = Object.values(
-      deploymentState.executionStates
-    ).filter(
-      (exState) =>
-        exState.status === ExecutionStatus.FAILED ||
-        exState.status === ExecutionStatus.TIMEOUT
-    );
-
-    return failuresOrTimeouts.map((exState) => ({
-      futureId: exState.id,
-      failure: this._previousRunFailedMessageFor(exState),
-    }));
-  }
-
-  private _previousRunFailedMessageFor(exState: ExecutionState): string {
-    if (exState.status === ExecutionStatus.FAILED) {
-      return `The previous run of the future ${exState.id} failed, and will need wiped before running again`;
-    }
-
-    if (exState.status === ExecutionStatus.TIMEOUT) {
-      return `The previous run of the future ${exState.id} timed out, and will need wiped before running again`;
-    }
-
-    throw new IgnitionError(`Unsupported execution status: ${exState.status}`);
   }
 }
 

--- a/packages/core/src/internal/deployer.ts
+++ b/packages/core/src/internal/deployer.ts
@@ -1,5 +1,6 @@
 import type { IgnitionModule, IgnitionModuleResult } from "../types/module";
 
+import { IgnitionError } from "../errors";
 import { isContractFuture } from "../type-guards";
 import { ArtifactResolver } from "../types/artifact";
 import {
@@ -8,6 +9,7 @@ import {
   DeploymentResult,
   DeploymentResultType,
   ExecutionErrorDeploymentResult,
+  PreviousRunErrorDeploymentResult,
   ReconciliationErrorDeploymentResult,
   SuccessfulDeploymentResult,
 } from "../types/deploy";
@@ -39,6 +41,7 @@ import {
 import { ExecutionStrategy } from "./execution/types/execution-strategy";
 import { formatExecutionError } from "./formatters";
 import { Reconciler } from "./reconciliation/reconciler";
+import { ReconciliationFailure } from "./reconciliation/types";
 import { assertIgnitionInvariant } from "./utils/assertions";
 import { getFuturesFromModule } from "./utils/get-futures-from-module";
 import { validateStageTwo } from "./validation/validateStageTwo";
@@ -146,6 +149,30 @@ export class Deployer {
       this._emitDeploymentCompleteEvent(reconciliationErrorResult);
 
       return reconciliationErrorResult;
+    }
+
+    const previousRunErrors = this._checkForPreviousRunErrors(deploymentState);
+
+    if (previousRunErrors.length > 0) {
+      // todo: can this be more DRY?
+      const errors: PreviousRunErrorDeploymentResult["errors"] = {};
+
+      for (const { futureId, failure } of previousRunErrors) {
+        if (errors[futureId] === undefined) {
+          errors[futureId] = [];
+        }
+
+        errors[futureId].push(failure);
+      }
+
+      const previousRunErrorResult: PreviousRunErrorDeploymentResult = {
+        type: DeploymentResultType.PREVIOUS_RUN_ERROR,
+        errors,
+      };
+
+      // this._emitDeploymentCompleteEvent(reconciliationErrorResult);
+
+      return previousRunErrorResult;
     }
 
     if (reconciliationResult.missingExecutedFutures.length > 0) {
@@ -315,6 +342,35 @@ export class Deployer {
           };
         }),
     };
+  }
+
+  private _checkForPreviousRunErrors(
+    deploymentState: DeploymentState
+  ): ReconciliationFailure[] {
+    const failuresOrTimeouts = Object.values(
+      deploymentState.executionStates
+    ).filter(
+      (exState) =>
+        exState.status === ExecutionStatus.FAILED ||
+        exState.status === ExecutionStatus.TIMEOUT
+    );
+
+    return failuresOrTimeouts.map((exState) => ({
+      futureId: exState.id,
+      failure: this._previousRunFailedMessageFor(exState),
+    }));
+  }
+
+  private _previousRunFailedMessageFor(exState: ExecutionState): string {
+    if (exState.status === ExecutionStatus.FAILED) {
+      return `The previous run of the future ${exState.id} failed, and will need wiped before running again`;
+    }
+
+    if (exState.status === ExecutionStatus.TIMEOUT) {
+      return `The previous run of the future ${exState.id} timed out, and will need wiped before running again`;
+    }
+
+    throw new IgnitionError(`Unsupported execution status: ${exState.status}`);
   }
 }
 

--- a/packages/core/src/internal/reconciliation/reconciler.ts
+++ b/packages/core/src/internal/reconciliation/reconciler.ts
@@ -1,13 +1,9 @@
-import { IgnitionError } from "../../errors";
 import { ArtifactResolver } from "../../types/artifact";
 import { DeploymentParameters } from "../../types/deploy";
 import { Future, IgnitionModule } from "../../types/module";
 import { DeploymentLoader } from "../deployment-loader/types";
 import { DeploymentState } from "../execution/types/deployment-state";
-import {
-  ExecutionState,
-  ExecutionStatus,
-} from "../execution/types/execution-state";
+import { ExecutionState } from "../execution/types/execution-state";
 import { AdjacencyList } from "../utils/adjacency-list";
 import { AdjacencyListConverter } from "../utils/adjacency-list-converter";
 import { getFuturesFromModule } from "../utils/get-futures-from-module";
@@ -33,7 +29,7 @@ export class Reconciler {
     artifactResolver: ArtifactResolver,
     defaultSender: string
   ): Promise<ReconciliationResult> {
-    let reconciliationFailures = await this._reconcileEachFutureInModule(
+    const reconciliationFailures = await this._reconcileEachFutureInModule(
       module,
       {
         deploymentState,
@@ -49,10 +45,6 @@ export class Reconciler {
         reconcileFutureSpecificReconciliations,
       ]
     );
-
-    if (reconciliationFailures.length === 0) {
-      reconciliationFailures = this._reconcileNoErroredFutures(deploymentState);
-    }
 
     // TODO: Reconcile sender of incomplete futures.
 
@@ -90,35 +82,6 @@ export class Reconciler {
     }
 
     return failures;
-  }
-
-  private static _reconcileNoErroredFutures(
-    deploymentState: DeploymentState
-  ): ReconciliationFailure[] {
-    const failuresOrTimeouts = Object.values(
-      deploymentState.executionStates
-    ).filter(
-      (exState) =>
-        exState.status === ExecutionStatus.FAILED ||
-        exState.status === ExecutionStatus.TIMEOUT
-    );
-
-    return failuresOrTimeouts.map((exState) => ({
-      futureId: exState.id,
-      failure: this._previousRunFailedMessageFor(exState),
-    }));
-  }
-
-  private static _previousRunFailedMessageFor(exState: ExecutionState): string {
-    if (exState.status === ExecutionStatus.FAILED) {
-      return `The previous run of the future ${exState.id} failed, and will need wiped before running again`;
-    }
-
-    if (exState.status === ExecutionStatus.TIMEOUT) {
-      return `The previous run of the future ${exState.id} timed out, and will need wiped before running again`;
-    }
-
-    throw new IgnitionError(`Unsupported execution status: ${exState.status}`);
   }
 
   private static _missingPreviouslyExecutedFutures(

--- a/packages/core/src/types/deploy.ts
+++ b/packages/core/src/types/deploy.ts
@@ -42,6 +42,7 @@ export type DeploymentResult<
   | ValidationErrorDeploymentResult
   | ReconciliationErrorDeploymentResult
   | ExecutionErrorDeploymentResult
+  | PreviousRunErrorDeploymentResult
   | SuccessfulDeploymentResult<ContractNameT, IgnitionModuleResultsT>;
 
 /**
@@ -65,6 +66,11 @@ export enum DeploymentResultType {
    * One or more future's execution failed or timed out.
    */
   EXECUTION_ERROR = "EXECUTION_ERROR",
+
+  /**
+   * One or more futures from a previous run failed or timed out.
+   */
+  PREVIOUS_RUN_ERROR = "PREVIOUS_RUN_ERROR",
 
   /**
    * The entire deployment was successful.
@@ -135,6 +141,23 @@ export interface ExecutionErrorDeploymentResult {
    * A list with the id of all the future that have successfully executed.
    */
   successful: string[];
+}
+
+/**
+ * A deployment result where one or more futures from a previous run failed or timed out
+ * and need their state wiped.
+ *
+ * @beta
+ */
+export interface PreviousRunErrorDeploymentResult {
+  type: DeploymentResultType.PREVIOUS_RUN_ERROR;
+
+  /**
+   * A map from future id to a list of all of its previous run errors.
+   */
+  errors: {
+    [futureId: string]: string[];
+  };
 }
 
 /**

--- a/packages/core/test/reconciliation/reconciler.ts
+++ b/packages/core/test/reconciliation/reconciler.ts
@@ -8,6 +8,7 @@ import {
   ExecutionStatus,
 } from "../../src/internal/execution/types/execution-state";
 import { getDefaultSender } from "../../src/internal/execution/utils/get-default-sender";
+import { Reconciler } from "../../src/internal/reconciliation/reconciler";
 import { FutureType } from "../../src/types/module";
 import { exampleAccounts } from "../helpers";
 
@@ -129,14 +130,8 @@ describe("Reconciliation", () => {
     ]);
   });
 
-  it("should flag as unreconsiliable a future that timed out on the previous run", async () => {
-    const moduleDefinition = buildModule("Module1", (m) => {
-      const contract1 = m.contract("Contract1");
-
-      return { contract1 };
-    });
-
-    const reconiliationResult = await reconcile(moduleDefinition, {
+  it("should flag as PreviousRunError a future that timed out on the previous run", async () => {
+    const reconiliationResult = Reconciler.checkForPreviousRunErrors({
       chainId: 123,
       executionStates: {
         "Module1:Example": {
@@ -146,7 +141,7 @@ describe("Reconciliation", () => {
       },
     });
 
-    assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
+    assert.deepStrictEqual(reconiliationResult, [
       {
         futureId: "Module1:Contract1",
         failure:
@@ -155,14 +150,8 @@ describe("Reconciliation", () => {
     ]);
   });
 
-  it("should flag as unreconsiliable a future that failed on the previous run", async () => {
-    const moduleDefinition = buildModule("Module1", (m) => {
-      const contract1 = m.contract("Contract1");
-
-      return { contract1 };
-    });
-
-    const reconiliationResult = await reconcile(moduleDefinition, {
+  it("should flag as PreviousRunError a future that failed on the previous run", async () => {
+    const reconiliationResult = Reconciler.checkForPreviousRunErrors({
       chainId: 123,
       executionStates: {
         "Module1:Example": {
@@ -172,7 +161,7 @@ describe("Reconciliation", () => {
       },
     });
 
-    assert.deepStrictEqual(reconiliationResult.reconciliationFailures, [
+    assert.deepStrictEqual(reconiliationResult, [
       {
         futureId: "Module1:Contract1",
         failure:

--- a/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
@@ -2,6 +2,7 @@ import {
   DeploymentResultType,
   ExecutionErrorDeploymentResult,
   IgnitionModuleResult,
+  PreviousRunErrorDeploymentResult,
   ReconciliationErrorDeploymentResult,
   SuccessfulDeploymentResult,
   ValidationErrorDeploymentResult,
@@ -42,6 +43,15 @@ export const FinalStatus = ({ state }: { state: UiState }) => {
     case DeploymentResultType.EXECUTION_ERROR: {
       return (
         <ExecutionErrorResult
+          chainId={state.chainId!}
+          moduleName={state.moduleName!}
+          result={state.result}
+        />
+      );
+    }
+    case DeploymentResultType.PREVIOUS_RUN_ERROR: {
+      return (
+        <PreviousRunErrorResult
           chainId={state.chainId!}
           moduleName={state.moduleName!}
           result={state.result}
@@ -165,6 +175,47 @@ const ExecutionErrorResult: React.FC<{
       </Box>
 
       <Newline />
+    </Box>
+  );
+};
+
+const PreviousRunErrorResult: React.FC<{
+  moduleName: string;
+  chainId: number;
+  result: PreviousRunErrorDeploymentResult;
+}> = ({ moduleName, result }) => {
+  return (
+    <Box margin={0} flexDirection="column">
+      <Divider />
+
+      <Text>
+        ⛔ Deployment cancelled due to failed or timed out futures on a previous
+        run of module <Text italic={true}>{moduleName}.</Text>
+      </Text>
+
+      <Divider />
+
+      <Box flexDirection="column" marginTop={1}>
+        {Object.entries(result.errors).map(([futureId, futureErrors]) => (
+          <Text key={futureId}>
+            {futureId}{" "}
+            <Text color="red">
+              These futures will need to be rerun; use the `wipe` task to reset
+              them:
+            </Text>
+            <Newline />
+            {futureErrors.map((error, i) => (
+              <Text key={i}>
+                {" "}
+                - {error}
+                <Newline />
+              </Text>
+            ))}
+          </Text>
+        ))}
+      </Box>
+
+      <Text> </Text>
     </Box>
   );
 };

--- a/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
@@ -196,14 +196,14 @@ const PreviousRunErrorResult: React.FC<{
       <Divider />
 
       <Box flexDirection="column" marginTop={1}>
+        <Text color="red">
+          These futures will need to be rerun; use the `wipe` task to reset
+          them:
+        </Text>
+        <Newline />
         {Object.entries(result.errors).map(([futureId, futureErrors]) => (
           <Text key={futureId}>
-            {futureId}{" "}
-            <Text color="red">
-              These futures will need to be rerun; use the `wipe` task to reset
-              them:
-            </Text>
-            <Newline />
+            {futureId} <Newline />
             {futureErrors.map((error, i) => (
               <Text key={i}>
                 {" "}

--- a/packages/hardhat-plugin/src/utils/error-deployment-result-to-exception-message.ts
+++ b/packages/hardhat-plugin/src/utils/error-deployment-result-to-exception-message.ts
@@ -1,6 +1,7 @@
 import {
   DeploymentResultType,
   ExecutionErrorDeploymentResult,
+  PreviousRunErrorDeploymentResult,
   ReconciliationErrorDeploymentResult,
   ValidationErrorDeploymentResult,
 } from "@ignored/ignition-core";
@@ -18,6 +19,7 @@ export function errorDeploymentResultToExceptionMessage(
     | ValidationErrorDeploymentResult
     | ReconciliationErrorDeploymentResult
     | ExecutionErrorDeploymentResult
+    | PreviousRunErrorDeploymentResult
 ): string {
   switch (result.type) {
     case DeploymentResultType.VALIDATION_ERROR:
@@ -26,6 +28,8 @@ export function errorDeploymentResultToExceptionMessage(
       return _convertReconciliationError(result);
     case DeploymentResultType.EXECUTION_ERROR:
       return _convertExecutionError(result);
+    case DeploymentResultType.PREVIOUS_RUN_ERROR:
+      return _convertPreviousRunError(result);
   }
 }
 
@@ -83,6 +87,16 @@ function _convertExecutionError(result: ExecutionErrorDeploymentResult) {
   )}:
 
 ${sections.join("\n\n")}`;
+}
+
+function _convertPreviousRunError(result: PreviousRunErrorDeploymentResult) {
+  const errorsList = Object.entries(result.errors).flatMap(
+    ([futureId, errors]) => errors.map((err) => `  * ${futureId}: ${err}`)
+  );
+
+  return `The deployment wasn't run because of the following errors in a previous run:
+
+${errorsList.join("\n")}`;
 }
 
 function _toText({


### PR DESCRIPTION
- Moved logic for checking for previous run errors out of reconciliation flow
- Created a new `DeploymentResult` type to encapsulate the previous run errors
- Updated the UI to display more information to the user for the new `DeploymentResult` type (see screenshot)

fixes #431 


<img width="931" alt="Screen Shot 2023-09-13 at 8 10 59 PM" src="https://github.com/NomicFoundation/ignition/assets/14796043/b1e2a75d-bd51-4f95-96a2-86ad17741044">
