### PR TITLE
feat: store debug files with build infos

### DIFF
--- a/packages/core/src/internal/deployment-loader/ephemeral-deployment-loader.ts
+++ b/packages/core/src/internal/deployment-loader/ephemeral-deployment-loader.ts
@@ -46,7 +46,10 @@ export class EphemeralDeploymentLoader implements DeploymentLoader {
     this._deployedAddresses[futureId] = contractAddress;
   }
 
-  public async storeBuildInfo(_buildInfo: BuildInfo): Promise<void> {
+  public async storeBuildInfo(
+    _futureId: string,
+    _buildInfo: BuildInfo
+  ): Promise<void> {
     // For ephemeral we are ignoring build info
   }
 

--- a/packages/core/src/internal/deployment-loader/file-deployment-loader.ts
+++ b/packages/core/src/internal/deployment-loader/file-deployment-loader.ts
@@ -81,7 +81,10 @@ export class FileDeploymentLoader implements DeploymentLoader {
     await writeFile(artifactFilePath, JSON.stringify(artifact, undefined, 2));
   }
 
-  public async storeBuildInfo(buildInfo: BuildInfo): Promise<void> {
+  public async storeBuildInfo(
+    futureId: string,
+    buildInfo: BuildInfo
+  ): Promise<void> {
     await this._initialize();
 
     const buildInfoFilePath = path.join(
@@ -90,6 +93,28 @@ export class FileDeploymentLoader implements DeploymentLoader {
     );
 
     await writeFile(buildInfoFilePath, JSON.stringify(buildInfo, undefined, 2));
+
+    const debugInfoFilePath = path.join(
+      this._paths.artifactsDir,
+      `${futureId}.dbg.json`
+    );
+
+    const relativeBuildInfoPath = path.relative(
+      this._paths.artifactsDir,
+      buildInfoFilePath
+    );
+
+    await writeFile(
+      debugInfoFilePath,
+      JSON.stringify(
+        {
+          _format: "hh-sol-dbg-1",
+          buildInfo: relativeBuildInfoPath,
+        },
+        undefined,
+        2
+      )
+    );
   }
 
   public async loadArtifact(futureId: string): Promise<Artifact> {

--- a/packages/core/src/internal/deployment-loader/types.ts
+++ b/packages/core/src/internal/deployment-loader/types.ts
@@ -19,7 +19,7 @@ export interface DeploymentLoader {
     contractName: string,
     artifact: Artifact
   ): Promise<void>;
-  storeBuildInfo(buildInfo: BuildInfo): Promise<void>;
+  storeBuildInfo(futureId: string, buildInfo: BuildInfo): Promise<void>;
   recordDeployedAddress(
     futureId: string,
     contractAddress: string

--- a/packages/core/src/internal/execution/future-processor/helpers/save-artifacts-for-future.ts
+++ b/packages/core/src/internal/execution/future-processor/helpers/save-artifacts-for-future.ts
@@ -58,6 +58,6 @@ async function _storeArtifactAndBuildInfoAgainstDeployment(
   const buildInfo = await artifactResolver.getBuildInfo(future.contractName);
 
   if (buildInfo !== undefined) {
-    await deploymentLoader.storeBuildInfo(buildInfo);
+    await deploymentLoader.storeBuildInfo(future.id, buildInfo);
   }
 }

--- a/packages/core/test/reconciliation/helpers.ts
+++ b/packages/core/test/reconciliation/helpers.ts
@@ -56,7 +56,10 @@ class MockDeploymentLoader implements DeploymentLoader {
     throw new Error("Method not implemented.");
   }
 
-  public storeBuildInfo(_buildInfo: BuildInfo): Promise<void> {
+  public storeBuildInfo(
+    _futureId: string,
+    _buildInfo: BuildInfo
+  ): Promise<void> {
     throw new Error("Method not implemented.");
   }
 


### PR DESCRIPTION
If a build info is stored for a future id, record a debug file as a pointer. The debug file is a sibling to the artifact file, so under `./ignition/deployments/<depid>/artifacts`:
    
- `LockModule#Lock.json`
- `LockModule#Lock.dbg.json`
    
The dbg file points at the Ignition build info file via a relative path.

